### PR TITLE
chore: 升级版本号到 0.1.0-beta.11

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/desktop",
-  "version": "0.1.0-beta.9",
+  "version": "0.1.0-beta.11",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termdock",
-  "version": "0.1.0-beta.9",
+  "version": "0.1.0-beta.11",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",


### PR DESCRIPTION
## 变更内容
- 将根目录 package.json 版本号升级到 0.1.0-beta.11
- 将 apps/desktop/package.json 版本号升级到 0.1.0-beta.11

## 目的
- 为 release/0.1.0-beta.11 后续打 tag 和触发打包 CI 做准备

## 合并后操作
- 合并到 release/0.1.0-beta.11
- 在 release 分支当前提交上打并推送 tag：v0.1.0-beta.11
- 触发 GitHub Actions 打包流程