### PR TITLE
fix: add cpu-features shim for Electron 42 native module compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ coverage/
 .antigravitycli/
 .vscode/
 .claude/
+.githooks

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "termdock",
       "version": "0.1.0-beta.9",
+      "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "npm run build --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "release:mac": "npm run release:mac -w @termdock/desktop",
-    "release:win": "npm run release:win -w @termdock/desktop"
+    "release:win": "npm run release:win -w @termdock/desktop",
+    "postinstall": "node ./vendor/cpu-features-shim/apply-shim.mjs"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/vendor/cpu-features-shim/apply-shim.mjs
+++ b/vendor/cpu-features-shim/apply-shim.mjs
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const packageDir = path.resolve(process.cwd(), 'node_modules/cpu-features');
+
+if (!fs.existsSync(packageDir)) {
+  console.log('[cpu-features-shim] skip: cpu-features is not installed');
+  process.exit(0);
+}
+
+const packageJsonPath = path.join(packageDir, 'package.json');
+
+let packageJson = {
+  name: 'cpu-features',
+  version: '0.0.10',
+  main: 'index.js'
+};
+
+if (fs.existsSync(packageJsonPath)) {
+  packageJson = {
+    ...JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')),
+    main: 'index.js',
+    scripts: {},
+    gypfile: false
+  };
+}
+
+const shimSource = `'use strict';
+
+module.exports = function getCpuFeatures() {
+  return {
+    arch: process.arch === 'ia32' ? 'x86' : process.arch,
+    flags: {}
+  };
+};
+`;
+
+for (const entry of ['binding.gyp', 'src', 'build', 'deps']) {
+  const target = path.join(packageDir, entry);
+  if (fs.existsSync(target)) {
+    fs.rmSync(target, { recursive: true, force: true });
+  }
+}
+
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+fs.writeFileSync(path.join(packageDir, 'index.js'), shimSource);
+
+console.log('[cpu-features-shim] applied shim at', packageDir);


### PR DESCRIPTION
## Summary

ssh2 depends on `cpu-features` (optional native module). Electron 42 uses a different Node ABI than CI's build Node, causing native module compilation and runtime failures during electron-builder packaging.

## Solution

Add a `postinstall` shim script that replaces `cpu-features` with a pure JS stub, preventing native compilation while keeping ssh2 functional.

## Changes

| File | Change |
|------|--------|
| `vendor/cpu-features-shim/apply-shim.mjs` | New — postinstall shim script |
| `package.json` | Add `postinstall` hook |
| `package-lock.json` | Add `hasInstallScript: true` (required for `npm ci` to run postinstall) |
| `.gitignore` | Add `.githooks` entry |

## How the shim works

1. Runs after every `npm install`/`npm ci` via postinstall hook
2. Deletes all native build artifacts from `node_modules/cpu-features` (`binding.gyp`, `src`, `build`, `deps`)
3. Replaces `cpu-features/index.js` with a pure JS stub returning `{ arch, flags: {} }`
4. Sets `gypfile: false` in its `package.json` to prevent recompilation attempts

## Context

This was battle-tested on `release/0.1.0-beta.11` — three other approaches were tried and reverted before landing on this solution.

🤖 Generated with [Claude Code](https://claude.ai/code)