### PR TITLE
feat: macOS 应用菜单、系统侧栏折叠、FTP 列表智能降级与 Cmd+W 优化

### DIFF
--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -66,6 +66,10 @@ export function registerAppHandlers(options: IpcWindowOptions) {
     BrowserWindow.fromWebContents(event.sender)?.close()
   })
 
+  ipcMain.handle('app:requestQuitApp', () => {
+    options.requestQuitApp()
+  })
+
   ipcMain.handle('app:confirmCloseWindow', (_event, action: 'quit' | 'hide' | 'cancel') => {
     options.confirmCloseWindow(action)
   })

--- a/apps/desktop/src/main/ipc/types.ts
+++ b/apps/desktop/src/main/ipc/types.ts
@@ -13,6 +13,7 @@ export interface IpcWindowOptions {
   openCommandFormWindow(parent: BrowserWindow, mode: 'create' | 'edit', commandId?: string, folderId?: string): void
   openFileEditorWindow(parent: BrowserWindow, input: { source: 'local' | 'remote'; path: string; name: string; tabId?: string; encoding?: string }): void
   openLogsDirectory(): Promise<void>
+  requestQuitApp(): void
   confirmCloseWindow(action: 'quit' | 'hide' | 'cancel'): void
 }
 

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -213,6 +213,62 @@ function requestQuitConfirmation() {
   app.quit()
 }
 
+function requestCloseFocusedWindow() {
+  const focusedWindow = BrowserWindow.getFocusedWindow()
+  const targetWindow = focusedWindow ?? mainWindow
+
+  if (!targetWindow || targetWindow.isDestroyed()) {
+    return
+  }
+
+  if (targetWindow === mainWindow) {
+    targetWindow.webContents.send('app:close-active-workspace-item-request')
+    return
+  }
+
+  targetWindow.close()
+}
+
+function installApplicationMenu() {
+  if (!isMac) {
+    Menu.setApplicationMenu(null)
+    return
+  }
+
+  const menu = Menu.buildFromTemplate([
+    {
+      label: app.name,
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        {
+          label: `Quit ${app.name}`,
+          accelerator: 'CmdOrCtrl+Q',
+          click: () => {
+            requestQuitConfirmation()
+          }
+        }
+      ]
+    },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        {
+          label: 'Close',
+          accelerator: 'CmdOrCtrl+W',
+          click: () => {
+            requestCloseFocusedWindow()
+          }
+        },
+        { role: 'front' }
+      ]
+    }
+  ])
+
+  Menu.setApplicationMenu(menu)
+}
+
 function loadAppWindow(win: BrowserWindow, searchParams?: Record<string, string>, preferences: UiPreferences = uiPreferences) {
   const query = {
     ...(searchParams ?? {}),
@@ -326,6 +382,19 @@ function createMainWindow() {
     }
     event.preventDefault()
     win.webContents.send('app:window-close-request', { isQuit: false })
+  })
+  win.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown') {
+      return
+    }
+
+    const isCloseShortcut = input.key.toLowerCase() === 'w' && (input.meta || input.control)
+    if (!isCloseShortcut) {
+      return
+    }
+
+    event.preventDefault()
+    win.webContents.send('app:close-active-workspace-item-request')
   })
 
   win.on('closed', () => {
@@ -589,6 +658,7 @@ function openFileEditorWindow(parent: BrowserWindow, input: {
 app.whenReady().then(() => {
   initAppLogger(app.getPath('userData'))
   readUiPreferences()
+  installApplicationMenu()
   createTray()
   const appIconPath = getAppIconPath()
   if (isMac && appIconPath) {
@@ -613,6 +683,9 @@ app.whenReady().then(() => {
     openCommandFormWindow,
     openFileEditorWindow,
     openLogsDirectory,
+    requestQuitApp: () => {
+      requestQuitConfirmation()
+    },
     confirmCloseWindow: (action) => {
       if (action === 'quit') {
         isQuitting = true
@@ -654,6 +727,12 @@ app.whenReady().then(() => {
   createMainWindow()
 
   app.on('activate', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.show()
+      mainWindow.focus()
+      return
+    }
+
     if (BrowserWindow.getAllWindows().length === 0) {
       createMainWindow()
     }

--- a/apps/desktop/src/main/services/sessions/ftp-session-controller.ts
+++ b/apps/desktop/src/main/services/sessions/ftp-session-controller.ts
@@ -15,6 +15,7 @@ export class LiveFtpSessionController extends BaseFileSessionController implemen
   private readonly ftp = new BasicFtpClient(20000)
   private readonly entryDebugInfo = new Map<string, string>()
   private readonly defaultParseList: (rawList: string) => FileInfo[]
+  private listingMode: 'auto' | 'classic-list' = 'auto'
   private currentRemotePath: string
   private operationQueue: Promise<unknown> = Promise.resolve()
 
@@ -199,18 +200,19 @@ export class LiveFtpSessionController extends BaseFileSessionController implemen
   }
 
   private async readRemoteDirectory(targetPath: string): Promise<RemoteFileItem[]> {
-    const entries = await this.ftp.list(targetPath)
+    const entries = await this.listRemoteDirectoryEntries(targetPath)
+    const previousPath = await this.ftp.pwd()
     const rows = entries
       .filter((entry) => entry.name !== '.' && entry.name !== '..')
     appLog(`[TermDock][FTP] Listing remote directory ${targetPath} (${rows.length} entries)`)
     const items: RemoteFileItem[] = []
 
     for (const entry of rows) {
-      const isDirectory = entry.type === FileType.Directory || entry.isDirectory
+      const isDirectory = await this.resolveDirectoryFlag(targetPath, entry, previousPath)
       const item = toResolvedFtpRemoteFileItem(targetPath, entry, isDirectory)
       const debugInfo = describeFtpEntry(targetPath, entry, isDirectory)
       this.entryDebugInfo.set(item.path, debugInfo)
-      if ((entry as FileInfoWithRaw).rawLine || entry.type === FileType.Unknown) {
+      if ((entry as FileInfoWithRaw).rawLine || entry.type === FileType.Unknown || isDirectory !== entry.isDirectory) {
         appLog(`[TermDock][FTP] Resolved remote entry: ${debugInfo}`)
       }
       items.push(item)
@@ -274,6 +276,74 @@ export class LiveFtpSessionController extends BaseFileSessionController implemen
     this.operationQueue = nextOperation.then(() => undefined, () => undefined)
     return nextOperation
   }
+
+  private async listRemoteDirectoryEntries(targetPath: string) {
+    if (this.listingMode === 'classic-list') {
+      this.setClassicListCommands()
+      return this.ftp.list(targetPath)
+    }
+
+    const initialEntries = await this.ftp.list(targetPath)
+    if (!shouldRetryWithClassicList(initialEntries)) {
+      return initialEntries
+    }
+
+    this.listingMode = 'classic-list'
+    appLog(`[TermDock][FTP] Switching listing mode to classic LIST for current session: ${targetPath}`)
+    this.setClassicListCommands()
+    const retriedEntries = await this.ftp.list(targetPath)
+    return retriedEntries
+  }
+
+  private setClassicListCommands() {
+    const ftpWithListCommands = this.ftp as BasicFtpClient & { availableListCommands?: string[] }
+    ftpWithListCommands.availableListCommands = ['LIST -a', 'LIST']
+  }
+
+  private async resolveDirectoryFlag(targetPath: string, entry: FileInfo, previousPath: string) {
+    if (entry.type === FileType.Directory || entry.isDirectory) {
+      entry.type = FileType.Directory
+      return true
+    }
+
+    if (entry.type !== FileType.Unknown) {
+      entry.type = FileType.File
+      return false
+    }
+
+    const candidatePath = path.posix.join(targetPath, entry.name)
+    try {
+      await this.ftp.cd(candidatePath)
+      entry.type = FileType.Directory
+      appLog(`[TermDock][FTP] Directory probe succeeded for ${candidatePath}`)
+      return true
+    } catch {
+      entry.type = FileType.File
+      return false
+    } finally {
+      await this.ftp.cd(previousPath).catch(() => undefined)
+    }
+  }
+}
+
+function shouldRetryWithClassicList(entries: FileInfo[]) {
+  if (!entries.length) {
+    return false
+  }
+
+  return entries.every((entry) => {
+    const rawLine = (entry as FileInfoWithRaw).rawLine?.trim()
+    if (entry.type !== FileType.Unknown || !rawLine) {
+      return false
+    }
+    return !looksLikeStructuredFtpLine(rawLine)
+  })
+}
+
+function looksLikeStructuredFtpLine(rawLine: string) {
+  return /^\S+=\S+;/.test(rawLine)
+    || /^\d{2}-\d{2}-\d{2}\s+\d{2}:\d{2}(AM|PM)/i.test(rawLine)
+    || /^[\-ldpscbD]/.test(rawLine)
 }
 
 function validateMode(mode: string) {

--- a/apps/desktop/src/preload/preload.cts
+++ b/apps/desktop/src/preload/preload.cts
@@ -46,6 +46,8 @@ const api: TermdockDesktopApi = {
     ipcRenderer.invoke('app:toggleMaximizeCurrentWindow'),
   closeCurrentWindow: (): Promise<void> =>
     ipcRenderer.invoke('app:closeCurrentWindow'),
+  requestQuitApp: (): Promise<void> =>
+    ipcRenderer.invoke('app:requestQuitApp'),
   getSnapshot: (): Promise<WorkspaceSnapshot> => ipcRenderer.invoke('workspace:getSnapshot'),
   createProfile: (input: CreateProfileInput): Promise<WorkspaceSnapshot> =>
     ipcRenderer.invoke('workspace:createProfile', input),
@@ -179,6 +181,11 @@ const api: TermdockDesktopApi = {
     const wrapped = (_event: unknown, data: { isQuit: boolean }) => listener(data)
     ipcRenderer.on('app:window-close-request', wrapped)
     return () => ipcRenderer.off('app:window-close-request', wrapped)
+  },
+  onRequestCloseActiveWorkspaceItem: (listener: () => void) => {
+    const wrapped = () => listener()
+    ipcRenderer.on('app:close-active-workspace-item-request', wrapped)
+    return () => ipcRenderer.off('app:close-active-workspace-item-request', wrapped)
   },
   confirmCloseWindow: (action: 'quit' | 'hide' | 'cancel'): Promise<void> =>
     ipcRenderer.invoke('app:confirmCloseWindow', action)

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -29,6 +29,7 @@ import { FileEditorModal } from './features/files/FileEditorModal'
 import { FilePermissionModal } from './features/files/FilePermissionModal'
 import { RootAccessModal } from './features/files/RootAccessModal'
 import { AppIcon } from './features/common/AppIcon'
+import { ConfirmActionDialog } from './features/common/ConfirmActionDialog'
 import { TabBar, type OrderedTabEntry, type TabContextTarget } from './features/layout/TabBar'
 import { TabContextMenu } from './features/layout/TabContextMenu'
 import { SystemSidebar } from './features/system/SystemSidebar'
@@ -58,6 +59,7 @@ type StoredMainTabUiState = {
   activeLocalTabId: string | null
   nextHomeTabNumber: number
   tabOrder: string[]
+  isSystemSidebarCollapsed: boolean
 }
 
 function formatSystemInfoTabTitle(sourceTabTitle: string) {
@@ -252,7 +254,8 @@ function readStoredMainTabUiState(enabled: boolean): StoredMainTabUiState | null
       nextHomeTabNumber: typeof parsed.nextHomeTabNumber === 'number' && Number.isFinite(parsed.nextHomeTabNumber)
         ? Math.max(1, Math.floor(parsed.nextHomeTabNumber))
         : 1,
-      tabOrder
+      tabOrder,
+      isSystemSidebarCollapsed: parsed.isSystemSidebarCollapsed === true
     }
   } catch {
     return null
@@ -400,6 +403,7 @@ export function App() {
     target: TabContextTarget
   } | null>(null)
   const [sidebarWidth, setSidebarWidth] = useState(214)
+  const [isSystemSidebarCollapsed, setIsSystemSidebarCollapsed] = useState(() => storedMainTabUiState?.isSystemSidebarCollapsed === true)
   const [isResizingSidebar, setIsResizingSidebar] = useState(false)
   const [fileEditor, setFileEditor] = useState<FileContentSnapshot | null>(
     isFileEditorWindow && fileEditorWindowSource && fileEditorWindowPath && fileEditorWindowName
@@ -444,6 +448,11 @@ export function App() {
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => readInitialTheme(searchParams))
   const [locale, setLocaleState] = useState<AppLocale>(() => readInitialLocale(searchParams))
   const [closeConfirmDialog, setCloseConfirmDialog] = useState<{ isQuit: boolean; hasActiveConnections: boolean } | null>(null)
+  const [shortcutCloseConfirm, setShortcutCloseConfirm] = useState<{
+    tabId: string
+    title: string
+    variant: 'connecting' | 'active-last-session'
+  } | null>(null)
 
   useThemeMode(themeMode)
 
@@ -486,6 +495,18 @@ export function App() {
 
     return () => unsubscribe()
   }, [desktopApi, isMainWorkspaceWindow])
+
+  useEffect(() => {
+    if (!desktopApi || !isMainWorkspaceWindow) {
+      return
+    }
+
+    const unsubscribe = desktopApi.onRequestCloseActiveWorkspaceItem(() => {
+      void handleShortcutCloseActiveWorkspaceItem()
+    })
+
+    return () => unsubscribe()
+  }, [desktopApi, isMainWorkspaceWindow, activeLocalTabId, isBusy, localTabs, workspace.activeTabId, workspace.tabs])
 
   useEffect(() => {
     document.documentElement.dataset.platform = desktopApi?.platform ?? 'browser'
@@ -758,9 +779,10 @@ export function App() {
       localTabs,
       activeLocalTabId,
       nextHomeTabNumber,
-      tabOrder
+      tabOrder,
+      isSystemSidebarCollapsed
     })
-  }, [activeLocalTabId, hasLoadedInitialSnapshot, isMainWorkspaceWindow, localTabs, nextHomeTabNumber, tabOrder])
+  }, [activeLocalTabId, hasLoadedInitialSnapshot, isMainWorkspaceWindow, isSystemSidebarCollapsed, localTabs, nextHomeTabNumber, tabOrder])
 
   useEffect(() => {
     if (!isResizingSidebar) {
@@ -829,6 +851,7 @@ export function App() {
     : null
   const activeTransferCount = workspace.transfers.filter(isActiveTransfer).length
   const showSidebar = activeTab !== null && activeSession !== null && activeLocalTab?.kind !== 'home'
+  const resolvedSidebarWidth = showSidebar ? (isSystemSidebarCollapsed ? 44 : sidebarWidth) : 0
 
   const normalizeErrorMessage = (err: unknown) => {
     const rawMessage = err instanceof Error ? err.message : String(err)
@@ -888,6 +911,10 @@ export function App() {
 
   const closeCurrentWindow = () => {
     void desktopApi?.closeCurrentWindow()
+  }
+
+  const requestQuitApp = () => {
+    void desktopApi?.requestQuitApp()
   }
 
   const openCreateModal = () => {
@@ -1235,6 +1262,29 @@ export function App() {
     return snapshot
   }
 
+  const closeHomeTabById = (homeTabId: string) => {
+    setLocalTabs((prev) => {
+      const remaining = prev.filter((tab) => tab.id !== homeTabId)
+
+      if (remaining.length === 0 && workspace.tabs.length === 0) {
+        setActiveLocalTabId('home-1')
+        setNextHomeTabNumber(2)
+        setTabOrder((prevOrder) => {
+          const filtered = prevOrder.filter((key) => key !== homeTabKey(homeTabId))
+          return filtered.includes('home:home-1') ? filtered : ['home:home-1', ...filtered]
+        })
+        return [{ id: 'home-1', kind: 'home', title: t.untitledTab }]
+      }
+
+      if (activeLocalTabId === homeTabId) {
+        setActiveLocalTabId(remaining.at(-1)?.id ?? null)
+      }
+
+      setTabOrder((prevOrder) => prevOrder.filter((key) => key !== homeTabKey(homeTabId)))
+      return remaining
+    })
+  }
+
   const handleCloseTab = async (event: MouseEvent<HTMLButtonElement>, tabId: string) => {
     event.stopPropagation()
     if (!desktopApi) {
@@ -1298,27 +1348,7 @@ export function App() {
 
   const handleCloseHomeTab = (event: MouseEvent<HTMLButtonElement>, homeTabId: string) => {
     event.stopPropagation()
-
-    setLocalTabs((prev) => {
-      const remaining = prev.filter((tab) => tab.id !== homeTabId)
-
-      if (remaining.length === 0 && workspace.tabs.length === 0) {
-        setActiveLocalTabId('home-1')
-        setNextHomeTabNumber(2)
-        setTabOrder((prevOrder) => {
-          const filtered = prevOrder.filter((key) => key !== homeTabKey(homeTabId))
-          return filtered.includes('home:home-1') ? filtered : ['home:home-1', ...filtered]
-        })
-        return [{ id: 'home-1', kind: 'home', title: t.untitledTab }]
-      }
-
-      if (activeLocalTabId === homeTabId) {
-        setActiveLocalTabId(remaining.at(-1)?.id ?? null)
-      }
-
-      setTabOrder((prevOrder) => prevOrder.filter((key) => key !== homeTabKey(homeTabId)))
-      return remaining
-    })
+    closeHomeTabById(homeTabId)
   }
 
   const closeHomeTabs = (
@@ -1360,6 +1390,75 @@ export function App() {
 
     if (lastSnapshot) {
       applySnapshot(lastSnapshot)
+    }
+  }
+
+  const handleShortcutCloseActiveWorkspaceItem = async () => {
+    if (!desktopApi || isBusy) {
+      return
+    }
+
+    const activeLocalTab = activeLocalTabId
+      ? localTabs.find((tab) => tab.id === activeLocalTabId) ?? null
+      : null
+    const activeSessionTab = !activeLocalTab && workspace.activeTabId
+      ? workspace.tabs.find((tab) => tab.id === workspace.activeTabId) ?? null
+      : null
+    const totalClosableItems = localTabs.length + workspace.tabs.length
+
+    if (activeLocalTab) {
+      if (totalClosableItems <= 1) {
+        closeCurrentWindow()
+        return
+      }
+
+      closeHomeTabById(activeLocalTab.id)
+      return
+    }
+
+    if (activeSessionTab) {
+      const isLastSessionTab = workspace.tabs.length === 1
+      const needsDisconnectConfirm = isLastSessionTab
+        && (activeSessionTab.status === 'connecting' || activeSessionTab.status === 'connected')
+
+      if (needsDisconnectConfirm) {
+        setShortcutCloseConfirm({
+          tabId: activeSessionTab.id,
+          title: activeSessionTab.title,
+          variant: activeSessionTab.status === 'connecting' ? 'connecting' : 'active-last-session'
+        })
+        return
+      }
+
+      try {
+        setIsBusy(true)
+        await closeSessionTabById(activeSessionTab.id)
+      } catch (err) {
+        reportError(setError, '关闭当前标签页', err)
+      } finally {
+        setIsBusy(false)
+      }
+      return
+    }
+
+    requestQuitApp()
+  }
+
+  const confirmShortcutCloseConnectingTab = async () => {
+    if (!shortcutCloseConfirm) {
+      return
+    }
+
+    const { tabId } = shortcutCloseConfirm
+    setShortcutCloseConfirm(null)
+
+    try {
+      setIsBusy(true)
+      await closeSessionTabById(tabId)
+    } catch (err) {
+      reportError(setError, '关闭正在连接的标签页', err)
+    } finally {
+      setIsBusy(false)
     }
   }
 
@@ -2388,7 +2487,12 @@ export function App() {
 
   return (
     <>
-      <div className={`fs-shell ${isWindowsDesktop ? 'has-window-menubar' : ''}`} style={{ '--sidebar-width': `${sidebarWidth}px` } as CSSProperties}>
+      <div
+        className={`fs-shell ${isWindowsDesktop ? 'has-window-menubar' : ''}`}
+        style={{
+          '--sidebar-width': `${resolvedSidebarWidth}px`
+        } as CSSProperties}
+      >
         {isWindowsDesktop ? (
           <div className="window-menubar">
             <div className="window-brandmark" aria-label={t.appTitle}>
@@ -2450,14 +2554,22 @@ export function App() {
         />
 
         {showSidebar ? (
-          <aside className="fs-sidebar" style={{ position: 'relative' }}>
-            <SystemSidebar activeProfile={activeProfile} activeSession={activeSession} onOpenSystemInfo={handleOpenSystemInfo} />
-            <div
-              aria-label={t.resizeSidebar}
-              className={`sidebar-resizer ${isResizingSidebar ? 'is-active' : ''}`}
-              onMouseDown={() => setIsResizingSidebar(true)}
-              role="separator"
+          <aside className={`fs-sidebar ${isSystemSidebarCollapsed ? 'is-collapsed' : ''}`} style={{ position: 'relative' }}>
+            <SystemSidebar
+              activeProfile={activeProfile}
+              activeSession={activeSession}
+              collapsed={isSystemSidebarCollapsed}
+              onOpenSystemInfo={handleOpenSystemInfo}
+              onToggleCollapsed={() => setIsSystemSidebarCollapsed((prev) => !prev)}
             />
+            {!isSystemSidebarCollapsed ? (
+              <div
+                aria-label={t.resizeSidebar}
+                className={`sidebar-resizer ${isResizingSidebar ? 'is-active' : ''}`}
+                onMouseDown={() => setIsResizingSidebar(true)}
+                role="separator"
+              />
+            ) : null}
           </aside>
         ) : null}
 
@@ -2762,6 +2874,24 @@ export function App() {
             void handleSubmitPermissions(options)
           }}
           supportsRecursive={permissionDialog.supportsRecursive}
+        />
+      ) : null}
+
+      {shortcutCloseConfirm ? (
+        <ConfirmActionDialog
+          confirmLabel={t.closeShortcutCloseTab}
+          description={
+            (shortcutCloseConfirm.variant === 'connecting'
+              ? t.closeShortcutConnectingDescription
+              : t.closeShortcutLastActiveDescription)
+              .replace('{name}', shortcutCloseConfirm.title)
+          }
+          isSubmitting={isBusy}
+          onClose={() => setShortcutCloseConfirm(null)}
+          onConfirm={() => {
+            void confirmShortcutCloseConnectingTab()
+          }}
+          title={shortcutCloseConfirm.variant === 'connecting' ? t.closeShortcutConnectingTitle : t.closeShortcutLastActiveTitle}
         />
       ) : null}
 

--- a/apps/desktop/src/renderer/features/system/SystemSidebar.tsx
+++ b/apps/desktop/src/renderer/features/system/SystemSidebar.tsx
@@ -15,13 +15,16 @@ function parseMemory(memStr: string): number {
 export function SystemSidebar({
   activeProfile,
   activeSession,
-  onOpenSystemInfo
+  collapsed,
+  onOpenSystemInfo,
+  onToggleCollapsed
 }: {
   activeProfile: ConnectionProfile | null
   activeSession: SessionSnapshot | null
+  collapsed: boolean
   onOpenSystemInfo(): void
+  onToggleCollapsed(): void
 }) {
-
   const [sortMode, setSortMode] = useState<'memory' | 'cpu' | 'command'>('cpu')
   const metrics = activeSession?.systemMetrics
   const internalIp = metrics?.ip || '-'
@@ -47,48 +50,64 @@ export function SystemSidebar({
   }, [metrics?.topProcesses, sortMode])
 
   return (
-    <>
-      <section className="sys-card">
-        <div className="connection-summary">
-          <AddressLine label={t.privateIp} value={internalIp} />
-          <AddressLine label={t.accessAddress} value={accessAddress} />
-        </div>
-        <button className="system-title" onClick={onOpenSystemInfo} type="button">{t.systemInfo}</button>
-        <div className="metric-line"><span>{t.running}</span><strong className="value">{formatUptime(metrics?.uptime)}</strong></div>
-        <div className="metric-line"><span>{t.load}</span><strong className="value">{metrics?.load ?? '-'}</strong></div>
-        <Meter
-          label={t.cpu}
-          value={metrics?.cpuPercent ?? 0}
-          tone={getMetricTone(metrics?.cpuPercent ?? 0).replace('status-', '')}
-          caption=""
-          percent={metrics ? `${metrics.cpuPercent}%` : '-'}
-        />
-        <MemoryMeter metrics={metrics} />
-        <Meter
-          label={t.swap}
-          value={metrics?.swapPercent ?? 0}
-          tone={getMetricTone(metrics?.swapPercent ?? 0).replace('status-', '')}
-          caption={metrics?.swapUsage ?? '-'}
-          percent={metrics ? `${metrics.swapPercent}%` : '-'}
-          dotTone={getMetricTone(metrics?.swapPercent ?? 0)}
-        />
-        <div className="mini-tabs">
-          <span className={sortMode === 'memory' ? 'active' : ''} onClick={() => setSortMode('memory')}>{t.memory}</span>
-          <span className={sortMode === 'cpu' ? 'active' : ''} onClick={() => setSortMode('cpu')}>{t.cpu}</span>
-          <span className={sortMode === 'command' ? 'active' : ''} onClick={() => setSortMode('command')}>{t.command}</span>
-        </div>
-        <ProcessTable rows={sortedProcesses} />
-        <NetworkPanel metrics={metrics} />
-      </section>
-      <section className="disk-table">
-        <div className="disk-head"><span>{t.path}</span><span>{t.availableSize}</span></div>
-        {rows.length ? rows.map((row) => (
-          <div className="disk-row" key={row.path}><span>{row.path}</span><span>{row.usage}</span></div>
-        )) : Array.from({ length: 8 }).map((_, i) => (
-          <div className="disk-row" key={`empty-${i}`}><span></span><span></span></div>
-        ))}
-      </section>
-    </>
+    <div className={`system-sidebar-layout ${collapsed ? 'is-collapsed' : ''}`}>
+      <button
+        aria-label={collapsed ? t.showSystemSidebar : t.hideSystemSidebar}
+        className={`system-sidebar-toggle ${collapsed ? 'is-collapsed' : ''}`}
+        onClick={onToggleCollapsed}
+        title={collapsed ? t.showSystemSidebar : t.hideSystemSidebar}
+        type="button"
+      >
+        <span className="system-sidebar-toggle-icon" aria-hidden="true">
+          <i className="panel-edge" />
+          <i className="panel-body" />
+        </span>
+      </button>
+      {!collapsed ? (
+        <>
+          <section className="sys-card">
+            <div className="connection-summary">
+              <AddressLine label={t.privateIp} value={internalIp} />
+              <AddressLine label={t.accessAddress} value={accessAddress} />
+            </div>
+            <button className="system-title" onClick={onOpenSystemInfo} type="button">{t.systemInfo}</button>
+            <div className="metric-line"><span>{t.running}</span><strong className="value">{formatUptime(metrics?.uptime)}</strong></div>
+            <div className="metric-line"><span>{t.load}</span><strong className="value">{metrics?.load ?? '-'}</strong></div>
+            <Meter
+              label={t.cpu}
+              value={metrics?.cpuPercent ?? 0}
+              tone={getMetricTone(metrics?.cpuPercent ?? 0).replace('status-', '')}
+              caption=""
+              percent={metrics ? `${metrics.cpuPercent}%` : '-'}
+            />
+            <MemoryMeter metrics={metrics} />
+            <Meter
+              label={t.swap}
+              value={metrics?.swapPercent ?? 0}
+              tone={getMetricTone(metrics?.swapPercent ?? 0).replace('status-', '')}
+              caption={metrics?.swapUsage ?? '-'}
+              percent={metrics ? `${metrics.swapPercent}%` : '-'}
+              dotTone={getMetricTone(metrics?.swapPercent ?? 0)}
+            />
+            <div className="mini-tabs">
+              <span className={sortMode === 'memory' ? 'active' : ''} onClick={() => setSortMode('memory')}>{t.memory}</span>
+              <span className={sortMode === 'cpu' ? 'active' : ''} onClick={() => setSortMode('cpu')}>{t.cpu}</span>
+              <span className={sortMode === 'command' ? 'active' : ''} onClick={() => setSortMode('command')}>{t.command}</span>
+            </div>
+            <ProcessTable rows={sortedProcesses} />
+            <NetworkPanel metrics={metrics} />
+          </section>
+          <section className="disk-table">
+            <div className="disk-head"><span>{t.path}</span><span>{t.availableSize}</span></div>
+            {rows.length ? rows.map((row) => (
+              <div className="disk-row" key={row.path}><span>{row.path}</span><span>{row.usage}</span></div>
+            )) : Array.from({ length: 8 }).map((_, i) => (
+              <div className="disk-row" key={`empty-${i}`}><span></span><span></span></div>
+            ))}
+          </section>
+        </>
+      ) : null}
+    </div>
   )
 }
 

--- a/apps/desktop/src/renderer/i18n.ts
+++ b/apps/desktop/src/renderer/i18n.ts
@@ -4,6 +4,8 @@ const zhCN = {
   systemInfo: '系统信息',
   systemInfoDescription: '查看当前主机的系统概览、资源占用、网络与文件系统状态。',
   systemInfoTabTitle: '系统信息',
+  showSystemSidebar: '显示系统占用侧栏',
+  hideSystemSidebar: '隐藏系统占用侧栏',
   noConnection: '暂时无连接',
   noConnectionDescription: '打开一个连接后，这里会显示主机状态、资源占用和网络监控。',
   remoteDisconnected: '远程连接已断开',
@@ -329,7 +331,13 @@ const zhCN = {
   closeConfirmQuitMsg: '确定要退出 TermDock 吗？',
   closeConfirmWindowsMsg: '请选择如何处理当前窗口：',
   closeConfirmQuit: '直接退出',
-  closeConfirmHide: '最小化到系统托盘'
+  closeConfirmHide: '最小化到系统托盘',
+  closeShortcutConnectingTitle: '连接尚未完成',
+  closeShortcutConnectingDescription: '“{name}” 仍在连接中。现在关闭会中断这次连接，确定继续吗？',
+  closeShortcutLastActiveTitle: '关闭当前连接',
+  closeShortcutLastActiveDescription: '“{name}” 是当前最后一个活跃连接。关闭后会先退回首页新标签页，确定继续吗？',
+  closeShortcutCloseTab: '关闭标签页',
+  closeShortcutQuitConfirm: '退出应用'
 }
 
 const enUS: typeof zhCN = {
@@ -338,6 +346,8 @@ const enUS: typeof zhCN = {
   systemInfo: 'System Info',
   systemInfoDescription: 'View host overview, resource usage, network, and filesystem status.',
   systemInfoTabTitle: 'System Info',
+  showSystemSidebar: 'Show system usage sidebar',
+  hideSystemSidebar: 'Hide system usage sidebar',
   noConnection: 'No Connection',
   noConnectionDescription: 'Open a connection to see host status, resource usage, and network monitoring here.',
   remoteDisconnected: 'Remote connection closed',
@@ -652,7 +662,13 @@ const enUS: typeof zhCN = {
   closeConfirmQuitMsg: 'Are you sure you want to quit TermDock?',
   closeConfirmWindowsMsg: 'Please choose how to handle the window:',
   closeConfirmQuit: 'Exit App',
-  closeConfirmHide: 'Minimize to Tray'
+  closeConfirmHide: 'Minimize to Tray',
+  closeShortcutConnectingTitle: 'Connection Still Starting',
+  closeShortcutConnectingDescription: '"{name}" is still connecting. Closing it now will interrupt that connection. Continue?',
+  closeShortcutLastActiveTitle: 'Close Current Connection',
+  closeShortcutLastActiveDescription: '"{name}" is the last active connection. Closing it will return you to a new home tab first. Continue?',
+  closeShortcutCloseTab: 'Close Tab',
+  closeShortcutQuitConfirm: 'Exit App'
 }
 
 export const messages = {

--- a/apps/desktop/src/renderer/styles/features/shell.css
+++ b/apps/desktop/src/renderer/styles/features/shell.css
@@ -112,6 +112,10 @@
   border-right: 1px solid var(--border-light);
 }
 
+.fs-sidebar.is-collapsed {
+  grid-template-rows: 1fr;
+}
+
 .fs-shell.has-window-menubar .fs-sidebar {
   grid-row: 3 / 5;
 }
@@ -133,6 +137,81 @@
   min-width: 0;
   overflow: hidden;
   container-type: inline-size;
+}
+
+.system-sidebar-layout {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 0;
+  height: 100%;
+}
+
+.system-sidebar-layout.is-collapsed {
+  grid-template-rows: 1fr;
+  justify-items: center;
+  align-items: flex-start;
+  padding-top: 10px;
+}
+
+.system-sidebar-toggle {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--border-light);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--bg-sidebar, transparent) 82%, transparent);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.system-sidebar-toggle:hover {
+  transform: translateX(-1px);
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.16);
+}
+
+.system-sidebar-toggle.is-collapsed {
+  position: static;
+  margin: 0 auto;
+}
+
+.system-sidebar-toggle-icon {
+  position: relative;
+  display: block;
+  width: 10px;
+  height: 10px;
+}
+
+.system-sidebar-toggle-icon i {
+  position: absolute;
+  display: block;
+  border-radius: 4px;
+}
+
+.system-sidebar-toggle-icon .panel-edge {
+  top: 1px;
+  bottom: 1px;
+  left: 0;
+  width: 2px;
+  background: currentColor;
+  opacity: 0.9;
+}
+
+.system-sidebar-toggle-icon .panel-body {
+  inset: 1px 0 1px 3px;
+  border: 1px solid currentColor;
+  opacity: 0.72;
+}
+
+.system-sidebar-layout.is-collapsed .system-sidebar-toggle-icon {
+  transform: scaleX(-1);
 }
 
 
@@ -188,7 +267,7 @@
 .system-title {
   width: 100%;
   height: 30px;
-  margin: 8px 0 8px;
+  margin: 8px 28px 8px 0;
   border: 1px solid var(--border-light);
   border-radius: var(--radius-md);
   font-weight: 600;
@@ -579,7 +658,7 @@
   grid-column: 1 / -1;
   grid-row: 1;
   display: grid;
-  grid-template-columns: var(--sidebar-width, 256px) minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: stretch;
   border-bottom: 1px solid var(--border-light);
   position: relative;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -388,6 +388,7 @@ export interface TermdockDesktopApi {
   minimizeCurrentWindow(): Promise<void>
   toggleMaximizeCurrentWindow(): Promise<void>
   closeCurrentWindow(): Promise<void>
+  requestQuitApp(): Promise<void>
   getSnapshot(): Promise<WorkspaceSnapshot>
   createFolder(name: string, parentId?: string): Promise<WorkspaceSnapshot>
   updateFolder(folderId: string, updates: Partial<ConnectionFolder>): Promise<WorkspaceSnapshot>
@@ -448,6 +449,7 @@ export interface TermdockDesktopApi {
   onWorkspaceSnapshot(listener: (snapshot: WorkspaceSnapshot) => void): () => void
   onSshInteraction(listener: (request: SshInteractionRequest) => void): () => void
   onWindowCloseRequest(listener: (event: { isQuit: boolean }) => void): () => void
+  onRequestCloseActiveWorkspaceItem(listener: () => void): () => void
   confirmCloseWindow(action: 'quit' | 'hide' | 'cancel'): Promise<void>
 }
 


### PR DESCRIPTION
## 概述

四个改进方向：macOS 原生应用菜单、系统侧栏折叠、FTP 列表智能降级、Cmd+W 关闭优化。

## 改动详情

### 1. macOS 原生应用菜单
- 新增 `installApplicationMenu()`，macOS 下注册原生菜单栏
- Quit 菜单项走退出确认链路（不再绕过）
- Close 菜单项/Cmd+W 关闭当前工作区条目而非直接关窗口
- Windows 下 `Menu.setApplicationMenu(null)` 保持一致

### 2. Cmd+W 快捷键优化
- `before-input-event` 拦截 Cmd/Ctrl+W，发送 `close-active-workspace-item-request`
- 关闭最后一个活跃连接时弹出确认弹窗
- 连接中 vs 活跃态分别提示，防止误操作
- 新增 `requestQuitApp` IPC 通道，renderer 可主动请求退出

### 3. 系统侧栏折叠
- 侧栏右上角新增折叠/展开切换按钮（面板图标动画）
- 折叠状态持久化到 `StoredMainTabUiState`
- 收起后侧栏仅 44px，隐藏分隔条，主区域自动扩展
- shell.css grid 从 `var(--sidebar-width)` 改为 `auto`

### 4. FTP 列表智能降级
- 如果 MLSD 返回全 `FileType.Unknown`，自动切换到经典 LIST 命令重试
- `resolveDirectoryFlag` 保留 cd 试探作为最终兜底
- 解析后修正 `entry.type`，下游不再误判

### 5. Dock 激活修复
- macOS 点击 Dock 图标时先尝试恢复已有窗口

## 文件
| 文件 | 说明 |
|------|------|
| `main.ts` | 应用菜单、Cmd+W 拦截、Dock 修复 |
| `app-handlers.ts` / `types.ts` / `preload.cts` / `index.ts` | API 桥接 |
| `App.tsx` | 快捷键关闭逻辑、侧栏折叠状态 |
| `SystemSidebar.tsx` | 折叠 UI |
| `ftp-session-controller.ts` | LIST 降级 + cd 兜底 |
| `i18n.ts` | 中英文案 |
| `shell.css` | 侧栏折叠样式 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)