### PR TITLE
[codex] 修复界面复制行为

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -293,6 +293,12 @@ function installApplicationMenu() {
       submenu: [
         { role: 'about' },
         { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
         {
           label: `Quit ${app.name}`,
           accelerator: 'CmdOrCtrl+Q',
@@ -300,6 +306,20 @@ function installApplicationMenu() {
             requestQuitConfirmation()
           }
         }
+      ]
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'pasteAndMatchStyle' },
+        { role: 'delete' },
+        { role: 'selectAll' }
       ]
     },
     {

--- a/apps/desktop/src/renderer/app/app-utils.ts
+++ b/apps/desktop/src/renderer/app/app-utils.ts
@@ -30,6 +30,15 @@ export function copyText(value: string) {
   document.body.removeChild(textarea)
 }
 
+export function hasSelectedText() {
+  const selection = window.getSelection()
+  if (!selection || selection.rangeCount === 0) {
+    return false
+  }
+
+  return selection.toString().trim().length > 0
+}
+
 export function runningTransfers(transfers: TransferTask[]) {
   return transfers.filter(isActiveTransfer).length
 }

--- a/apps/desktop/src/renderer/features/files/FileManager.tsx
+++ b/apps/desktop/src/renderer/features/files/FileManager.tsx
@@ -10,6 +10,7 @@ import type {
 } from '@termdock/core'
 import {
   copyText,
+  hasSelectedText,
   localFileDragType,
   mergeUnique,
   nextSelection,
@@ -454,6 +455,10 @@ export function FileManager({
 
     const target = event.target
     if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || (target instanceof HTMLElement && target.isContentEditable)) {
+      return
+    }
+
+    if (hasSelectedText()) {
       return
     }
 

--- a/apps/desktop/src/renderer/features/system/SystemSidebar.tsx
+++ b/apps/desktop/src/renderer/features/system/SystemSidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ConnectionProfile, NetworkSamplePoint, SessionSnapshot, SystemMetrics } from '@termdock/core'
-import { copyText } from '../../app/app-utils'
+import { copyText, hasSelectedText } from '../../app/app-utils'
 import { t } from '../../i18n'
 
 function parseMemory(memStr: string): number {
@@ -133,7 +133,7 @@ function AddressLine({ label, value }: { label: string; value: string }) {
         className={`${canCopy ? 'copyable' : ''} ${copied ? 'copied' : ''}`}
         title={canCopy ? (copied ? '已复制' : `${t.copy}: ${value}`) : value}
         onClick={() => {
-          if (canCopy) {
+          if (canCopy && !hasSelectedText()) {
             copyText(value)
             setCopied(true)
             setTimeout(() => setCopied(false), 1500)

--- a/apps/desktop/src/renderer/styles/features/session.css
+++ b/apps/desktop/src/renderer/styles/features/session.css
@@ -272,6 +272,13 @@
   white-space: nowrap;
 }
 
+.pane-path-bar strong,
+.pane-path-bar span,
+.file-current-path {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
 .pane-title span {
   max-width: 64%;
   overflow: hidden;

--- a/apps/desktop/src/renderer/styles/features/shell.css
+++ b/apps/desktop/src/renderer/styles/features/shell.css
@@ -590,6 +590,18 @@
   align-items: center;
 }
 
+.address-row span,
+.address-row strong,
+.metric-line span,
+.metric-line strong,
+.meter-header span,
+.metric-chip-summary,
+.disk-head span,
+.disk-row span {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
 .fs-main {
   grid-column: 2;
   grid-row: 2;


### PR DESCRIPTION
## 变更内容
- 恢复系统侧栏、路径栏和当前路径文案的文本选择能力
- 在文件管理器中，当用户已经选中文本时，不再劫持 `Cmd/Ctrl+C` 作为文件复制快捷键
- 为 macOS 应用菜单补齐标准 `Edit` 菜单，恢复 `复制/粘贴/剪切/全选` 等原生编辑命令
- 调整侧栏点击复制逻辑，避免用户框选文本时被点击复制行为打断

## 问题原因
- Renderer 层一部分展示文本被当成不可选中的面板内容处理，导致路径和系统信息难以直接复制
- 文件管理器会优先拦截 `Cmd/Ctrl+C`，把它当作“复制文件”而不是“复制已选中文本”
- macOS 主窗口缺少系统标准的 `Edit` 菜单，导致输入框等可编辑区域的原生复制命令无法稳定工作

## 影响
- 现在路径输入框、状态文案、系统信息等区域可以按桌面应用习惯直接选中复制
- 文件区仍保留原有的文件复制交互，但不会再抢走用户对文本的复制操作
- macOS 下恢复了更符合原生预期的编辑快捷键行为

## 验证
- `npm run typecheck -w @termdock/desktop`
- 手动验证路径输入框中文本选择后可使用 `Cmd+C` 复制
- 手动验证系统侧栏与路径展示文案可选中复制
