### PR TITLE
fix: 文件大小格式化改用十进制单位（1000进制）

### DIFF
--- a/apps/desktop/src/main/services/local-files-service.ts
+++ b/apps/desktop/src/main/services/local-files-service.ts
@@ -10,9 +10,9 @@ function formatSize(bytes: number) {
   let value = bytes
   let unit = -1
   do {
-    value /= 1024
+    value /= 1000
     unit += 1
-  } while (value >= 1024 && unit < units.length - 1)
+  } while (value >= 1000 && unit < units.length - 1)
   return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unit]}`
 }
 

--- a/apps/desktop/src/main/services/sessions/session-file-utils.ts
+++ b/apps/desktop/src/main/services/sessions/session-file-utils.ts
@@ -74,8 +74,8 @@ export function formatBytes(size = 0) {
   const units = ['B', 'KB', 'MB', 'GB', 'TB']
   let value = size
   let unitIndex = 0
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024
+  while (value >= 1000 && unitIndex < units.length - 1) {
+    value /= 1000
     unitIndex += 1
   }
   const digits = value >= 10 || unitIndex === 0 ? 0 : 1


### PR DESCRIPTION
## 问题

之前 `formatBytes` / `formatSize` 使用 1024 进制，导致显示的大小与 macOS Finder、Windows 资源管理器不一致。

## 修复

1024 → 1000，对齐系统文件管理器的十进制显示标准。

| 文件 | 说明 |
|------|------|
| `local-files-service.ts` | 本地文件大小格式化 |
| `session-file-utils.ts` | 远程文件大小格式化 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)