### PR TITLE
[codex] 修复 macOS 打包版 Safe Storage 钥匙串弹窗

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -10,8 +10,9 @@ import { AppUiStateStore } from './services/app-ui-state-store.js'
 // 被用作 macOS 钥匙串服务名（"@termdock/desktop Safe Storage"），导致每次启动弹出授权弹窗。
 app.setName('TermDock')
 app.setPath('sessionData', path.join(app.getPath('temp'), 'TermDock-session-data'))
-if (!app.isPackaged && process.platform === 'darwin') {
-  // Avoid macOS Keychain prompts from Chromium/Electron internals during local development.
+if (process.platform === 'darwin') {
+  // Keep Chromium/Electron away from macOS Keychain so both dev and packaged builds
+  // avoid triggering Safe Storage authorization prompts.
   app.commandLine.appendSwitch('use-mock-keychain')
 }
 


### PR DESCRIPTION
## 变更内容

这次只做了一处主进程入口修复：

- 将 `use-mock-keychain` 从“仅 macOS 开发态启用”改为“所有 macOS 运行态启用”
- 保持现有 `sessionData` 指向临时目录的策略不变
- 不改连接逻辑、不改 renderer，不引入额外行为变化

## 根因

前一轮修复只覆盖了 `npm run dev` 场景，因此现象会变成：

- 开发态不再弹 `Safe Storage` 钥匙串授权框
- 但正式打包安装后，Electron / Chromium 仍然会在 macOS 上触发系统 Keychain 链路

也就是说，问题不是修复方向错了，而是作用范围还停留在 `!app.isPackaged`。

## 这次修复后的效果

在 macOS 上，无论是本地开发运行，还是正式打包后的安装包运行，都会统一绕开系统 Keychain 的 Safe Storage 授权弹窗。

这能保证：

- `npm run dev` 不弹
- 打包安装后的应用启动也不弹

## 影响范围

- 仅影响 macOS 下 Electron 内部 Safe Storage / Keychain 的使用方式
- 不影响 SSH / SFTP / FTP 连接功能
- 不影响现有 UI、图标、字体、状态存储逻辑

## 验证

已完成：

```bash
npm run typecheck -w @termdock/desktop
npm run build -w @termdock/desktop
```

并结合问题现象确认：

- 之前开发态已不再弹窗
- 本次补齐的是打包态的同一条链路
