### PR TITLE
Release 0.2.0-beta.1: 构建修复合集

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,14 +133,36 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v5
 
+      - name: Clean up stale draft releases
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release list --limit 100 --json tagName,isDraft \
+            | jq -r '.[] | select(.isDraft) | .tagName' \
+            | while read -r tag; do
+              echo "Deleting draft release: ${tag}"
+              gh release delete "${tag}" --yes --cleanup-tag 2>/dev/null || true
+            done
+
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          prerelease: true
-          generate_release_notes: true
-          files: |
-            **/*.dmg
-            **/*.zip
-            **/*.exe
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+
+          # Delete any existing release for this tag (draft or otherwise)
+          if gh release view "${TAG}" &>/dev/null; then
+            echo "Removing existing release for tag ${TAG}..."
+            gh release delete "${TAG}" --yes --cleanup-tag 2>/dev/null || true
+            sleep 2  # Give GitHub API time to sync
+          fi
+
+          echo "Creating release for ${TAG}..."
+          gh release create "${TAG}" \
+            --prerelease \
+            --generate-notes \
+            **/*.dmg **/*.zip **/*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build packages (core, shared, storage)
-        run: npm run build -w @termdock/core -w @termdock/shared -w @termdock/storage
+      - name: Build packages (core → shared → storage)
+        run: |
+          npm run build -w @termdock/core
+          npm run build -w @termdock/shared
+          npm run build -w @termdock/storage
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,11 +138,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release list --limit 100 --json tagName,isDraft \
+          REPO="${{ github.repository }}"
+          gh release list -R "${REPO}" --limit 100 --json tagName,isDraft \
             | jq -r '.[] | select(.isDraft) | .tagName' \
             | while read -r tag; do
               echo "Deleting draft release: ${tag}"
-              gh release delete "${tag}" --yes --cleanup-tag 2>/dev/null || true
+              gh release delete "${tag}" -R "${REPO}" --yes --cleanup-tag 2>/dev/null || true
             done
 
       - name: Publish GitHub Release
@@ -152,17 +153,18 @@ jobs:
         run: |
           set -euo pipefail
 
+          REPO="${{ github.repository }}"
           TAG="${GITHUB_REF_NAME}"
 
           # Delete any existing release for this tag (draft or otherwise)
-          if gh release view "${TAG}" &>/dev/null; then
+          if gh release view "${TAG}" -R "${REPO}" &>/dev/null; then
             echo "Removing existing release for tag ${TAG}..."
-            gh release delete "${TAG}" --yes --cleanup-tag 2>/dev/null || true
+            gh release delete "${TAG}" -R "${REPO}" --yes --cleanup-tag 2>/dev/null || true
             sleep 2  # Give GitHub API time to sync
           fi
 
           echo "Creating release for ${TAG}..."
-          gh release create "${TAG}" \
+          gh release create "${TAG}" -R "${REPO}" \
             --prerelease \
             --generate-notes \
             **/*.dmg **/*.zip **/*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Download all artifacts
         uses: actions/download-artifact@v5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build packages (core → shared → storage)
+        run: |
+          npm run build -w @termdock/core
+          npm run build -w @termdock/shared
+          npm run build -w @termdock/storage
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Build packages (core, shared, storage)
+        run: npm run build -w @termdock/core -w @termdock/shared -w @termdock/storage
+
       - name: Build renderer + main
         run: npm run build -w @termdock/desktop
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,11 +67,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Typecheck
-        run: npm run typecheck
-
       - name: Build packages (core, shared, storage)
         run: npm run build -w @termdock/core -w @termdock/shared -w @termdock/storage
+
+      - name: Typecheck
+        run: npm run typecheck
 
       - name: Build renderer + main
         run: npm run build -w @termdock/desktop

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -72,6 +72,7 @@
     ],
     "mac": {
       "category": "public.app-category.developer-tools",
+      "identity": "-",
       "target": [
         "dmg",
         "zip"

--- a/apps/desktop/src/main/services/file-profile-repository.ts
+++ b/apps/desktop/src/main/services/file-profile-repository.ts
@@ -1,7 +1,6 @@
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
-import { safeStorage } from 'electron'
 import type {
   CommandSendPreferences,
   CommandFolder,
@@ -35,7 +34,7 @@ const legacyDemoCommandTemplateIds = new Set([
 type ProfileSecretField = 'password' | 'privateKeyPath' | 'passphrase'
 
 type StoredProfileSecret = {
-  storage: 'safeStorage' | 'plain-text-fallback'
+  storage: 'plain-text-fallback'
   value: string
 }
 
@@ -588,13 +587,6 @@ function getProfileSecretValue(profile: ConnectionProfile, field: ProfileSecretF
 }
 
 function encodeProfileSecret(value: string): StoredProfileSecret {
-  if (safeStorage.isEncryptionAvailable()) {
-    return {
-      storage: 'safeStorage',
-      value: safeStorage.encryptString(value).toString('base64')
-    }
-  }
-
   return {
     storage: 'plain-text-fallback',
     value
@@ -605,17 +597,7 @@ function decodeProfileSecret(secret: StoredProfileSecret | undefined) {
   if (!secret) {
     return undefined
   }
-  if (secret.storage === 'plain-text-fallback') {
-    return secret.value
-  }
-  if (!safeStorage.isEncryptionAvailable()) {
-    return undefined
-  }
-  try {
-    return safeStorage.decryptString(Buffer.from(secret.value, 'base64'))
-  } catch {
-    return undefined
-  }
+  return secret.value
 }
 
 function stripProfileSecrets(profile: ConnectionProfile): ConnectionProfile {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,5 +3,13 @@
   "version": "0.2.0-beta.1",
   "private": true,
   "type": "module",
-  "main": "src/index.ts"
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,5 +3,13 @@
   "version": "0.2.0-beta.1",
   "private": true,
   "type": "module",
-  "main": "src/index.ts"
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  }
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -3,7 +3,15 @@
   "version": "0.2.0-beta.1",
   "private": true,
   "type": "module",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
   "dependencies": {
     "@termdock/core": "0.2.0-beta.1"
   }

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Cherry-pick 导致的 SHA 分叉修复，让 release/0.2.0-beta.1 合并到 main 消掉差异。

  包含修复:
  - 锁定 electron 精确版本以兼容 electron-builder
  - 强制 ad-hoc 签名 macOS 应用包
  - 用 gh CLI 替换 action-gh-release 避免 draft 冲突
  - release job 需要 checkout 才能用 gh CLI
  - 编译内部包输出 JS 以支持打包运行
  - 编译内部包后再 typecheck 确保模块可见
  - 回退 composite 修复 typecheck，顺序执行内部包编译
  - Windows CI 也添加内部包编译步骤
  - 移除 safeStorage 避免 macOS 钥匙串弹窗

  🤖 Generated with [Claude Code](https://claude.ai/code)