### PR TITLE
fix: 开发模式 CSP 允许 script-src unsafe-inline

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -45,7 +45,7 @@
     "@types/ssh2": "^1.15.5",
     "@vitejs/plugin-react": "^5.1.0",
     "concurrently": "^9.2.1",
-    "electron": "38.3.0",
+    "electron": "42.3.3",
     "electron-builder": "^26.8.1",
     "typescript": "^5.9.3",
     "vite": "^7.2.1",

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain } from 'electron'
+import { BrowserWindow, ipcMain, shell } from 'electron'
 import type { ConnectionFormMode, FileEditorWindowInput } from '@termdock/core'
 import type { IpcWindowOptions } from './types.js'
 
@@ -44,6 +44,10 @@ export function registerAppHandlers(options: IpcWindowOptions) {
     }
   })
 
+  ipcMain.handle('app:openExternalUrl', async (_event, rawUrl: string) => {
+    await openExternalUrl(rawUrl)
+  })
+
   ipcMain.handle('app:openLogsDirectory', () => options.openLogsDirectory())
 
   ipcMain.handle('app:minimizeCurrentWindow', (event) => {
@@ -73,4 +77,12 @@ export function registerAppHandlers(options: IpcWindowOptions) {
   ipcMain.handle('app:confirmCloseWindow', (_event, action: 'quit' | 'hide' | 'cancel') => {
     options.confirmCloseWindow(action)
   })
+}
+
+async function openExternalUrl(rawUrl: string) {
+  const url = new URL(rawUrl)
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Unsupported external URL protocol: ${url.protocol}`)
+  }
+  await shell.openExternal(url.toString())
 }

--- a/apps/desktop/src/main/ipc/workspace-handlers.ts
+++ b/apps/desktop/src/main/ipc/workspace-handlers.ts
@@ -1,5 +1,11 @@
 import { BrowserWindow, ipcMain, type WebContents } from 'electron'
-import type { CommandExecutionOptions, CommandTemplateInput, CreateProfileInput } from '@termdock/core'
+import type {
+  CommandExecutionOptions,
+  CommandFolder,
+  CommandTemplateInput,
+  ConnectionFolder,
+  CreateProfileInput
+} from '@termdock/core'
 import type { IpcServices, IpcWindowOptions } from './types.js'
 
 export function registerWorkspaceHandlers(services: IpcServices, options: IpcWindowOptions) {
@@ -36,7 +42,7 @@ export function registerWorkspaceHandlers(services: IpcServices, options: IpcWin
     return snapshot
   })
 
-  ipcMain.handle('workspace:updateFolder', async (_, folderId: string, updates: any) => {
+  ipcMain.handle('workspace:updateFolder', async (_, folderId: string, updates: Partial<ConnectionFolder>) => {
     const snapshot = await workspaceService.updateFolder(folderId, updates)
     broadcastSnapshot(snapshot)
     return snapshot
@@ -60,7 +66,7 @@ export function registerWorkspaceHandlers(services: IpcServices, options: IpcWin
     return snapshot
   })
 
-  ipcMain.handle('workspace:updateCommandFolder', async (_, folderId: string, updates: any) => {
+  ipcMain.handle('workspace:updateCommandFolder', async (_, folderId: string, updates: Partial<CommandFolder>) => {
     const snapshot = await workspaceService.updateCommandFolder(folderId, updates)
     broadcastSnapshot(snapshot)
     return snapshot

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, nativeTheme, Tray, Menu, nativeImage, shell } from 'electron'
+import { app, BrowserWindow, nativeTheme, Tray, Menu, nativeImage, shell, session } from 'electron'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -18,6 +18,7 @@ let tray: Tray | null = null
 
 const isMac = process.platform === 'darwin'
 const isWindows = process.platform === 'win32'
+const ALLOWED_EXTERNAL_PROTOCOLS = new Set(['http:', 'https:'])
 const DEFAULT_WINDOW_BOUNDS = {
   main: {
     width: 1280,
@@ -86,6 +87,8 @@ function safeConsoleError(...args: unknown[]) {
 }
 
 function attachWindowDiagnostics(win: BrowserWindow, label: string) {
+  attachWindowSecurity(win, label)
+
   win.webContents.on('render-process-gone', (_event, details) => {
     safeConsoleError(`[TermDock] ${label} render-process-gone`, details)
   })
@@ -102,6 +105,15 @@ function attachWindowDiagnostics(win: BrowserWindow, label: string) {
       validatedURL,
       isMainFrame
     })
+  })
+}
+
+function attachWindowSecurity(win: BrowserWindow, label: string) {
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    void openExternalUrl(url).catch((error) => {
+      safeConsoleError(`[TermDock] blocked external URL from ${label}`, error)
+    })
+    return { action: 'deny' }
   })
 }
 
@@ -134,6 +146,46 @@ async function openLogsDirectory() {
   if (result) {
     throw new Error(result)
   }
+}
+
+async function openExternalUrl(rawUrl: string) {
+  const url = new URL(rawUrl)
+  if (!ALLOWED_EXTERNAL_PROTOCOLS.has(url.protocol)) {
+    throw new Error(`Unsupported external URL protocol: ${url.protocol}`)
+  }
+  await shell.openExternal(url.toString())
+}
+
+function installContentSecurityPolicy() {
+  const connectSrc = app.isPackaged
+    ? ["'self'"]
+    : ["'self'", 'http://localhost:5188', 'ws://localhost:5188']
+  const scriptSrc = app.isPackaged
+    ? ["'self'"]
+    : ["'self'", "'unsafe-eval'"]
+  const directives = [
+    "default-src 'self'",
+    `script-src ${scriptSrc.join(' ')}`,
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "font-src 'self' data: https://fonts.gstatic.com",
+    "img-src 'self' data: blob: file:",
+    "worker-src 'self' blob:",
+    `connect-src ${connectSrc.join(' ')}`,
+    "media-src 'self' blob:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'"
+  ].join('; ')
+
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [directives]
+      }
+    })
+  })
 }
 
 function normalizeUiPreferences(input?: Partial<UiPreferences> | null): UiPreferences {
@@ -359,7 +411,7 @@ function createMainWindow() {
     center: true,
     title: 'TermDock',
     autoHideMenuBar: true,
-    frame: isMac ? undefined : true,
+    frame: isWindows ? false : isMac ? undefined : true,
     titleBarStyle: isMac ? 'hiddenInset' : 'default',
     trafficLightPosition: isMac ? { x: 20, y: 18 } : undefined,
     backgroundColor: getWindowBackgroundColor(uiPreferences.theme),
@@ -368,11 +420,12 @@ function createMainWindow() {
       preload: path.join(__dirname, '../preload/preload.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false
+      sandbox: true
     }
   })
 
   mainWindow = win
+  attachWindowDiagnostics(win, 'main')
   if (isWindows) {
     win.setMenuBarVisibility(false)
   }
@@ -445,7 +498,7 @@ function createNativeChildWindow(options: {
   titleBarStyle?: 'default' | 'hidden' | 'hiddenInset' | 'customButtonsOnHover'
 }) {
   const enableVibrancy = isMac && options.useVibrancy === true
-  return new BrowserWindow({
+  const win = new BrowserWindow({
     width: options.width,
     height: options.height,
     minWidth: options.minWidth,
@@ -455,7 +508,7 @@ function createNativeChildWindow(options: {
     title: options.title,
     backgroundColor: options.backgroundColor ?? getWindowBackgroundColor(uiPreferences.theme),
     autoHideMenuBar: true,
-    frame: isMac ? undefined : true,
+    frame: isWindows ? false : isMac ? undefined : true,
     titleBarStyle: isMac ? options.titleBarStyle ?? 'hiddenInset' : 'default',
     trafficLightPosition: isMac ? { x: 16, y: 14 } : undefined,
     minimizable: false,
@@ -466,9 +519,10 @@ function createNativeChildWindow(options: {
       preload: path.join(__dirname, '../preload/preload.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false
+      sandbox: true
     }
   })
+  return win
 }
 
 function centerChildWindowToParent(parent: BrowserWindow | null, child: BrowserWindow) {
@@ -658,6 +712,7 @@ function openFileEditorWindow(parent: BrowserWindow, input: {
 app.whenReady().then(() => {
   initAppLogger(app.getPath('userData'))
   readUiPreferences()
+  installContentSecurityPolicy()
   installApplicationMenu()
   createTray()
   const appIconPath = getAppIconPath()

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -486,7 +486,7 @@ function createMainWindow() {
   return win
 }
 
-function createNativeChildWindow(options: {
+function createNativeChildWindow(parent: BrowserWindow, options: {
   title: string
   width: number
   height: number
@@ -505,13 +505,15 @@ function createNativeChildWindow(options: {
     minHeight: options.minHeight,
     center: true,
     show: false,
+    parent,
+    modal: false,
     title: options.title,
     backgroundColor: options.backgroundColor ?? getWindowBackgroundColor(uiPreferences.theme),
     autoHideMenuBar: true,
     frame: isWindows ? false : isMac ? undefined : true,
     titleBarStyle: isMac ? options.titleBarStyle ?? 'hiddenInset' : 'default',
     trafficLightPosition: isMac ? { x: 16, y: 14 } : undefined,
-    minimizable: false,
+    minimizable: isWindows,
     vibrancy: enableVibrancy ? 'sidebar' : undefined,
     visualEffectState: enableVibrancy ? options.visualEffectState ?? 'active' : undefined,
     ...getWindowIconOptions(),
@@ -544,7 +546,7 @@ function openConnectionManagerWindow(parent: BrowserWindow) {
     return
   }
 
-  const win = createNativeChildWindow({
+  const win = createNativeChildWindow(parent, {
     title: '连接管理器',
     width: DEFAULT_WINDOW_BOUNDS.connectionManager.width,
     height: DEFAULT_WINDOW_BOUNDS.connectionManager.height,
@@ -573,7 +575,7 @@ function openCommandManagerWindow(parent: BrowserWindow) {
     return
   }
 
-  const win = createNativeChildWindow({
+  const win = createNativeChildWindow(parent, {
     title: '命令管理器',
     width: DEFAULT_WINDOW_BOUNDS.commandManager.width,
     height: DEFAULT_WINDOW_BOUNDS.commandManager.height,
@@ -604,7 +606,7 @@ function openConnectionFormWindow(parent: BrowserWindow, mode: 'create' | 'edit'
     connectionFormWindow.close()
   }
 
-  const win = createNativeChildWindow({
+  const win = createNativeChildWindow(parent, {
     title: mode === 'edit' ? '编辑连接' : '新建连接',
     width: DEFAULT_WINDOW_BOUNDS.connectionForm.width,
     height: DEFAULT_WINDOW_BOUNDS.connectionForm.height,
@@ -636,7 +638,7 @@ function openCommandFormWindow(parent: BrowserWindow, mode: 'create' | 'edit', c
     commandFormWindow.close()
   }
 
-  const win = createNativeChildWindow({
+  const win = createNativeChildWindow(parent, {
     title: mode === 'edit' ? '编辑命令' : '新建命令',
     width: DEFAULT_WINDOW_BOUNDS.commandForm.width,
     height: DEFAULT_WINDOW_BOUNDS.commandForm.height,
@@ -678,7 +680,7 @@ function openFileEditorWindow(parent: BrowserWindow, input: {
     fileEditorWindow.close()
   }
 
-  const win = createNativeChildWindow({
+  const win = createNativeChildWindow(parent, {
     title: `编辑文件 - ${input.name}`,
     width: DEFAULT_WINDOW_BOUNDS.fileEditor.width,
     height: DEFAULT_WINDOW_BOUNDS.fileEditor.height,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -162,7 +162,7 @@ function installContentSecurityPolicy() {
     : ["'self'", 'http://localhost:5188', 'ws://localhost:5188']
   const scriptSrc = app.isPackaged
     ? ["'self'"]
-    : ["'self'", "'unsafe-eval'"]
+    : ["'self'", "'unsafe-eval'", "'unsafe-inline'"]
   const directives = [
     "default-src 'self'",
     `script-src ${scriptSrc.join(' ')}`,

--- a/apps/desktop/src/main/services/file-profile-repository.ts
+++ b/apps/desktop/src/main/services/file-profile-repository.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
+import { safeStorage } from 'electron'
 import type {
   CommandFolder,
   CommandTemplate,
@@ -28,8 +29,21 @@ const legacyDemoCommandTemplateIds = new Set([
   'cmd-restart-service'
 ])
 
+type ProfileSecretField = 'password' | 'privateKeyPath' | 'passphrase'
+
+type StoredProfileSecret = {
+  storage: 'safeStorage' | 'plain-text-fallback'
+  value: string
+}
+
+type StoredProfileSecrets = {
+  version: 1
+  profiles: Record<string, Partial<Record<ProfileSecretField, StoredProfileSecret>>>
+}
+
 export class FileProfileRepository implements ProfileRepository {
   private readonly filePath: string
+  private readonly secretsPath: string
   private readonly foldersPath: string
   private readonly commandFoldersPath: string
   private readonly commandsPath: string
@@ -45,6 +59,7 @@ export class FileProfileRepository implements ProfileRepository {
     seedCommandFolders: CommandFolder[] = []
   ) {
     this.filePath = path.join(baseDir, 'profiles.json')
+    this.secretsPath = path.join(baseDir, 'profile-secrets.json')
     this.foldersPath = path.join(baseDir, 'folders.json')
     this.commandFoldersPath = path.join(baseDir, 'command-folders.json')
     this.commandsPath = path.join(baseDir, 'commands.json')
@@ -70,7 +85,11 @@ export class FileProfileRepository implements ProfileRepository {
 
   async update(id: string, input: CreateProfileInput): Promise<ConnectionProfile> {
     const profiles = await this.readProfiles()
-    const profile = toProfile(id, input)
+    const previous = profiles.find((item) => item.id === id)
+    if (!previous) {
+      throw new Error('Profile not found')
+    }
+    const profile = preserveProfileMetadata(toProfile(id, input), previous)
     const nextProfiles = profiles.map((item) => (item.id === id ? profile : item))
     await this.writeProfiles(nextProfiles)
     return profile
@@ -144,8 +163,25 @@ export class FileProfileRepository implements ProfileRepository {
   }
 
   async deleteFolder(id: string): Promise<void> {
-    const folders = await this.readFolders()
-    await this.writeFolders(folders.filter((f) => f.id !== id))
+    const [profiles, folders] = await Promise.all([
+      this.readProfiles(),
+      this.readFolders()
+    ])
+    const folder = folders.find((item) => item.id === id)
+    if (!folder) {
+      return
+    }
+    const nextParentId = folder.parentId
+    await Promise.all([
+      this.writeProfiles(profiles.map((profile) => (
+        profile.parentId === id ? { ...profile, parentId: nextParentId } : profile
+      ))),
+      this.writeFolders(folders
+        .filter((item) => item.id !== id)
+        .map((item) => (
+          item.parentId === id ? { ...item, parentId: nextParentId } : item
+        )))
+    ])
   }
 
   async updateOrder(id: string, newParentId: string | undefined, newOrder: number): Promise<void> {
@@ -211,10 +247,19 @@ export class FileProfileRepository implements ProfileRepository {
       this.readCommandFolders(),
       this.readCommandTemplates()
     ])
+    const folder = folders.find((item) => item.id === id)
+    if (!folder) {
+      return
+    }
+    const nextParentId = folder.parentId
     await Promise.all([
-      this.writeCommandFolders(folders.filter((item) => item.id !== id)),
+      this.writeCommandFolders(folders
+        .filter((item) => item.id !== id)
+        .map((item) => (
+          item.parentId === id ? { ...item, parentId: nextParentId } : item
+        ))),
       this.writeCommandTemplates(commands.map((item) => (
-        item.parentId === id ? { ...item, parentId: undefined } : item
+        item.parentId === id ? { ...item, parentId: nextParentId } : item
       )))
     ])
   }
@@ -291,6 +336,7 @@ export class FileProfileRepository implements ProfileRepository {
     }
 
     await this.removeLegacyDemoData()
+    await this.migrateProfileSecrets()
   }
 
   private async removeLegacyDemoData() {
@@ -323,12 +369,31 @@ export class FileProfileRepository implements ProfileRepository {
   private async readProfiles(): Promise<ConnectionProfile[]> {
     await this.ready
     const content = await readFile(this.filePath, 'utf8')
-    return JSON.parse(content) as ConnectionProfile[]
+    const profiles = JSON.parse(content) as ConnectionProfile[]
+    const secrets = await this.readProfileSecrets()
+    return profiles.map((profile) => mergeProfileSecrets(profile, secrets.profiles[profile.id]))
   }
 
   private async writeProfiles(profiles: ConnectionProfile[]) {
     await mkdir(path.dirname(this.filePath), { recursive: true })
-    await writeFile(this.filePath, JSON.stringify(profiles, null, 2), 'utf8')
+    const { publicProfiles, secrets } = splitProfileSecrets(profiles)
+    await Promise.all([
+      writeFile(this.filePath, JSON.stringify(publicProfiles, null, 2), 'utf8'),
+      writeFile(this.secretsPath, JSON.stringify(secrets, null, 2), 'utf8')
+    ])
+    await lockDownFile(this.secretsPath)
+  }
+
+  private async migrateProfileSecrets() {
+    const profiles = await readJsonFile<ConnectionProfile[]>(this.filePath, [])
+    if (!profiles.some(hasInlineProfileSecret)) {
+      return
+    }
+    await this.writeProfiles(profiles)
+  }
+
+  private async readProfileSecrets(): Promise<StoredProfileSecrets> {
+    return readJsonFile<StoredProfileSecrets>(this.secretsPath, createEmptyProfileSecrets())
   }
 
   private async readFolders(): Promise<ConnectionFolder[]> {
@@ -370,6 +435,150 @@ async function readJsonFile<T>(filePath: string, fallback: T): Promise<T> {
     return JSON.parse(await readFile(filePath, 'utf8')) as T
   } catch {
     return fallback
+  }
+}
+
+function createEmptyProfileSecrets(): StoredProfileSecrets {
+  return {
+    version: 1,
+    profiles: {}
+  }
+}
+
+function preserveProfileMetadata(profile: ConnectionProfile, previous: ConnectionProfile): ConnectionProfile {
+  return {
+    ...profile,
+    parentId: previous.parentId,
+    order: previous.order
+  }
+}
+
+function hasInlineProfileSecret(profile: ConnectionProfile) {
+  return Boolean(
+    profile.password
+      || (profile.type === 'ssh' && (profile.privateKeyPath || profile.passphrase))
+  )
+}
+
+function splitProfileSecrets(profiles: ConnectionProfile[]) {
+  const secrets = createEmptyProfileSecrets()
+  const publicProfiles = profiles.map((profile) => {
+    const profileSecrets = extractProfileSecrets(profile)
+    if (Object.keys(profileSecrets).length > 0) {
+      secrets.profiles[profile.id] = profileSecrets
+    }
+    return stripProfileSecrets(profile)
+  })
+
+  return { publicProfiles, secrets }
+}
+
+function extractProfileSecrets(profile: ConnectionProfile): Partial<Record<ProfileSecretField, StoredProfileSecret>> {
+  const secrets: Partial<Record<ProfileSecretField, StoredProfileSecret>> = {}
+  for (const field of getProfileSecretFields(profile)) {
+    const value = getProfileSecretValue(profile, field)
+    if (value) {
+      secrets[field] = encodeProfileSecret(value)
+    }
+  }
+  return secrets
+}
+
+function getProfileSecretFields(profile: ConnectionProfile): ProfileSecretField[] {
+  return profile.type === 'ssh'
+    ? ['password', 'privateKeyPath', 'passphrase']
+    : ['password']
+}
+
+function getProfileSecretValue(profile: ConnectionProfile, field: ProfileSecretField) {
+  if (field === 'password') {
+    return profile.password
+  }
+  if (profile.type !== 'ssh') {
+    return undefined
+  }
+  return profile[field]
+}
+
+function encodeProfileSecret(value: string): StoredProfileSecret {
+  if (safeStorage.isEncryptionAvailable()) {
+    return {
+      storage: 'safeStorage',
+      value: safeStorage.encryptString(value).toString('base64')
+    }
+  }
+
+  return {
+    storage: 'plain-text-fallback',
+    value
+  }
+}
+
+function decodeProfileSecret(secret: StoredProfileSecret | undefined) {
+  if (!secret) {
+    return undefined
+  }
+  if (secret.storage === 'plain-text-fallback') {
+    return secret.value
+  }
+  if (!safeStorage.isEncryptionAvailable()) {
+    return undefined
+  }
+  try {
+    return safeStorage.decryptString(Buffer.from(secret.value, 'base64'))
+  } catch {
+    return undefined
+  }
+}
+
+function stripProfileSecrets(profile: ConnectionProfile): ConnectionProfile {
+  if (profile.type === 'ssh') {
+    const { password, privateKeyPath, passphrase, ...publicProfile } = profile
+    return publicProfile
+  }
+
+  const { password, ...publicProfile } = profile
+  return publicProfile
+}
+
+function mergeProfileSecrets(
+  profile: ConnectionProfile,
+  storedSecrets: Partial<Record<ProfileSecretField, StoredProfileSecret>> | undefined
+): ConnectionProfile {
+  if (!storedSecrets) {
+    return profile
+  }
+
+  let next = profile
+  for (const field of getProfileSecretFields(profile)) {
+    const value = decodeProfileSecret(storedSecrets[field])
+    if (!value) {
+      continue
+    }
+    next = withProfileSecretValue(next, field, value)
+  }
+  return next
+}
+
+function withProfileSecretValue(
+  profile: ConnectionProfile,
+  field: ProfileSecretField,
+  value: string
+): ConnectionProfile {
+  if (field === 'password') {
+    return { ...profile, password: value }
+  }
+  if (profile.type !== 'ssh') {
+    return profile
+  }
+  return { ...profile, [field]: value }
+}
+
+async function lockDownFile(filePath: string) {
+  try {
+    await chmod(filePath, 0o600)
+  } catch {
+    // Best effort only: chmod is not equally meaningful on every target platform.
   }
 }
 

--- a/apps/desktop/src/main/services/workspace-service.ts
+++ b/apps/desktop/src/main/services/workspace-service.ts
@@ -5,6 +5,8 @@ import type { WebContents } from 'electron'
 import {
   type CommandExecutionOptions,
   type CommandTemplateInput,
+  type CommandFolder,
+  type ConnectionFolder,
   type ConnectionProfile,
   type CommandExecutionResult,
   type CreateProfileInput,
@@ -98,7 +100,7 @@ export class WorkspaceService {
     return this.getSnapshot()
   }
 
-  async updateFolder(folderId: string, updates: any): Promise<WorkspaceSnapshot> {
+  async updateFolder(folderId: string, updates: Partial<ConnectionFolder>): Promise<WorkspaceSnapshot> {
     await this.profileRepository.updateFolder?.(folderId, updates)
     return this.getSnapshot()
   }
@@ -118,7 +120,7 @@ export class WorkspaceService {
     return this.getSnapshot()
   }
 
-  async updateCommandFolder(folderId: string, updates: any): Promise<WorkspaceSnapshot> {
+  async updateCommandFolder(folderId: string, updates: Partial<CommandFolder>): Promise<WorkspaceSnapshot> {
     await this.profileRepository.updateCommandFolder?.(folderId, updates)
     return this.getSnapshot()
   }
@@ -721,7 +723,7 @@ export class WorkspaceService {
     }
 
     const { directories, files } = await this.collectLocalUploadEntries(localPath)
-    const remoteRoot = path.posix.join(remoteDirectory, path.basename(localPath))
+    const remoteRoot = path.posix.join(remoteDirectory, targetName ?? path.basename(localPath))
     const totalBytes = Math.max(files.reduce((sum, file) => sum + Math.max(file.size, 1), 0), 1)
     onProgress({ percent: 1, transferredBytes: 0, totalBytes })
     this.ensureTransferActive(transferState)

--- a/apps/desktop/src/preload/preload.cts
+++ b/apps/desktop/src/preload/preload.cts
@@ -3,7 +3,9 @@ const { contextBridge, ipcRenderer, webUtils } = require('electron') as typeof i
 import type {
   CommandExecutionOptions,
   CommandTemplateInput,
+  CommandFolder,
   ConnectionFormMode,
+  ConnectionFolder,
   CommandExecutionResult,
   CreateProfileInput,
   DirectorySnapshot,
@@ -38,6 +40,8 @@ const api: TermdockDesktopApi = {
     ipcRenderer.invoke('app:openCommandFormWindow', mode, commandId, folderId),
   openFileEditorWindow: (input: FileEditorWindowInput): Promise<void> =>
     ipcRenderer.invoke('app:openFileEditorWindow', input),
+  openExternalUrl: (url: string): Promise<void> =>
+    ipcRenderer.invoke('app:openExternalUrl', url),
   openLogsDirectory: (): Promise<void> =>
     ipcRenderer.invoke('app:openLogsDirectory'),
   minimizeCurrentWindow: (): Promise<void> =>
@@ -57,7 +61,7 @@ const api: TermdockDesktopApi = {
     ipcRenderer.invoke('workspace:deleteProfile', profileId),
   createFolder: (name: string, parentId?: string): Promise<WorkspaceSnapshot> =>
     ipcRenderer.invoke('workspace:createFolder', name, parentId),
-  updateFolder: (folderId: string, updates: any): Promise<WorkspaceSnapshot> =>
+  updateFolder: (folderId: string, updates: Partial<ConnectionFolder>): Promise<WorkspaceSnapshot> =>
     ipcRenderer.invoke('workspace:updateFolder', folderId, updates),
   deleteFolder: (folderId: string): Promise<WorkspaceSnapshot> =>
     ipcRenderer.invoke('workspace:deleteFolder', folderId),
@@ -65,7 +69,7 @@ const api: TermdockDesktopApi = {
     ipcRenderer.invoke('workspace:updateEntityOrder', id, newParentId, newOrder),
   createCommandFolder: (name: string, parentId?: string): Promise<WorkspaceSnapshot> =>
     ipcRenderer.invoke('workspace:createCommandFolder', name, parentId),
-  updateCommandFolder: (folderId: string, updates: any): Promise<WorkspaceSnapshot> =>
+  updateCommandFolder: (folderId: string, updates: Partial<CommandFolder>): Promise<WorkspaceSnapshot> =>
     ipcRenderer.invoke('workspace:updateCommandFolder', folderId, updates),
   deleteCommandFolder: (folderId: string): Promise<WorkspaceSnapshot> =>
     ipcRenderer.invoke('workspace:deleteCommandFolder', folderId),

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -466,7 +466,7 @@ export function App() {
   const pendingHomeReplacementKeyRef = useRef<string | null>(null)
   const hasSanitizedStoredPlaceholderRef = useRef(false)
   const desktopApi = window.termdock
-  const isWindowsDesktop = false
+  const isWindowsDesktop = desktopApi?.platform === 'win32'
 
   useEffect(() => {
     if (!desktopApi || !isMainWorkspaceWindow) {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type DragEvent, type FormEvent, type MouseEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type DragEvent, type FormEvent, type MouseEvent, type ReactNode } from 'react'
 import type {
   CommandExecutionOptions,
   CommandTemplateInput,
@@ -2304,8 +2304,7 @@ export function App() {
 
   if (isConnectionManagerWindow) {
     return (
-      <>
-        <StandaloneWindowTitlebar isWindows={isWindowsDesktop} title={t.connectionManager} />
+      <StandaloneWindowFrame isWindows={isWindowsDesktop} title={t.connectionManager}>
         <ConnectionManagerModal
           profiles={workspace.profiles}
           folders={workspace.folders || []}
@@ -2354,14 +2353,13 @@ export function App() {
             }}
           />
         ) : null}
-      </>
+      </StandaloneWindowFrame>
     )
   }
 
   if (isCommandManagerWindow) {
     return (
-      <>
-        <StandaloneWindowTitlebar isWindows={isWindowsDesktop} title={t.commandManager} />
+      <StandaloneWindowFrame isWindows={isWindowsDesktop} title={t.commandManager}>
         <CommandManagerModal
           commandFolders={workspace.commandFolders || []}
           commandTemplates={workspace.commandTemplates || []}
@@ -2389,7 +2387,7 @@ export function App() {
             void deleteCommandTemplate(commandId)
           }}
         />
-      </>
+      </StandaloneWindowFrame>
     )
   }
 
@@ -2399,8 +2397,7 @@ export function App() {
       : null
 
     return (
-      <>
-        <StandaloneWindowTitlebar isWindows={isWindowsDesktop} title={editingCommand ? t.commandEdit : t.commandCreate} />
+      <StandaloneWindowFrame isWindows={isWindowsDesktop} title={editingCommand ? t.commandEdit : t.commandCreate}>
         <CommandEditorModal
           folders={workspace.commandFolders || []}
           initialValue={editingCommand
@@ -2416,14 +2413,13 @@ export function App() {
             void saveCommandTemplate(editingCommand?.id ?? null, input)
           }}
         />
-      </>
+      </StandaloneWindowFrame>
     )
   }
 
   if (isConnectionFormWindow) {
     return (
-      <>
-        <StandaloneWindowTitlebar isWindows={isWindowsDesktop} title={editingProfileId ? t.editConnection : t.newConnection} />
+      <StandaloneWindowFrame isWindows={isWindowsDesktop} title={editingProfileId ? t.editConnection : t.newConnection}>
         <ConnectionModal
           errorMessage={formError}
           groupOptions={connectionGroupOptions}
@@ -2443,14 +2439,13 @@ export function App() {
           onSubmit={handleSaveProfile}
           onClose={closeCurrentWindow}
         />
-      </>
+      </StandaloneWindowFrame>
     )
   }
 
   if (isFileEditorWindow && fileEditor) {
     return (
-      <>
-        <StandaloneWindowTitlebar isWindows={isWindowsDesktop} title={fileEditor.name} />
+      <StandaloneWindowFrame isWindows={isWindowsDesktop} title={fileEditor.name}>
         <FileEditorModal
           errorMessage={fileEditorError}
           file={fileEditor}
@@ -2463,14 +2458,13 @@ export function App() {
           standalone
           themeMode={themeMode}
         />
-      </>
+      </StandaloneWindowFrame>
     )
   }
 
   if (isFileEditorWindow) {
     return (
-      <>
-        <StandaloneWindowTitlebar isWindows={isWindowsDesktop} title={fileEditorWindowName ?? t.appTitle} />
+      <StandaloneWindowFrame isWindows={isWindowsDesktop} title={fileEditorWindowName ?? t.appTitle}>
         <div className="standalone-shell file-editor-window">
           <div className={`modal-card file-editor-modal ${themeMode === 'default-dark' ? 'file-editor-modal--dark' : ''} standalone`}>
             <div className="modal-header">
@@ -2482,7 +2476,7 @@ export function App() {
             {fileEditorError ? <div className="modal-error">{fileEditorError}</div> : <div className="file-editor-path">{t.updating}</div>}
           </div>
         </div>
-      </>
+      </StandaloneWindowFrame>
     )
   }
 
@@ -2971,6 +2965,23 @@ export function App() {
         </div>
       ) : null}
     </>
+  )
+}
+
+function StandaloneWindowFrame({
+  children,
+  isWindows,
+  title
+}: {
+  children: ReactNode
+  isWindows: boolean
+  title: string
+}) {
+  return (
+    <div className={`standalone-window-frame ${isWindows ? 'has-standalone-titlebar' : ''}`}>
+      <StandaloneWindowTitlebar isWindows={isWindows} title={title} />
+      {children}
+    </div>
   )
 }
 

--- a/apps/desktop/src/renderer/components/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/TerminalView.tsx
@@ -522,7 +522,7 @@ export function TerminalView({
     const searchAddon = new SearchAddon({ highlightLimit: 2000 })
     const unicode11Addon = new Unicode11Addon()
     const webLinksAddon = new WebLinksAddon((_event, uri) => {
-      window.open(uri, '_blank', 'noopener,noreferrer')
+      void window.termdock?.openExternalUrl(uri)
     })
     terminal.loadAddon(fitAddon)
     terminal.loadAddon(searchAddon)

--- a/apps/desktop/src/renderer/features/commands/CommandManagerModal.tsx
+++ b/apps/desktop/src/renderer/features/commands/CommandManagerModal.tsx
@@ -55,13 +55,16 @@ export function CommandManagerModal({
 
   const tree = useMemo(() => {
     const items: CommandTreeNode[] = [
-      ...commandTemplates,
-      ...commandFolders.map((folder) => ({ ...folder, children: [] }))
+      ...commandTemplates.map((command, index) => ({
+        ...command,
+        order: typeof command.order === 'number' ? command.order : index * 1000
+      })),
+      ...commandFolders.map((folder, index) => ({
+        ...folder,
+        order: typeof folder.order === 'number' ? folder.order : (commandTemplates.length + index) * 1000,
+        children: []
+      }))
     ]
-
-    items.forEach((item, index) => {
-      if (typeof item.order !== 'number') item.order = index * 1000
-    })
 
     const roots: CommandTreeNode[] = []
     const map = new Map<string, CommandTreeNode>()
@@ -155,14 +158,14 @@ export function CommandManagerModal({
     if (!draggedNode || !targetNode) return
 
     // Prevent dropping a folder into its own descendant
-    let current = targetNode
+    let current: CommandTreeNode | undefined = targetNode
     let invalid = false
-    while (current.parentId) {
+    while (current?.parentId) {
       if (current.parentId === draggingId) {
         invalid = true
         break
       }
-      current = tree.map.get(current.parentId)!
+      current = tree.map.get(current.parentId)
     }
     if (invalid) {
       setDraggingId(null)
@@ -170,8 +173,9 @@ export function CommandManagerModal({
       return
     }
 
-    let newParentId = targetNode.parentId
-    let siblings = newParentId ? tree.map.get(newParentId)!.children! : tree.roots
+    const targetParent = targetNode.parentId ? tree.map.get(targetNode.parentId) : undefined
+    let newParentId = targetParent?.type === 'command-folder' ? targetParent.id : undefined
+    let siblings = targetParent?.type === 'command-folder' ? targetParent.children : tree.roots
 
     let newOrder = targetNode.order ?? 0
 

--- a/apps/desktop/src/renderer/features/connections/ConnectionManagerModal.tsx
+++ b/apps/desktop/src/renderer/features/connections/ConnectionManagerModal.tsx
@@ -3,6 +3,10 @@ import { useState, useMemo, useRef, type DragEvent } from 'react'
 import { ConfirmActionDialog } from '../common/ConfirmActionDialog'
 import { t } from '../../i18n'
 
+type ConnectionTreeNode =
+  | (ConnectionFolder & { children: ConnectionTreeNode[] })
+  | (ConnectionProfile & { children?: never })
+
 export function ConnectionManagerModal({
   profiles,
   folders,
@@ -57,39 +61,39 @@ export function ConnectionManagerModal({
     })
   }
 
-  // Build tree
   const tree = useMemo(() => {
-    type Node = (ConnectionProfile | ConnectionFolder) & { children?: Node[] }
-    const items: Node[] = [...profiles, ...folders]
-    // Ensure all have order
-    items.forEach((item, index) => {
-      if (typeof item.order !== 'number') item.order = index * 1000
-    })
+    const items: ConnectionTreeNode[] = [
+      ...profiles.map((profile, index) => ({
+        ...profile,
+        order: typeof profile.order === 'number' ? profile.order : index * 1000
+      })),
+      ...folders.map((folder, index) => ({
+        ...folder,
+        order: typeof folder.order === 'number' ? folder.order : (profiles.length + index) * 1000,
+        children: []
+      }))
+    ]
 
-    const roots: Node[] = []
-    const map = new Map<string, Node>()
-
-    items.forEach(item => {
-      if (item.type === 'folder') {
-        ;(item as Node).children = []
-      }
-      map.set(item.id, item as Node)
-    })
+    const roots: ConnectionTreeNode[] = []
+    const map = new Map<string, ConnectionTreeNode>()
 
     items.forEach(item => {
-      if (item.parentId && map.has(item.parentId)) {
-        const parent = map.get(item.parentId)!
-        if (!parent.children) parent.children = []
-        parent.children.push(item as Node)
+      map.set(item.id, item)
+    })
+
+    items.forEach(item => {
+      const parent = item.parentId ? map.get(item.parentId) : undefined
+      if (parent?.type === 'folder') {
+        parent.children.push(item)
       } else {
-        roots.push(item as Node)
+        roots.push(item)
       }
     })
 
-    const sortNodes = (nodes: Node[]) => {
+    const sortNodes = (nodes: ConnectionTreeNode[]) => {
       nodes.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
       nodes.forEach(n => {
-        if (n.children) sortNodes(n.children)
+        if (n.type === 'folder') sortNodes(n.children)
       })
     }
     sortNodes(roots)
@@ -149,14 +153,14 @@ export function ConnectionManagerModal({
     if (!draggedNode || !targetNode) return
 
     // Prevent dropping a folder into its own descendant
-    let current = targetNode
+    let current: ConnectionTreeNode | undefined = targetNode
     let invalid = false
-    while (current.parentId) {
+    while (current?.parentId) {
       if (current.parentId === draggingId) {
         invalid = true
         break
       }
-      current = tree.map.get(current.parentId)!
+      current = tree.map.get(current.parentId)
     }
     if (invalid) {
       setDraggingId(null)
@@ -164,8 +168,9 @@ export function ConnectionManagerModal({
       return
     }
 
-    let newParentId = targetNode.parentId
-    let siblings = newParentId ? tree.map.get(newParentId)!.children! : tree.roots
+    const targetParent = targetNode.parentId ? tree.map.get(targetNode.parentId) : undefined
+    let newParentId = targetParent?.type === 'folder' ? targetParent.id : undefined
+    let siblings = targetParent?.type === 'folder' ? targetParent.children : tree.roots
 
     let newOrder = targetNode.order ?? 0
 
@@ -201,7 +206,7 @@ export function ConnectionManagerModal({
     }, 0)
   }
 
-  const renderNode = (node: any, depth: number) => {
+  const renderNode = (node: ConnectionTreeNode, depth: number) => {
     const isFolder = node.type === 'folder'
     const isExpanded = expandedFolders.has(node.id)
     const isDragOver = dragOverId === node.id
@@ -303,7 +308,7 @@ export function ConnectionManagerModal({
         </div>
         {isFolder && isExpanded && node.children && (
           <div className="folder-children">
-            {node.children.map((child: any) => renderNode(child, depth + 1))}
+            {node.children.map((child) => renderNode(child, depth + 1))}
             {node.children.length === 0 && (
               <div className="manager-row empty-folder" style={{ paddingLeft: `${(depth + 1) * 20 + 14}px`, color: '#666' }}>
                 <span style={{ gridColumn: '1 / -1' }}>{t.emptyFolder}</span>

--- a/apps/desktop/src/renderer/features/system/SystemSidebar.tsx
+++ b/apps/desktop/src/renderer/features/system/SystemSidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ConnectionProfile, NetworkSamplePoint, SessionSnapshot, SystemMetrics } from '@termdock/core'
 import { copyText } from '../../app/app-utils'
-import { getLocale, t } from '../../i18n'
+import { t } from '../../i18n'
 
 function parseMemory(memStr: string): number {
   if (!memStr) return 0
@@ -82,7 +82,7 @@ export function SystemSidebar({
               <AddressLine label={t.accessAddress} value={accessAddress} />
             </div>
             <button className="system-title" onClick={onOpenSystemInfo} type="button">{t.systemInfo}</button>
-            <div className="metric-line"><span>{t.running}</span><strong className="value">{formatUptime(metrics?.uptime)}</strong></div>
+            <div className="metric-line"><span>{t.running}</span><strong className="value">{formatUptime(metrics?.uptimeSeconds, metrics?.uptime)}</strong></div>
             <div className="metric-line"><span>{t.load}</span><strong className="value">{metrics?.load ?? '-'}</strong></div>
             <Meter
               label={t.cpu}
@@ -216,15 +216,74 @@ function parseUsageTotal(usage?: string) {
   return parseMemory(usage.split('/')[1] ?? '')
 }
 
-function formatUptime(value?: string) {
-  if (!value) return '-'
-  if (getLocale() !== 'enUS') return value
+function formatUptime(uptimeSeconds?: number, fallback?: string) {
+  if (!uptimeSeconds || uptimeSeconds < 0) {
+    return formatLegacyUptime(fallback)
+  }
+
+  const days = Math.floor(uptimeSeconds / 86400)
+  const hours = Math.floor((uptimeSeconds % 86400) / 3600)
+  const minutes = Math.floor((uptimeSeconds % 3600) / 60)
+  const parts: string[] = []
+
+  if (days > 0) {
+    parts.push(`${days}${t.uptimeDayUnit}`)
+  }
+  if (hours > 0) {
+    parts.push(`${hours}${t.uptimeHourUnit}`)
+  }
+  if (!days && !hours && minutes > 0) {
+    parts.push(`${minutes}${t.uptimeMinuteUnit}`)
+  }
+
+  return parts.length ? parts.join(' ') : t.uptimeJustNow
+}
+
+function formatLegacyUptime(fallback?: string) {
+  if (!fallback) {
+    return '-'
+  }
+
+  const value = fallback.trim()
+  if (!value) {
+    return '-'
+  }
+
+  const zhDayMatch = value.match(/^(\d+)\s*天$/)
+  if (zhDayMatch) {
+    return `${zhDayMatch[1]}${t.uptimeDayUnit}`
+  }
+
+  const enDayHourMatch = value.match(/^(\d+)\s+days?,\s+(\d+):(\d+)$/i)
+  if (enDayHourMatch) {
+    const [, days, hours, minutes] = enDayHourMatch
+    return compactUptimeParts([
+      `${days}${t.uptimeDayUnit}`,
+      Number(hours) > 0 ? `${Number(hours)}${t.uptimeHourUnit}` : '',
+      Number(minutes) > 0 ? `${Number(minutes)}${t.uptimeMinuteUnit}` : ''
+    ])
+  }
+
+  const enDayMatch = value.match(/^(\d+)\s+days?$/i)
+  if (enDayMatch) {
+    return `${enDayMatch[1]}${t.uptimeDayUnit}`
+  }
+
+  const enHourMinuteMatch = value.match(/^(\d+):(\d+)$/)
+  if (enHourMinuteMatch) {
+    const [, hours, minutes] = enHourMinuteMatch
+    return compactUptimeParts([
+      Number(hours) > 0 ? `${Number(hours)}${t.uptimeHourUnit}` : '',
+      Number(minutes) > 0 ? `${Number(minutes)}${t.uptimeMinuteUnit}` : ''
+    ])
+  }
 
   return value
-    .replace(/(\d+)\s*天/g, '$1d')
-    .replace(/(\d+)\s*小时/g, '$1h')
-    .replace(/(\d+)\s*分钟/g, '$1m')
-    .replace(/(\d+)\s*秒/g, '$1s')
+}
+
+function compactUptimeParts(parts: string[]) {
+  const filtered = parts.filter(Boolean)
+  return filtered.length ? filtered.join(' ') : t.uptimeJustNow
 }
 
 function getMetricTone(percent: number) {

--- a/apps/desktop/src/renderer/features/workspace/HomeWorkspace.tsx
+++ b/apps/desktop/src/renderer/features/workspace/HomeWorkspace.tsx
@@ -3,6 +3,10 @@ import { useState, useMemo } from 'react'
 import { t } from '../../i18n'
 import { AppIcon } from '../common/AppIcon'
 
+type ConnectionTreeNode =
+  | (ConnectionFolder & { children: ConnectionTreeNode[] })
+  | (ConnectionProfile & { children?: never })
+
 export function HomeWorkspace({
   profiles,
   folders = [],
@@ -25,44 +29,45 @@ export function HomeWorkspace({
   }
 
   const tree = useMemo(() => {
-    type Node = (ConnectionProfile | ConnectionFolder) & { children?: Node[] }
-    const items: Node[] = [...profiles, ...folders]
-    
-    items.forEach((item, index) => {
-      if (typeof item.order !== 'number') item.order = index * 1000
-    })
+    const items: ConnectionTreeNode[] = [
+      ...profiles.map((profile, index) => ({
+        ...profile,
+        order: typeof profile.order === 'number' ? profile.order : index * 1000
+      })),
+      ...folders.map((folder, index) => ({
+        ...folder,
+        order: typeof folder.order === 'number' ? folder.order : (profiles.length + index) * 1000,
+        children: []
+      }))
+    ]
 
-    const roots: Node[] = []
-    const map = new Map<string, Node>()
-
-    items.forEach(item => {
-      if (item.type === 'folder') {
-        ;(item as Node).children = []
-      }
-      map.set(item.id, item as Node)
-    })
+    const roots: ConnectionTreeNode[] = []
+    const map = new Map<string, ConnectionTreeNode>()
 
     items.forEach(item => {
-      if (item.parentId && map.has(item.parentId)) {
-        const parent = map.get(item.parentId)!
-        if (!parent.children) parent.children = []
-        parent.children.push(item as Node)
+      map.set(item.id, item)
+    })
+
+    items.forEach(item => {
+      const parent = item.parentId ? map.get(item.parentId) : undefined
+      if (parent?.type === 'folder') {
+        parent.children.push(item)
       } else {
-        roots.push(item as Node)
+        roots.push(item)
       }
     })
 
-    const sortNodes = (nodes: Node[]) => {
+    const sortNodes = (nodes: ConnectionTreeNode[]) => {
       nodes.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
       nodes.forEach(n => {
-        if (n.children) sortNodes(n.children)
+        if (n.type === 'folder') sortNodes(n.children)
       })
     }
     sortNodes(roots)
     return roots
   }, [profiles, folders])
 
-  const renderNode = (node: any, depth: number) => {
+  const renderNode = (node: ConnectionTreeNode, depth: number) => {
     const isFolder = node.type === 'folder'
     const isExpanded = expandedFolders.has(node.id)
 
@@ -93,7 +98,7 @@ export function HomeWorkspace({
         </div>
         {isFolder && isExpanded && node.children && (
           <div className="folder-children">
-            {node.children.map((child: any) => renderNode(child, depth + 1))}
+            {node.children.map((child) => renderNode(child, depth + 1))}
             {node.children.length === 0 && (
               <div className="quick-row empty-folder" style={{ color: '#666' }}>
                 <span style={{ marginLeft: `${(depth + 1) * 20 + 20}px`, gridColumn: '1 / -1' }}>{t.emptyFolder}</span>

--- a/apps/desktop/src/renderer/styles/features/workstation-skin.css
+++ b/apps/desktop/src/renderer/styles/features/workstation-skin.css
@@ -956,3 +956,71 @@ textarea:focus-visible,
     padding: 9px 10px;
   }
 }
+
+.standalone-window-frame {
+  width: 100vw;
+  min-height: 100vh;
+}
+
+.standalone-window-frame.has-standalone-titlebar {
+  display: grid;
+  grid-template-rows: 32px minmax(0, 1fr);
+  height: 100vh;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg-main);
+}
+
+.has-standalone-titlebar .standalone-window-titlebar {
+  position: relative;
+  z-index: 10;
+  grid-row: 1;
+  min-width: 0;
+}
+
+.has-standalone-titlebar .standalone-window-titlebar .window-brandmark {
+  max-width: calc(100vw - 138px);
+}
+
+.has-standalone-titlebar > .standalone-shell,
+.has-standalone-titlebar > .connection-form-window {
+  grid-row: 2;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.has-standalone-titlebar .standalone-shell {
+  min-height: 0;
+}
+
+.has-standalone-titlebar .modal-card.manager-modal.standalone,
+.has-standalone-titlebar .modal-card.ssh-modal.standalone,
+.has-standalone-titlebar .command-form-standalone,
+.has-standalone-titlebar .command-editor-page.standalone,
+.has-standalone-titlebar .command-manager-modal.standalone,
+.has-standalone-titlebar .file-editor-modal.standalone {
+  height: 100%;
+  min-height: 0;
+}
+
+.has-standalone-titlebar .modal-card.manager-modal.standalone,
+.has-standalone-titlebar .modal-card.ssh-modal.standalone,
+.has-standalone-titlebar .command-form-standalone,
+.has-standalone-titlebar .command-editor-page.standalone,
+.has-standalone-titlebar .command-manager-modal.standalone {
+  padding-top: 20px !important;
+}
+
+.has-standalone-titlebar .modal-card.ssh-modal.standalone,
+.has-standalone-titlebar .command-form-standalone {
+  grid-template-rows: minmax(0, 1fr);
+}
+
+.has-standalone-titlebar .modal-card.manager-modal.standalone > .modal-header,
+.has-standalone-titlebar .modal-card.ssh-modal.standalone > .modal-header,
+.has-standalone-titlebar .command-form-standalone > .modal-header,
+.has-standalone-titlebar .command-editor-page.standalone > .modal-header,
+.has-standalone-titlebar .command-manager-modal.standalone > .modal-header {
+  display: none;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,28 @@
 {
   "name": "termdock",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "termdock",
-      "version": "0.1.0-beta.2",
+      "version": "0.1.0-beta.9",
       "license": "MIT",
       "workspaces": [
         "apps/*",
         "packages/*"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.12.0"
       }
     },
     "apps/desktop": {
       "name": "@termdock/desktop",
-      "version": "0.1.0-beta.2",
+      "version": "0.1.0-beta.9",
       "dependencies": {
         "@monaco-editor/react": "4.7.0",
-        "@termdock/core": "0.1.0-beta.2",
-        "@termdock/storage": "0.1.0-beta.2",
+        "@termdock/core": "0.1.0-beta.9",
+        "@termdock/storage": "0.1.0-beta.9",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-unicode11": "^0.9.0",
@@ -43,48 +43,12 @@
         "@types/ssh2": "^1.15.5",
         "@vitejs/plugin-react": "^5.1.0",
         "concurrently": "^9.2.1",
-        "electron": "38.3.0",
+        "electron": "42.3.3",
         "electron-builder": "^26.8.1",
         "typescript": "^5.9.3",
         "vite": "^7.2.1",
         "wait-on": "^9.0.3"
       }
-    },
-    "apps/desktop/node_modules/electron": {
-      "version": "38.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.3.0.tgz",
-      "integrity": "sha512-Wij4AzX4SAV0X/ktq+NrWrp5piTCSS8F6YWh1KAcG+QRtNzyns9XLKERP68nFHIwfprhxF2YCN2uj7nx9DaeJw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
-        "extract-zip": "^2.0.1"
-      },
-      "bin": {
-        "electron": "cli.js"
-      },
-      "engines": {
-        "node": ">= 12.20.55"
-      }
-    },
-    "apps/desktop/node_modules/electron/node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "apps/desktop/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -490,25 +454,61 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/get/node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@electron/notarize": {
@@ -3442,6 +3442,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/electron": {
+      "version": "42.3.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.3.3.tgz",
+      "integrity": "sha512-0MwYp9wTb7TrtTalOYqeW+suqd9T/Znstr/nDLKqFGIjHdBZX339guo3mQqTPURRZ/UQmYM4uMpzKpI5wLptfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
     "node_modules/electron-builder": {
       "version": "26.8.1",
       "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.8.1.tgz",
@@ -3933,21 +3952,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -6278,7 +6282,7 @@
     },
     "packages/core": {
       "name": "@termdock/core",
-      "version": "0.1.0-beta.2"
+      "version": "0.1.0-beta.9"
     },
     "packages/shared": {
       "name": "@termdock/shared",
@@ -6286,9 +6290,9 @@
     },
     "packages/storage": {
       "name": "@termdock/storage",
-      "version": "0.1.0-beta.2",
+      "version": "0.1.0-beta.9",
       "dependencies": {
-        "@termdock/core": "0.1.0-beta.2"
+        "@termdock/core": "0.1.0-beta.9"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "release:win": "npm run release:win -w @termdock/desktop"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.12.0"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -384,6 +384,7 @@ export interface TermdockDesktopApi {
   openConnectionFormWindow(mode: ConnectionFormMode, profileId?: string): Promise<void>
   openCommandFormWindow(mode: ConnectionFormMode, commandId?: string, folderId?: string): Promise<void>
   openFileEditorWindow(input: FileEditorWindowInput): Promise<void>
+  openExternalUrl(url: string): Promise<void>
   openLogsDirectory(): Promise<void>
   minimizeCurrentWindow(): Promise<void>
   toggleMaximizeCurrentWindow(): Promise<void>

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -57,7 +57,11 @@ export class MemoryProfileRepository implements ProfileRepository {
   }
 
   async update(id: string, input: CreateProfileInput): Promise<ConnectionProfile> {
-    const profile = toProfile(id, input)
+    const previous = this.profiles.find((item) => item.id === id)
+    if (!previous) {
+      throw new Error('Profile not found')
+    }
+    const profile = preserveProfileMetadata(toProfile(id, input), previous)
     this.profiles = this.profiles.map((item) => (item.id === id ? profile : item))
     return profile
   }
@@ -106,7 +110,19 @@ export class MemoryProfileRepository implements ProfileRepository {
   }
 
   async deleteFolder(id: string): Promise<void> {
-    this.folders = this.folders.filter((f) => f.id !== id)
+    const folder = this.folders.find((item) => item.id === id)
+    if (!folder) {
+      return
+    }
+    const nextParentId = folder.parentId
+    this.profiles = this.profiles.map((profile) => (
+      profile.parentId === id ? { ...profile, parentId: nextParentId } : profile
+    ))
+    this.folders = this.folders
+      .filter((item) => item.id !== id)
+      .map((item) => (
+        item.parentId === id ? { ...item, parentId: nextParentId } : item
+      ))
   }
 
   async updateOrder(id: string, newParentId: string | undefined, newOrder: number): Promise<void> {
@@ -142,9 +158,18 @@ export class MemoryProfileRepository implements ProfileRepository {
   }
 
   async deleteCommandFolder(id: string): Promise<void> {
-    this.commandFolders = this.commandFolders.filter((item) => item.id !== id)
+    const folder = this.commandFolders.find((item) => item.id === id)
+    if (!folder) {
+      return
+    }
+    const nextParentId = folder.parentId
+    this.commandFolders = this.commandFolders
+      .filter((item) => item.id !== id)
+      .map((item) => (
+        item.parentId === id ? { ...item, parentId: nextParentId } : item
+      ))
     this.commandTemplates = this.commandTemplates.map((item) => (
-      item.parentId === id ? { ...item, parentId: undefined } : item
+      item.parentId === id ? { ...item, parentId: nextParentId } : item
     ))
   }
 
@@ -186,6 +211,14 @@ export class MemoryProfileRepository implements ProfileRepository {
       command.parentId = newParentId
       command.order = newOrder
     }
+  }
+}
+
+function preserveProfileMetadata(profile: ConnectionProfile, previous: ConnectionProfile): ConnectionProfile {
+  return {
+    ...profile,
+    parentId: previous.parentId,
+    order: previous.order
   }
 }
 


### PR DESCRIPTION
## 修复

开发模式下 Vite HMR 和某些调试工具依赖 inline script 注入。之前 CSP 只允许 `unsafe-eval`，缺少 `unsafe-inline` 会导致热更新失败。

生产包（`app.isPackaged`）不受影响，只允许 `'self'`。

## 包含
- 合入 `release-20260608` 分支改动（独立窗口框架 + 密钥存储 + 外部 URL 处理）
- CSP script-src 添加 `unsafe-inline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)