### PR TITLE
Merge release/0.2.0-beta.2: 版本号升级 + CI 快速失败优化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
           path: |
             apps/desktop/release/*.dmg
             apps/desktop/release/*.zip
+          if-no-files-found: error
 
   build-win:
     needs: validate-release-tag
@@ -136,6 +137,7 @@ jobs:
           name: TermDock-Windows-${{ matrix.arch }}
           path: |
             apps/desktop/release/*.exe
+          if-no-files-found: error
 
   release:
     needs: [validate-release-tag, build-mac, build-win]

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/desktop",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.2",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",
@@ -28,9 +28,9 @@
   },
   "dependencies": {
     "@monaco-editor/react": "4.7.0",
-    "@termdock/core": "0.2.0-beta.1",
-    "@termdock/shared": "0.2.0-beta.1",
-    "@termdock/storage": "0.2.0-beta.1",
+    "@termdock/core": "0.2.0-beta.2",
+    "@termdock/shared": "0.2.0-beta.2",
+    "@termdock/storage": "0.2.0-beta.2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "termdock",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "termdock",
-      "version": "0.2.0-beta.1",
+      "version": "0.2.0-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -22,11 +22,11 @@
     },
     "apps/desktop": {
       "name": "@termdock/desktop",
-      "version": "0.2.0-beta.1",
+      "version": "0.2.0-beta.2",
       "dependencies": {
         "@monaco-editor/react": "4.7.0",
-        "@termdock/core": "0.2.0-beta.1",
-        "@termdock/storage": "0.2.0-beta.1",
+        "@termdock/core": "0.2.0-beta.2",
+        "@termdock/storage": "0.2.0-beta.2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-unicode11": "^0.9.0",
@@ -5269,17 +5269,17 @@
     },
     "packages/core": {
       "name": "@termdock/core",
-      "version": "0.2.0-beta.1"
+      "version": "0.2.0-beta.2"
     },
     "packages/shared": {
       "name": "@termdock/shared",
-      "version": "0.2.0-beta.1"
+      "version": "0.2.0-beta.2"
     },
     "packages/storage": {
       "name": "@termdock/storage",
-      "version": "0.2.0-beta.1",
+      "version": "0.2.0-beta.2",
       "dependencies": {
-        "@termdock/core": "0.2.0-beta.1"
+        "@termdock/core": "0.2.0-beta.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termdock",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.2",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/core",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/shared",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/storage",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@termdock/core": "0.2.0-beta.1"
+    "@termdock/core": "0.2.0-beta.2"
   }
 }


### PR DESCRIPTION
## 合并内容

- `chore`: 版本号升级到 `0.2.0-beta.2`
- `fix`: upload-artifact 添加 `if-no-files-found: error` 快速失败

## 验证
- CI run [27898756358](https://github.com/St0ff3l/termdock/actions/runs/27898756358) ✅ 全部通过
- v0.2.0-beta.2 Release 已发布