### PR TITLE
fix: 关闭会话标签页即时隐藏，避免等待后端响应造成 UI 延迟

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -453,6 +453,7 @@ export function App() {
     title: string
     variant: 'connecting' | 'active-last-session'
   } | null>(null)
+  const [closingSessionTabIds, setClosingSessionTabIds] = useState<string[]>([])
 
   useThemeMode(themeMode)
 
@@ -516,6 +517,12 @@ export function App() {
     localTabsRef.current = localTabs
   }, [localTabs])
 
+  const closingSessionTabIdSet = useMemo(() => new Set(closingSessionTabIds), [closingSessionTabIds])
+  const visibleWorkspaceTabs = useMemo(
+    () => workspace.tabs.filter((tab) => !closingSessionTabIdSet.has(tab.id)),
+    [closingSessionTabIdSet, workspace.tabs]
+  )
+
   useEffect(() => {
     window.localStorage.setItem(THEME_STORAGE_KEY, themeMode)
     void desktopApi?.setUiPreferences({ theme: themeMode })
@@ -535,7 +542,7 @@ export function App() {
           changed = true
           return { ...tab, title: t.untitledTab }
         }
-        const sourceTabTitle = workspace.tabs.find((entry) => entry.id === tab.sessionTabId)?.title ?? tab.sourceTabTitle
+        const sourceTabTitle = visibleWorkspaceTabs.find((entry) => entry.id === tab.sessionTabId)?.title ?? tab.sourceTabTitle
         const title = formatSystemInfoTabTitle(sourceTabTitle)
         if (tab.sourceTabTitle === sourceTabTitle && tab.title === title) {
           return tab
@@ -549,7 +556,7 @@ export function App() {
       })
       return changed ? next : prev
     })
-  }, [locale, workspace.tabs])
+  }, [locale, visibleWorkspaceTabs])
 
   useEffect(() => {
     const onStorage = (event: StorageEvent) => {
@@ -701,7 +708,7 @@ export function App() {
   useEffect(() => {
     const allKeys = [
       ...localTabs.map((tab) => homeTabKey(tab.id)),
-      ...workspace.tabs.map((tab) => sessionTabKey(tab.id))
+      ...visibleWorkspaceTabs.map((tab) => sessionTabKey(tab.id))
     ]
 
     setTabOrder((prev) => {
@@ -723,10 +730,10 @@ export function App() {
       const nextOrder = [...kept, ...missing]
       return areStringArraysEqual(prev, nextOrder) ? prev : nextOrder
     })
-  }, [localTabs, workspace.tabs])
+  }, [localTabs, visibleWorkspaceTabs])
 
   useEffect(() => {
-    if (!hasLoadedInitialSnapshot || localTabs.length > 0 || workspace.tabs.length > 0) {
+    if (!hasLoadedInitialSnapshot || localTabs.length > 0 || visibleWorkspaceTabs.length > 0) {
       return
     }
 
@@ -734,7 +741,7 @@ export function App() {
     setActiveLocalTabId((current) => current ?? 'home-1')
     setTabOrder((prev) => prev.includes('home:home-1') ? prev : ['home:home-1', ...prev])
     setNextHomeTabNumber((prev) => Math.max(prev, 2))
-  }, [hasLoadedInitialSnapshot, localTabs.length, workspace.tabs.length])
+  }, [hasLoadedInitialSnapshot, localTabs.length, visibleWorkspaceTabs.length])
 
   useEffect(() => {
     if (!hasLoadedInitialSnapshot) {
@@ -744,7 +751,7 @@ export function App() {
     if (!hasSanitizedStoredPlaceholderRef.current) {
       hasSanitizedStoredPlaceholderRef.current = true
       const onlyPlaceholderHomeTab = localTabs.length === 1 && isDefaultPlaceholderHomeTab(localTabs[0]!)
-      const hasRemoteSessions = workspace.tabs.length > 0
+      const hasRemoteSessions = visibleWorkspaceTabs.length > 0
       const isPlaceholderInactive = activeLocalTabId === null
 
       if (onlyPlaceholderHomeTab && hasRemoteSessions && isPlaceholderInactive) {
@@ -755,7 +762,7 @@ export function App() {
       }
     }
 
-    const validSessionTabIds = new Set(workspace.tabs.map((tab) => tab.id))
+    const validSessionTabIds = new Set(visibleWorkspaceTabs.map((tab) => tab.id))
     const nextLocalTabs = localTabs.filter((tab) => tab.kind === 'home' || validSessionTabIds.has(tab.sessionTabId))
     if (nextLocalTabs.length !== localTabs.length) {
       setLocalTabs(nextLocalTabs)
@@ -768,7 +775,7 @@ export function App() {
         ? prev
         : null
     })
-  }, [activeLocalTabId, hasLoadedInitialSnapshot, localTabs, workspace.tabs])
+  }, [activeLocalTabId, hasLoadedInitialSnapshot, localTabs, visibleWorkspaceTabs])
 
   useEffect(() => {
     if (!hasLoadedInitialSnapshot) {
@@ -841,10 +848,19 @@ export function App() {
   }, [fileClipboard])
 
   const activeLocalTab = activeLocalTabId ? localTabs.find((tab) => tab.id === activeLocalTabId) ?? null : null
+  const visibleSessionTabOrder = tabOrder
+    .filter((key) => key.startsWith('session:'))
+    .map((key) => key.slice('session:'.length))
+    .filter((id) => visibleWorkspaceTabs.some((tab) => tab.id === id))
+  const visibleActiveSessionTabId = activeLocalTab
+    ? null
+    : visibleWorkspaceTabs.some((tab) => tab.id === workspace.activeTabId)
+      ? workspace.activeTabId
+      : visibleSessionTabOrder.at(-1) ?? visibleWorkspaceTabs.at(-1)?.id ?? null
   const displayedSessionTabId = activeLocalTab
     ? activeLocalTab.kind === 'system' ? activeLocalTab.sessionTabId : null
-    : workspace.activeTabId
-  const activeTab = displayedSessionTabId ? workspace.tabs.find((tab) => tab.id === displayedSessionTabId) ?? null : null
+    : visibleActiveSessionTabId
+  const activeTab = displayedSessionTabId ? visibleWorkspaceTabs.find((tab) => tab.id === displayedSessionTabId) ?? null : null
   const activeSession = activeTab ? workspace.sessions[activeTab.id] : null
   const activeProfile = activeTab
     ? workspace.profiles.find((profile) => profile.id === activeTab.profileId) ?? null
@@ -900,6 +916,7 @@ export function App() {
 
   const applySnapshot = (snapshot: WorkspaceSnapshot) => {
     setWorkspace(snapshot)
+    setClosingSessionTabIds((prev) => prev.filter((tabId) => snapshot.tabs.some((tab) => tab.id === tabId)))
     setFormError(null)
   }
 
@@ -1109,7 +1126,7 @@ export function App() {
     try {
       setIsBusy(true)
       const targetTabs = scope === 'all-ssh'
-        ? workspace.tabs.filter((tab) => tab.sessionType === 'ssh' && tab.status !== 'closed')
+        ? visibleWorkspaceTabs.filter((tab) => tab.sessionType === 'ssh' && tab.status !== 'closed')
         : activeTab && activeTab.sessionType === 'ssh'
           ? [activeTab]
           : []
@@ -1246,12 +1263,25 @@ export function App() {
       return null
     }
 
+    const nextVisibleSessionTabs = visibleWorkspaceTabs.filter((tab) => tab.id !== tabId)
+    const relatedLocalTabs = localTabsRef.current
+      .filter((tab) => tab.kind === 'system' && tab.sessionTabId === tabId)
+      .map((tab) => tab.id)
+
+    setClosingSessionTabIds((prev) => prev.includes(tabId) ? prev : [...prev, tabId])
+    setTabOrder((prev) => prev.filter((key) => key !== sessionTabKey(tabId)))
+    if (relatedLocalTabs.length) {
+      closeHomeTabs(
+        relatedLocalTabs,
+        activeLocalTabId && relatedLocalTabs.includes(activeLocalTabId) ? null : activeLocalTabId,
+        nextVisibleSessionTabs
+      )
+    } else if (!activeLocalTabId && workspace.activeTabId === tabId && nextVisibleSessionTabs.length === 0) {
+      closeHomeTabs([], 'home-1', nextVisibleSessionTabs)
+    }
+
     const snapshot = await desktopApi.closeTab(tabId)
     applySnapshot(snapshot)
-    const relatedLocalTabs = localTabsRef.current.filter((tab) => tab.kind === 'system' && tab.sessionTabId === tabId).map((tab) => tab.id)
-    if (relatedLocalTabs.length) {
-      closeHomeTabs(relatedLocalTabs, activeLocalTabId && relatedLocalTabs.includes(activeLocalTabId) ? null : activeLocalTabId, snapshot.tabs)
-    }
     if (snapshot.activeTabId === null) {
       setLocalTabs((prev) => prev.length ? prev : [{ id: 'home-1', kind: 'home', title: t.untitledTab }])
       setTabOrder((prev) => {
@@ -1267,7 +1297,7 @@ export function App() {
     setLocalTabs((prev) => {
       const remaining = prev.filter((tab) => tab.id !== homeTabId)
 
-      if (remaining.length === 0 && workspace.tabs.length === 0) {
+      if (remaining.length === 0 && visibleWorkspaceTabs.length === 0) {
         setActiveLocalTabId('home-1')
         setNextHomeTabNumber(2)
         setTabOrder((prevOrder) => {
@@ -1293,12 +1323,10 @@ export function App() {
     }
 
     try {
-      setIsBusy(true)
       await closeSessionTabById(tabId)
     } catch (err) {
+      setClosingSessionTabIds((prev) => prev.filter((id) => id !== tabId))
       reportError(setError, '关闭标签页', err)
-    } finally {
-      setIsBusy(false)
     }
   }
 
@@ -1402,10 +1430,10 @@ export function App() {
     const activeLocalTab = activeLocalTabId
       ? localTabs.find((tab) => tab.id === activeLocalTabId) ?? null
       : null
-    const activeSessionTab = !activeLocalTab && workspace.activeTabId
-      ? workspace.tabs.find((tab) => tab.id === workspace.activeTabId) ?? null
+    const activeSessionTab = !activeLocalTab && visibleActiveSessionTabId
+      ? visibleWorkspaceTabs.find((tab) => tab.id === visibleActiveSessionTabId) ?? null
       : null
-    const totalClosableItems = localTabs.length + workspace.tabs.length
+    const totalClosableItems = localTabs.length + visibleWorkspaceTabs.length
 
     if (activeLocalTab) {
       if (totalClosableItems <= 1) {
@@ -1418,7 +1446,7 @@ export function App() {
     }
 
     if (activeSessionTab) {
-      const isLastSessionTab = workspace.tabs.length === 1
+      const isLastSessionTab = visibleWorkspaceTabs.length === 1
       const needsDisconnectConfirm = isLastSessionTab
         && (activeSessionTab.status === 'connecting' || activeSessionTab.status === 'connected')
 
@@ -1432,12 +1460,10 @@ export function App() {
       }
 
       try {
-        setIsBusy(true)
         await closeSessionTabById(activeSessionTab.id)
       } catch (err) {
+        setClosingSessionTabIds((prev) => prev.filter((id) => id !== activeSessionTab.id))
         reportError(setError, '关闭当前标签页', err)
-      } finally {
-        setIsBusy(false)
       }
       return
     }
@@ -1454,12 +1480,10 @@ export function App() {
     setShortcutCloseConfirm(null)
 
     try {
-      setIsBusy(true)
       await closeSessionTabById(tabId)
     } catch (err) {
+      setClosingSessionTabIds((prev) => prev.filter((id) => id !== tabId))
       reportError(setError, '关闭正在连接的标签页', err)
-    } finally {
-      setIsBusy(false)
     }
   }
 
@@ -1483,7 +1507,7 @@ export function App() {
         return
       }
 
-      const sourceTab = workspace.tabs.find((tab) => tab.id === target.id)
+      const sourceTab = visibleWorkspaceTabs.find((tab) => tab.id === target.id)
       if (!sourceTab) {
         return
       }
@@ -1522,7 +1546,7 @@ export function App() {
       if (!desktopApi) {
         return
       }
-      const reconnectableTabs = workspace.tabs.filter((tab) => tab.status !== 'connected' && tab.status !== 'connecting')
+      const reconnectableTabs = visibleWorkspaceTabs.filter((tab) => tab.status !== 'connected' && tab.status !== 'connecting')
       if (!reconnectableTabs.length) {
         return
       }
@@ -1561,12 +1585,12 @@ export function App() {
     }
 
     const sessionTabsToClose = action === 'closeAll'
-      ? workspace.tabs.map((tab) => tab.id)
+      ? visibleWorkspaceTabs.map((tab) => tab.id)
       : action === 'close'
         ? target.kind === 'session' ? [target.id] : []
         : target.kind === 'session'
-          ? workspace.tabs.filter((tab) => tab.id !== target.id).map((tab) => tab.id)
-          : workspace.tabs.map((tab) => tab.id)
+          ? visibleWorkspaceTabs.filter((tab) => tab.id !== target.id).map((tab) => tab.id)
+          : visibleWorkspaceTabs.map((tab) => tab.id)
 
     const homeTabsToClose = action === 'closeAll'
       ? localTabs.map((tab) => tab.id)
@@ -1576,7 +1600,7 @@ export function App() {
           ? localTabs.filter((tab) => tab.id !== target.id).map((tab) => tab.id)
           : localTabs.map((tab) => tab.id)
 
-    const remainingSessionTabs = workspace.tabs.filter((tab) => !sessionTabsToClose.includes(tab.id))
+    const remainingSessionTabs = visibleWorkspaceTabs.filter((tab) => !sessionTabsToClose.includes(tab.id))
     const preferredActiveHomeId = target.kind === 'local' && action !== 'close' ? target.id : null
     closeHomeTabs(homeTabsToClose, preferredActiveHomeId, remainingSessionTabs)
 
@@ -2092,7 +2116,7 @@ export function App() {
       }
 
       const id = key.slice(8)
-      const sessionTab = workspace.tabs.find((tab) => tab.id === id)
+      const sessionTab = visibleWorkspaceTabs.find((tab) => tab.id === id)
       return sessionTab ? { key, kind: 'session' as const, tab: sessionTab } : null
     })
     .filter((item): item is OrderedTabEntry => item !== null)
@@ -2504,7 +2528,7 @@ export function App() {
         ) : null}
         <TabBar
           activeHomeTabId={activeLocalTabId}
-          activeSessionTabId={workspace.activeTabId}
+          activeSessionTabId={visibleActiveSessionTabId}
           locale={locale}
           onAddHomeTab={handleAddHomeTab}
           onActivateHome={handleActivateHome}
@@ -2597,7 +2621,7 @@ export function App() {
               activeProfile={activeProfile}
               activeSession={activeSession}
               activeTab={activeTab}
-              tabs={workspace.tabs}
+              tabs={visibleWorkspaceTabs}
               commandFolders={workspace.commandFolders || []}
               commandTemplates={workspace.commandTemplates || []}
               folders={workspace.folders || []}
@@ -2728,10 +2752,10 @@ export function App() {
 
       {tabContextMenu ? (
         <TabContextMenu
-          canConnectAll={workspace.tabs.some((tab) => tab.status !== 'connected' && tab.status !== 'connecting')}
-          canCloseAll={localTabs.length + workspace.tabs.length > 0}
-          canCloseCurrent={tabContextMenu.target.kind === 'session' ? true : localTabs.length + workspace.tabs.length > 1}
-          canCloseOthers={localTabs.length + workspace.tabs.length > 1}
+          canConnectAll={visibleWorkspaceTabs.some((tab) => tab.status !== 'connected' && tab.status !== 'connecting')}
+          canCloseAll={localTabs.length + visibleWorkspaceTabs.length > 0}
+          canCloseCurrent={tabContextMenu.target.kind === 'session' ? true : localTabs.length + visibleWorkspaceTabs.length > 1}
+          canCloseOthers={localTabs.length + visibleWorkspaceTabs.length > 1}
           isSessionTab={tabContextMenu.target.kind === 'session'}
           onAction={(action) => {
             void handleTabContextAction(action)


### PR DESCRIPTION
- 新增 closingSessionTabIds 状态，关闭标签页时立即从 UI 移除
- visibleWorkspaceTabs 过滤掉正在关闭的标签页，render 层无需等待 closeTab 返回
- 关闭失败时从 closingSessionTabIds 中恢复，保持数据一致性
- 移除 closeSessionTabById 中多余的 setIsBusy，不再阻止操作