### PR TITLE
fix: 安装包命名加入平台标识（macOS / Windows）

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -70,7 +70,7 @@
         "dmg",
         "zip"
       ],
-      "artifactName": "TermDock-${version}-${arch}.${ext}"
+      "artifactName": "TermDock-${version}-macos-${arch}.${ext}"
     },
     "win": {
       "icon": "build/icon.ico",
@@ -84,10 +84,10 @@
           "arch": ["x64"]
         }
       ],
-      "artifactName": "TermDock-${version}-${arch}-setup.${ext}"
+      "artifactName": "TermDock-${version}-windows-${arch}-setup.${ext}"
     },
     "portable": {
-      "artifactName": "TermDock-${version}-${arch}-portable.${ext}"
+      "artifactName": "TermDock-${version}-windows-${arch}-portable.${ext}"
     }
   }
 }


### PR DESCRIPTION
## 问题

当前产物命名无法直观区分平台：
- `TermDock-x.x.x-x64.dmg` — 是 macOS Intel？还是别的？
- `TermDock-x.x.x-x64-setup.exe` — 看不出是 Windows

## 修复

| 之前 | 之后 |
|------|------|
| `TermDock-${version}-${arch}.dmg` | `TermDock-${version}-**macOS**-${arch}.dmg` |
| `TermDock-${version}-${arch}-setup.exe` | `TermDock-${version}-**Windows**-${arch}-setup.exe` |
| `TermDock-${version}-${arch}-portable.exe` | `TermDock-${version}-**Windows**-${arch}-portable.exe` |

下个版本生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)