### PR TITLE
修复 Windows 安装器默认跳过向导的问题

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -90,6 +90,10 @@
       ],
       "artifactName": "TermDock-${version}-windows-${arch}-setup.${ext}"
     },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true
+    },
     "portable": {
       "artifactName": "TermDock-${version}-windows-${arch}-portable.${ext}"
     }


### PR DESCRIPTION
## 变更说明
- 为 `electron-builder` 增加 `nsis` 配置
- 将 `oneClick` 设为 `false`，改为向导式安装
- 开启 `allowToChangeInstallationDirectory`，允许用户选择安装位置

## 原因
当前 Windows 安装版使用的是 NSIS 默认配置。`electron-builder` 在未显式配置 `nsis` 时，`oneClick` 默认是 `true`，因此安装器会直接开始安装，不会展示安装路径和确认步骤。

`.github/workflows/release.yml` 这里只是调用 `npx electron-builder --win --x64`，没有覆盖 NSIS 配置，所以不需要额外修改 workflow；补齐 `apps/desktop/package.json` 中的 `build.nsis` 即可同时影响本地打包和 CI 产物。

## 验证
- 已校验 `apps/desktop/package.json` JSON 结构有效
- 本次 diff 仅包含 NSIS 配置补充
- 建议在 Windows CI 或本地重新打一个 `nsis` 安装包，确认出现安装向导和安装目录选择页
