### PR TITLE
feat: make outer left sidebar resizable and fix tab bar alignment on Home workspace

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -3218,6 +3218,8 @@ export function App() {
               }}
               onOpenLogsDirectory={openLogsDirectory}
               tabBarProps={tabBarProps}
+              isResizingSidebar={isResizingSidebar}
+              onResizeStart={() => setIsResizingSidebar(true)}
             />
           </div>
         </main>

--- a/apps/desktop/src/renderer/features/workspace/HomeWorkspace.tsx
+++ b/apps/desktop/src/renderer/features/workspace/HomeWorkspace.tsx
@@ -33,7 +33,9 @@ export function HomeWorkspace({
   onSetTheme,
   onSetLocale,
   onOpenLogsDirectory,
-  tabBarProps
+  tabBarProps,
+  isResizingSidebar,
+  onResizeStart
 }: {
   profiles: ConnectionProfile[]
   folders?: ConnectionFolder[]
@@ -60,6 +62,8 @@ export function HomeWorkspace({
   onSetLocale(value: 'zhCN' | 'enUS'): void
   onOpenLogsDirectory(): void
   tabBarProps: any
+  isResizingSidebar: boolean
+  onResizeStart(): void
 }) {
   const [activeTab, setActiveTab] = useState<'overview' | 'quick-links' | 'command-manager' | 'connection-manager' | 'settings'>('overview')
   const [navDirection, setNavDirection] = useState<'down' | 'up'>('down')
@@ -170,6 +174,12 @@ export function HomeWorkspace({
             <span>GitHub</span>
           </button>
         </div>
+        <div
+          aria-label={t.resizeSidebar}
+          className={`sidebar-resizer ${isResizingSidebar ? 'is-active' : ''}`}
+          onMouseDown={onResizeStart}
+          role="separator"
+        />
       </aside>
 
       {/* Main Content Area */}

--- a/apps/desktop/src/renderer/features/workspace/WorkspaceStage.tsx
+++ b/apps/desktop/src/renderer/features/workspace/WorkspaceStage.tsx
@@ -87,7 +87,9 @@ export function WorkspaceStage({
   onSetTheme,
   onSetLocale,
   onOpenLogsDirectory,
-  tabBarProps
+  tabBarProps,
+  isResizingSidebar,
+  onResizeStart
 }: {
   activeLocalTab: ActiveLocalTab
   activeHomeTabId: string | null
@@ -156,6 +158,8 @@ export function WorkspaceStage({
   onSetLocale(value: 'zhCN' | 'enUS'): void
   onOpenLogsDirectory(): void
   tabBarProps: any
+  isResizingSidebar: boolean
+  onResizeStart(): void
 }) {
   if (activeLocalTab?.kind === 'system') {
     return <SystemInfoWorkspace activeProfile={activeProfile} activeSession={activeSession} />
@@ -237,6 +241,8 @@ export function WorkspaceStage({
       onOpenLogsDirectory={onOpenLogsDirectory}
       profiles={profiles}
       tabBarProps={tabBarProps}
+      isResizingSidebar={isResizingSidebar}
+      onResizeStart={onResizeStart}
     />
   )
 }

--- a/apps/desktop/src/renderer/styles/features/home.css
+++ b/apps/desktop/src/renderer/styles/features/home.css
@@ -17,6 +17,7 @@
 
 /* Sidebar Styling */
 .home-sidebar {
+  position: relative;
   width: var(--sidebar-width, 214px);
   height: 100%;
   background-color: var(--bg-sidebar);
@@ -728,5 +729,5 @@
 }
 
 .home-tabs-bar .fs-tabs {
-  padding-left: calc(var(--brand-width, 214px) - var(--sidebar-width, 214px)) !important;
+  padding-left: 0 !important;
 }


### PR DESCRIPTION
This PR makes the outer left sidebar (navigation menu) resizable on the Home workspace, and fixes the tab bar alignment issue where tabs did not correctly follow the sidebar's edge when resized.