### PR TITLE
fix: FTP 列表对齐诊断日志、终端 resize 等待命令完成并保留可见内容

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/desktop",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@monaco-editor/react": "4.7.0",
-    "@termdock/core": "0.1.0-beta.8",
-    "@termdock/storage": "0.1.0-beta.8",
+    "@termdock/core": "0.1.0-beta.9",
+    "@termdock/storage": "0.1.0-beta.9",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",

--- a/apps/desktop/src/main/services/sessions/ftp-session-controller.ts
+++ b/apps/desktop/src/main/services/sessions/ftp-session-controller.ts
@@ -219,6 +219,7 @@ export class LiveFtpSessionController extends BaseFileSessionController implemen
     const previousPath = await this.ftp.pwd()
     const rows = entries
       .filter((entry) => entry.name !== '.' && entry.name !== '..')
+    logFtpListingAlignment(targetPath, rows)
     appLog(`[TermDock][FTP] Listing remote directory ${targetPath} (${rows.length} entries)`)
     const items: RemoteFileItem[] = []
 
@@ -498,6 +499,8 @@ function formatPermissionsForDebug(entry: FileInfo) {
 
 type FileInfoWithRaw = FileInfo & {
   rawLine?: string
+  rawName?: string
+  rawIndex?: number
 }
 
 function enrichFtpListing(files: FileInfo[], rawList: string) {
@@ -507,33 +510,69 @@ function enrichFtpListing(files: FileInfo[], rawList: string) {
     .filter((line) => line.trim() !== '')
     .filter((line) => !line.startsWith('total'))
     .filter((line) => !/type=(cdir|pdir)/i.test(line))
-    .filter((line) => {
-      const rawName = extractRawEntryName(line)
-      return rawName !== '.' && rawName !== '..'
+    .map((line, index) => ({
+      rawLine: line,
+      rawName: extractRawEntryName(line),
+      rawIndex: index
+    }))
+    .filter((entry) => {
+      return entry.rawName !== '.' && entry.rawName !== '..'
     })
 
   return files.map((file, index) => {
     const enriched = file as FileInfoWithRaw
-    const rawLine = findMatchingRawLine(lines, file.name, index)
-    if (!rawLine) {
+    const rawEntry = findMatchingRawLine(lines, file.name, index)
+    if (!rawEntry) {
       return enriched
     }
 
-    enriched.rawLine = rawLine
-    enrichFromRawLine(enriched, rawLine)
+    enriched.rawLine = rawEntry.rawLine
+    enriched.rawName = rawEntry.rawName
+    enriched.rawIndex = rawEntry.rawIndex
+    enrichFromRawLine(enriched, rawEntry.rawLine)
     return enriched
   })
 }
 
-function findMatchingRawLine(lines: string[], fileName: string, fallbackIndex: number) {
+function findMatchingRawLine(
+  lines: Array<{ rawLine: string; rawName: string; rawIndex: number }>,
+  fileName: string,
+  fallbackIndex: number
+) {
   for (let index = fallbackIndex; index < lines.length; index += 1) {
     const line = lines[index]
-    if (extractRawEntryName(line) === fileName) {
+    if (line.rawName === fileName) {
       return line
     }
   }
 
   return lines[fallbackIndex]
+}
+
+function logFtpListingAlignment(targetPath: string, entries: FileInfo[]) {
+  const parsedNames = entries.map((entry) => entry.name)
+  const rawNames = entries.map((entry) => (entry as FileInfoWithRaw).rawName ?? '?')
+  const mismatches = entries
+    .map((entry, index) => ({
+      index,
+      parsedName: entry.name,
+      rawName: (entry as FileInfoWithRaw).rawName ?? '?',
+      rawIndex: (entry as FileInfoWithRaw).rawIndex ?? -1
+    }))
+    .filter((item) => item.parsedName !== item.rawName)
+
+  if (!mismatches.length) {
+    return
+  }
+
+  const mismatchSummary = mismatches
+    .slice(0, 8)
+    .map((item) => `#${item.index}:${item.parsedName}<-${item.rawName}@${item.rawIndex}`)
+    .join(' | ')
+
+  appWarn(`[TermDock][FTP] Listing alignment mismatch detected for ${targetPath}: ${mismatchSummary}`)
+  appWarn(`[TermDock][FTP] Parsed listing sequence for ${targetPath}: ${parsedNames.join(' | ')}`)
+  appWarn(`[TermDock][FTP] Raw listing sequence for ${targetPath}: ${rawNames.join(' | ')}`)
 }
 
 function extractRawEntryName(rawLine: string) {

--- a/apps/desktop/src/renderer/components/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/TerminalView.tsx
@@ -84,13 +84,39 @@ function trimTranscript(transcript: string) {
   return transcript.slice(transcript.length - TERMINAL_TRANSCRIPT_LIMIT)
 }
 
+function getLastVisibleTerminalLine(terminal: Terminal) {
+  const buffer = terminal.buffer.active
+  for (let row = buffer.length - 1; row >= 0; row -= 1) {
+    const line = buffer.getLine(row)?.translateToString(false) ?? ''
+    const normalized = line.trimEnd()
+    if (normalized) {
+      return normalized
+    }
+  }
+  return ''
+}
+
+function looksLikeShellPrompt(line: string) {
+  if (!line) {
+    return false
+  }
+
+  return [
+    /(?:^|\s)[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+(?::[^\n]*)?[#$%>]$/,
+    /^\[[^\]]+@[^\]]+\][#$]$/,
+    /^[#$%>]$/
+  ].some((pattern) => pattern.test(line))
+}
+
 export function TerminalView({
   tabId,
   bootText,
+  connected = false,
   onStatus
 }: {
   tabId: string
   bootText: string
+  connected?: boolean
   onStatus?(message: string | null): void
 }) {
   const hostRef = useRef<HTMLDivElement | null>(null)
@@ -114,6 +140,8 @@ export function TerminalView({
   const lastObservedHostRectRef = useRef<{ width: number; height: number } | null>(null)
   const isHorizontalResizeActiveRef = useRef(false)
   const lastTerminalOutputAtRef = useRef(0)
+  const awaitingCommandCompletionRef = useRef(false)
+  const pendingPromptResizeRef = useRef(false)
   const [hasSelection, setHasSelection] = useState(false)
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
   const [findOpen, setFindOpen] = useState(false)
@@ -401,9 +429,10 @@ export function TerminalView({
     options: {
       force?: boolean
       freezeCols?: boolean
+      preserveVisibleBuffer?: boolean
     } = {}
   ) => {
-    const { force = false, freezeCols = false } = options
+    const { force = false, freezeCols = false, preserveVisibleBuffer = false } = options
     const host = hostRef.current
     if (!host) {
       return
@@ -430,8 +459,19 @@ export function TerminalView({
     const cols = freezeCols && previousSize
       ? previousSize.cols
       : liveCols
+    const shouldPreserveVisibleBuffer = preserveVisibleBuffer && previousSize && previousSize.cols !== cols
+    const visibleBufferSnapshot = shouldPreserveVisibleBuffer
+      ? snapshotTerminalBuffer(terminal)
+      : ''
     if (terminal.cols !== cols || terminal.rows !== rows) {
       terminal.resize(cols, rows)
+      if (shouldPreserveVisibleBuffer && visibleBufferSnapshot) {
+        renderedTranscriptRef.current = trimTranscript(visibleBufferSnapshot)
+        pendingWriteRef.current = ''
+        terminal.reset()
+        terminal.write(visibleBufferSnapshot)
+        suppressHydratedChunksUntilRef.current = Date.now() + 300
+      }
       terminal.refresh(0, Math.max(terminal.rows - 1, 0))
     }
 
@@ -533,11 +573,11 @@ export function TerminalView({
       replaceTerminalWithTranscript(terminal, bootTextRef.current)
     }
 
-    const resize = (force = false, freezeCols = false) => {
-      syncTerminalSize(fitAddon, terminal, { force, freezeCols })
+    const resize = (force = false, freezeCols = false, preserveVisibleBuffer = false) => {
+      syncTerminalSize(fitAddon, terminal, { force, freezeCols, preserveVisibleBuffer })
     }
 
-    const scheduleResize = (force = false, freezeCols = false) => {
+    const scheduleResize = (force = false, freezeCols = false, preserveVisibleBuffer = false) => {
       pendingResizeForceRef.current = pendingResizeForceRef.current || force
       pendingResizeFreezeColsRef.current = pendingResizeFreezeColsRef.current || freezeCols
 
@@ -551,7 +591,7 @@ export function TerminalView({
         const shouldFreezeCols = pendingResizeFreezeColsRef.current
         pendingResizeForceRef.current = false
         pendingResizeFreezeColsRef.current = false
-        resize(shouldForce, shouldFreezeCols)
+        resize(shouldForce, shouldFreezeCols, preserveVisibleBuffer)
       })
     }
 
@@ -567,13 +607,28 @@ export function TerminalView({
           return
         }
 
+        if (awaitingCommandCompletionRef.current) {
+          const promptLine = getLastVisibleTerminalLine(terminal)
+          if (!looksLikeShellPrompt(promptLine)) {
+            resizeSettleTimerRef.current = null
+            isHorizontalResizeActiveRef.current = false
+            pendingPromptResizeRef.current = true
+            return
+          }
+          awaitingCommandCompletionRef.current = false
+        }
+
         resizeSettleTimerRef.current = null
         isHorizontalResizeActiveRef.current = false
-        window.requestAnimationFrame(() => scheduleResize(true))
+        pendingPromptResizeRef.current = false
+        window.requestAnimationFrame(() => scheduleResize(true, false, true))
       }, TERMINAL_RESIZE_SETTLE_MS)
     }
 
     const onDataDispose = terminal.onData((data) => {
+      if (data.includes('\r') || data.includes('\n')) {
+        awaitingCommandCompletionRef.current = true
+      }
       clearEphemeralHighlight()
       setContextMenu(null)
       void window.termdock?.writeTerminal(tabId, data)
@@ -592,6 +647,9 @@ export function TerminalView({
         appendRenderedTranscript(chunk)
         clearEphemeralHighlight()
         scheduleTerminalWrite(formatTerminalChunk(terminal, chunk))
+        if (pendingPromptResizeRef.current) {
+          scheduleSettledHorizontalResize()
+        }
       }
     })
 
@@ -607,6 +665,8 @@ export function TerminalView({
         }
         if (!wasConnectedRef.current && connected) {
           preserveVisibleBufferRef.current = false
+          awaitingCommandCompletionRef.current = false
+          pendingPromptResizeRef.current = false
           window.requestAnimationFrame(() => scheduleResize(true))
         }
         if (isDisconnecting) {
@@ -748,6 +808,8 @@ export function TerminalView({
       lastObservedHostRectRef.current = null
       isHorizontalResizeActiveRef.current = false
       lastTerminalOutputAtRef.current = 0
+      awaitingCommandCompletionRef.current = false
+      pendingPromptResizeRef.current = false
       searchResultsDisposable.dispose()
       osc52Disposable.dispose()
       resizeObserver.disconnect()
@@ -764,12 +826,16 @@ export function TerminalView({
   useEffect(() => {
     bootTextRef.current = bootText
     const terminal = terminalRef.current
-    if (!terminal || !shouldHydrateTranscript(renderedTranscriptRef.current, bootText, wasConnectedRef.current)) {
+    if (
+      !terminal
+      || connected
+      || !shouldHydrateTranscript(renderedTranscriptRef.current, bootText, wasConnectedRef.current)
+    ) {
       return
     }
 
     replaceTerminalWithTranscript(terminal, bootText)
-  }, [bootText])
+  }, [bootText, connected])
 
   useEffect(() => {
     if (!terminalRef.current) {

--- a/apps/desktop/src/renderer/features/workspace/SessionWorkspace.tsx
+++ b/apps/desktop/src/renderer/features/workspace/SessionWorkspace.tsx
@@ -248,7 +248,12 @@ export function SessionWorkspace({
     >
       {!isFileOnly ? (
         <div className="terminal-area">
-          <TerminalView key={activeTab.id} tabId={activeTab.id} bootText={activeSession.terminalTranscript ?? ''} />
+          <TerminalView
+            key={activeTab.id}
+            tabId={activeTab.id}
+            bootText={activeSession.terminalTranscript ?? ''}
+            connected={activeSession.connected === true}
+          />
         </div>
       ) : null}
       {!isFileOnly ? (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termdock",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/core",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": true,
   "type": "module",
   "main": "src/index.ts"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@termdock/storage",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": true,
   "type": "module",
   "main": "src/index.ts",
   "dependencies": {
-    "@termdock/core": "0.1.0-beta.8"
+    "@termdock/core": "0.1.0-beta.9"
   }
 }


### PR DESCRIPTION
## 概述

两个改进：FTP 列表对齐诊断 + 终端 resize 智能等待。

## 改动

### FTP 列表对齐诊断
- `enrichFtpListing` 重构：先 map 原始行为结构体（rawLine/rawName/rawIndex）再过滤 `./..`
- 新增 `logFtpListingAlignment`：解析名与原始名不一致时输出完整序列对比日志
- 便于排查 Serv-U 等弱列表服务器的条目错位问题

### 终端 resize 智能等待
- 新增 `looksLikeShellPrompt` 识别 shell 提示符
- 拖拽停止后等待命令执行完成（检测到提示符）再同步列数
- 列数变化时 `preserveVisibleBuffer` 保留可见内容，不清屏
- `TerminalView` 新增 `connected` 属性，未连接时不覆盖 bootText

🤖 Generated with [Claude Code](https://claude.com/claude-code)