### PR TITLE
fix: FTP 会话操作串行化，修复并发请求导致的连接冲突

### DIFF
--- a/apps/desktop/src/main/services/sessions/ftp-session-controller.ts
+++ b/apps/desktop/src/main/services/sessions/ftp-session-controller.ts
@@ -13,6 +13,7 @@ export class LiveFtpSessionController extends BaseFileSessionController implemen
 
   private readonly ftp = new BasicFtpClient(20000)
   private currentRemotePath: string
+  private operationQueue: Promise<unknown> = Promise.resolve()
 
   constructor(id: string, profile: FtpProfile) {
     super(id, 'ftp', profile)
@@ -20,6 +21,149 @@ export class LiveFtpSessionController extends BaseFileSessionController implemen
   }
 
   override async connect(): Promise<void> {
+    await this.runSerialized(async () => {
+      if (this.connected) {
+        return
+      }
+
+      await this.connectInternal()
+    })
+  }
+
+  override async disconnect(): Promise<void> {
+    await this.runSerialized(async () => {
+      this.disconnectInternal()
+    })
+  }
+
+  override getRemotePath(): string {
+    return this.currentRemotePath
+  }
+
+  async abortTransfer(): Promise<void> {
+    await this.runSerialized(async () => {
+      this.disconnectInternal()
+    })
+  }
+
+  async listRemoteFiles(): Promise<RemoteFileItem[]> {
+    return this.runWithConnectedClient(() => this.readRemoteDirectory(this.currentRemotePath))
+  }
+
+  async openRemotePath(nextPath: string): Promise<RemoteFileItem[]> {
+    return this.runWithConnectedClient(async () => {
+      await this.ftp.cd(nextPath)
+      this.currentRemotePath = await this.ftp.pwd()
+      return this.readRemoteDirectory(this.currentRemotePath)
+    })
+  }
+
+  async readRemoteFile(targetPath: string, encoding = 'utf-8'): Promise<string> {
+    return this.runWithConnectedClient(async () => {
+      const localPath = this.tempFilePath(targetPath)
+      try {
+        await this.ftp.downloadTo(localPath, targetPath)
+        return decodeBuffer(await readFile(localPath), encoding)
+      } finally {
+        void unlink(localPath).catch(() => undefined)
+      }
+    })
+  }
+
+  async writeRemoteFile(targetPath: string, content: string, encoding = 'utf-8'): Promise<void> {
+    await this.runWithConnectedClient(async () => {
+      const localPath = this.tempFilePath(targetPath)
+      try {
+        await writeFile(localPath, encodeText(content, encoding))
+        await this.ensureRemoteDirectoryInternal(path.posix.dirname(targetPath))
+        await this.ftp.uploadFrom(localPath, targetPath)
+      } finally {
+        void unlink(localPath).catch(() => undefined)
+      }
+    })
+  }
+
+  async copyRemotePath(_targetPath: string, _destinationPath: string, _targetType: RemoteFileItem['type']): Promise<void> {
+    throw new Error('FTP 暂不支持服务器内复制，请改用下载后上传')
+  }
+
+  async moveRemotePath(targetPath: string, destinationPath: string): Promise<void> {
+    await this.renameRemotePath(targetPath, destinationPath)
+  }
+
+  async renameRemotePath(targetPath: string, nextPath: string): Promise<void> {
+    await this.runWithConnectedClient(async () => {
+      await this.ftp.rename(targetPath, nextPath)
+    })
+  }
+
+  async deleteRemotePath(targetPath: string, targetType: RemoteFileItem['type']): Promise<void> {
+    await this.runWithConnectedClient(async () => {
+      if (targetType === 'folder') {
+        await this.ftp.removeDir(targetPath)
+        return
+      }
+      await this.ftp.remove(targetPath)
+    })
+  }
+
+  async changeRemotePermissions(targetPath: string, options: PermissionChangeOptions): Promise<void> {
+    validateMode(options.mode)
+    await this.runWithConnectedClient(async () => {
+      if (options.recursive) {
+        throw new Error('FTP 暂不支持递归修改权限')
+      }
+      await this.ftp.send(`SITE CHMOD ${options.mode.trim()} ${targetPath}`)
+    })
+  }
+
+  async ensureRemoteDirectory(targetPath: string): Promise<void> {
+    await this.runWithConnectedClient(async () => {
+      await this.ensureRemoteDirectoryInternal(targetPath)
+    })
+  }
+
+  async uploadFile(localPath: string, remotePath: string, onProgress: (progress: TransferProgress) => void): Promise<void> {
+    const info = await stat(localPath)
+    const total = Math.max(info.size, 1)
+    await this.runWithConnectedClient(async () => {
+      this.ftp.trackProgress((progress) => {
+        onProgress({
+          percent: Math.min(99, Math.round((progress.bytes / total) * 100)),
+          transferredBytes: progress.bytes,
+          totalBytes: total
+        })
+      })
+      try {
+        await this.ensureRemoteDirectoryInternal(path.posix.dirname(remotePath))
+        await this.ftp.uploadFrom(localPath, remotePath)
+        onProgress({ percent: 100, transferredBytes: total, totalBytes: total })
+      } finally {
+        this.ftp.trackProgress()
+      }
+    })
+  }
+
+  async downloadFile(remotePath: string, localPath: string, onProgress: (progress: TransferProgress) => void): Promise<void> {
+    await this.runWithConnectedClient(async () => {
+      const total = Math.max(await this.ftp.size(remotePath), 1)
+      this.ftp.trackProgress((progress) => {
+        onProgress({
+          percent: Math.min(99, Math.round((progress.bytes / total) * 100)),
+          transferredBytes: progress.bytes,
+          totalBytes: total
+        })
+      })
+      try {
+        await this.ftp.downloadTo(localPath, remotePath)
+        onProgress({ percent: 100, transferredBytes: total, totalBytes: total })
+      } finally {
+        this.ftp.trackProgress()
+      }
+    })
+  }
+
+  private async connectInternal(): Promise<void> {
     const profile = this.profile as FtpProfile
     await this.ftp.access({
       host: profile.host,
@@ -37,136 +181,9 @@ export class LiveFtpSessionController extends BaseFileSessionController implemen
     }
   }
 
-  override async disconnect(): Promise<void> {
+  private disconnectInternal() {
     this.ftp.close()
     this.connected = false
-  }
-
-  override getRemotePath(): string {
-    return this.currentRemotePath
-  }
-
-  async abortTransfer(): Promise<void> {
-    this.ftp.close()
-    this.connected = false
-  }
-
-  async listRemoteFiles(): Promise<RemoteFileItem[]> {
-    await this.ensureConnected()
-    return this.readRemoteDirectory(this.currentRemotePath)
-  }
-
-  async openRemotePath(nextPath: string): Promise<RemoteFileItem[]> {
-    await this.ensureConnected()
-    await this.ftp.cd(nextPath)
-    this.currentRemotePath = await this.ftp.pwd()
-    return this.readRemoteDirectory(this.currentRemotePath)
-  }
-
-  async readRemoteFile(targetPath: string, encoding = 'utf-8'): Promise<string> {
-    await this.ensureConnected()
-    const localPath = this.tempFilePath(targetPath)
-    try {
-      await this.ftp.downloadTo(localPath, targetPath)
-      return decodeBuffer(await readFile(localPath), encoding)
-    } finally {
-      void unlink(localPath).catch(() => undefined)
-    }
-  }
-
-  async writeRemoteFile(targetPath: string, content: string, encoding = 'utf-8'): Promise<void> {
-    await this.ensureConnected()
-    const localPath = this.tempFilePath(targetPath)
-    try {
-      await writeFile(localPath, encodeText(content, encoding))
-      await this.ensureRemoteDirectory(path.posix.dirname(targetPath))
-      await this.ftp.uploadFrom(localPath, targetPath)
-    } finally {
-      void unlink(localPath).catch(() => undefined)
-    }
-  }
-
-  async copyRemotePath(_targetPath: string, _destinationPath: string, _targetType: RemoteFileItem['type']): Promise<void> {
-    throw new Error('FTP 暂不支持服务器内复制，请改用下载后上传')
-  }
-
-  async moveRemotePath(targetPath: string, destinationPath: string): Promise<void> {
-    await this.renameRemotePath(targetPath, destinationPath)
-  }
-
-  async renameRemotePath(targetPath: string, nextPath: string): Promise<void> {
-    await this.ensureConnected()
-    await this.ftp.rename(targetPath, nextPath)
-  }
-
-  async deleteRemotePath(targetPath: string, targetType: RemoteFileItem['type']): Promise<void> {
-    await this.ensureConnected()
-    if (targetType === 'folder') {
-      await this.ftp.removeDir(targetPath)
-      return
-    }
-    await this.ftp.remove(targetPath)
-  }
-
-  async changeRemotePermissions(targetPath: string, options: PermissionChangeOptions): Promise<void> {
-    await this.ensureConnected()
-    if (options.recursive) {
-      throw new Error('FTP 暂不支持递归修改权限')
-    }
-    validateMode(options.mode)
-    await this.ftp.send(`SITE CHMOD ${options.mode.trim()} ${targetPath}`)
-  }
-
-  async ensureRemoteDirectory(targetPath: string): Promise<void> {
-    await this.ensureConnected()
-    if (!targetPath || targetPath === '.') {
-      return
-    }
-
-    const previousPath = await this.ftp.pwd()
-    try {
-      await this.ftp.ensureDir(targetPath)
-    } finally {
-      await this.ftp.cd(previousPath)
-    }
-  }
-
-  async uploadFile(localPath: string, remotePath: string, onProgress: (progress: TransferProgress) => void): Promise<void> {
-    await this.ensureConnected()
-    const info = await stat(localPath)
-    const total = Math.max(info.size, 1)
-    this.ftp.trackProgress((progress) => {
-      onProgress({
-        percent: Math.min(99, Math.round((progress.bytes / total) * 100)),
-        transferredBytes: progress.bytes,
-        totalBytes: total
-      })
-    })
-    try {
-      await this.ensureRemoteDirectory(path.posix.dirname(remotePath))
-      await this.ftp.uploadFrom(localPath, remotePath)
-      onProgress({ percent: 100, transferredBytes: total, totalBytes: total })
-    } finally {
-      this.ftp.trackProgress()
-    }
-  }
-
-  async downloadFile(remotePath: string, localPath: string, onProgress: (progress: TransferProgress) => void): Promise<void> {
-    await this.ensureConnected()
-    const total = Math.max(await this.ftp.size(remotePath), 1)
-    this.ftp.trackProgress((progress) => {
-      onProgress({
-        percent: Math.min(99, Math.round((progress.bytes / total) * 100)),
-        transferredBytes: progress.bytes,
-        totalBytes: total
-      })
-    })
-    try {
-      await this.ftp.downloadTo(localPath, remotePath)
-      onProgress({ percent: 100, transferredBytes: total, totalBytes: total })
-    } finally {
-      this.ftp.trackProgress()
-    }
   }
 
   private async readRemoteDirectory(targetPath: string): Promise<RemoteFileItem[]> {
@@ -202,8 +219,34 @@ export class LiveFtpSessionController extends BaseFileSessionController implemen
 
   private async ensureConnected() {
     if (!this.connected) {
-      await this.connect()
+      await this.connectInternal()
     }
+  }
+
+  private async ensureRemoteDirectoryInternal(targetPath: string) {
+    if (!targetPath || targetPath === '.') {
+      return
+    }
+
+    const previousPath = await this.ftp.pwd()
+    try {
+      await this.ftp.ensureDir(targetPath)
+    } finally {
+      await this.ftp.cd(previousPath)
+    }
+  }
+
+  private async runWithConnectedClient<T>(operation: () => Promise<T>): Promise<T> {
+    return this.runSerialized(async () => {
+      await this.ensureConnected()
+      return operation()
+    })
+  }
+
+  private async runSerialized<T>(operation: () => Promise<T>): Promise<T> {
+    const nextOperation = this.operationQueue.catch(() => undefined).then(operation)
+    this.operationQueue = nextOperation.then(() => undefined, () => undefined)
+    return nextOperation
   }
 }
 

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -837,19 +837,26 @@ export function App() {
 
   const formatAppError = (scope: string, err: unknown, details?: ErrorDetails) => {
     const message = normalizeErrorMessage(err)
-    const likelyPathIssue = /can't cd to|__NOT_DIR__|no such file|not a directory|permission denied|failure/i.test(message)
+    const likelyConcurrentRequestIssue = /another one is still running|forgot to use 'await'|client is closed because user launched a task/i.test(message)
+    const likelyPathIssue = /can't cd to|__NOT_DIR__|no such file|not a directory|permission denied|\b550\b/i.test(message)
     const metadata = details?.item
       ? ` (${t.permission}: ${details.item.permission || '-'}, ${t.ownerGroup}: ${details.item.ownerGroup || '-'})`
       : ''
     const pathText = details?.targetPath ? ` ${details.targetPath}` : ''
 
     if (locale === 'zhCN') {
+      if (details?.targetPath && likelyConcurrentRequestIssue) {
+        return `打开远程目录${pathText}${metadata}失败：远程连接正在处理另一项请求，请稍后重试。原始错误：${message}`
+      }
       if (details?.targetPath && likelyPathIssue) {
         return `无法打开远程目录${pathText}${metadata}。可能是目录不存在、不是目录，或者当前账号没有进入权限。原始错误：${message}`
       }
       return `${scope}${pathText}${metadata}失败：${message}`
     }
 
+    if (details?.targetPath && likelyConcurrentRequestIssue) {
+      return `Failed to open remote directory${pathText}${metadata}: the remote connection is still processing another request. Raw error: ${message}`
+    }
     if (details?.targetPath && likelyPathIssue) {
       return `Could not open remote directory${pathText}${metadata}. It may not exist, may not be a directory, or your account may not have permission to enter it. Raw error: ${message}`
     }


### PR DESCRIPTION
## 问题

FTP 客户端（basic-ftp）不支持并发操作。当用户快速切换目录或同时触发上传/下载时，会抛出 `another one is still running` 等错误，导致连接状态混乱。

## 修复

### ftp-session-controller.ts 重构
- 新增 `operationQueue` 操作队列，通过 `runSerialized()` 将所有 FTP 操作串行化
- 抽取 `connectInternal()` / `disconnectInternal()` 内部实现，避免队列递归
- 新增 `runWithConnectedClient()` 统一封装「串行化 + 自动重连」模式
- `ensureRemoteDirectory` 拆分为公开方法 + `ensureRemoteDirectoryInternal` 内部方法
- 所有公开方法统一走 `runWithConnectedClient` 或 `runSerialized`，从根源消除并发竞态

### App.tsx 错误提示增强
- 新增 `likelyConcurrentRequestIssue` 正则匹配 basic-ftp 并发错误
- 新增中英文并发请求错误提示，告诉用户「稍后重试」

## 影响范围
仅 FTP 会话，SSH/SFTP 不受影响。

## 验证
- [x] `npm run typecheck -w @termdock/desktop`
- [ ] FTP 快速连续切换目录不再报错
- [ ] FTP 上传/下载期间切换目录不会冲突

🤖 Generated with [Claude Code](https://claude.com/claude-code)