### PR TITLE
[codex] 重新提交：修复系统信息进度条样式并放宽内置编辑器文件大小限制

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -217,7 +217,7 @@ function joinLocalPath(directoryPath: string, name: string) {
   return `${normalized}${separator}${name}`
 }
 
-const TEXT_EDITOR_MAX_BYTES = 4 * 1024 * 1024
+const TEXT_EDITOR_MAX_BYTES = 16 * 1024 * 1024
 const LIKELY_BINARY_FILE_EXTENSIONS = new Set([
   '.7z',
   '.a',

--- a/apps/desktop/src/renderer/features/system/SystemSidebar.tsx
+++ b/apps/desktop/src/renderer/features/system/SystemSidebar.tsx
@@ -87,7 +87,7 @@ export function SystemSidebar({
             <Meter
               label={t.cpu}
               value={metrics?.cpuPercent ?? 0}
-              tone={getMetricTone(metrics?.cpuPercent ?? 0).replace('status-', '')}
+              tone={getMetricTone(metrics?.cpuPercent ?? 0)}
               caption=""
               percent={metrics ? `${metrics.cpuPercent}%` : '-'}
             />
@@ -95,7 +95,7 @@ export function SystemSidebar({
             <Meter
               label={t.swap}
               value={metrics?.swapPercent ?? 0}
-              tone={getMetricTone(metrics?.swapPercent ?? 0).replace('status-', '')}
+              tone={getMetricTone(metrics?.swapPercent ?? 0)}
               caption={metrics?.swapUsage ?? '-'}
               percent={metrics ? `${metrics.swapPercent}%` : '-'}
               dotTone={getMetricTone(metrics?.swapPercent ?? 0)}
@@ -168,6 +168,9 @@ function MemoryMeter({ metrics }: { metrics?: SystemMetrics }) {
   const cache = parseMemory(metrics?.memoryCacheUsage ?? '')
   const kernel = parseMemory(metrics?.memoryKernelUsage ?? '')
   const memoryTone = getMetricTone(metrics?.memoryPercent ?? 0)
+  // System meters intentionally use two color protocols:
+  // - tone-* for status/warning severity (cpu/swap and memory fallback)
+  // - app/cache/kernel for memory composition segments
   const segments = total > 0
     ? [
         { key: 'app', label: t.app, value: metrics?.memoryAppUsage ?? '-', width: Math.max(0, Math.min(100, (app / total) * 100)) },
@@ -193,7 +196,7 @@ function MemoryMeter({ metrics }: { metrics?: SystemMetrics }) {
             key={segment.key}
             style={{ width: `${segment.width}%` }}
           />
-        )) : <i className="meter-fill orange" style={{ width: `${metrics?.memoryPercent ?? 0}%` }} />}
+        )) : <i className="meter-fill tone-warning" style={{ width: `${metrics?.memoryPercent ?? 0}%` }} />}
 
         {segments.length ? (
           <div className="memory-hover-popover">
@@ -287,9 +290,10 @@ function compactUptimeParts(parts: string[]) {
 }
 
 function getMetricTone(percent: number) {
-  if (percent >= 85) return 'status-red'
-  if (percent >= 60) return 'status-yellow'
-  return 'status-green'
+  // Status meters use the shared tone-* classes so dot/fill styling stays aligned.
+  if (percent >= 85) return 'tone-danger'
+  if (percent >= 60) return 'tone-warning'
+  return 'tone-success'
 }
 
 function ProcessTable({ rows }: { rows: SystemMetrics['topProcesses'] }) {

--- a/apps/desktop/src/renderer/styles/themes/default-dark.css
+++ b/apps/desktop/src/renderer/styles/themes/default-dark.css
@@ -244,21 +244,21 @@
   background: var(--metric-kernel);
 }
 
-:root:not([data-theme]) .metric-dot.status-green,
-:root[data-theme='default-dark'] .metric-dot.status-green,
-:root[data-theme='default'] .metric-dot.status-green {
+:root:not([data-theme]) .metric-dot.tone-success,
+:root[data-theme='default-dark'] .metric-dot.tone-success,
+:root[data-theme='default'] .metric-dot.tone-success {
   background: var(--metric-status-green);
 }
 
-:root:not([data-theme]) .metric-dot.status-yellow,
-:root[data-theme='default-dark'] .metric-dot.status-yellow,
-:root[data-theme='default'] .metric-dot.status-yellow {
+:root:not([data-theme]) .metric-dot.tone-warning,
+:root[data-theme='default-dark'] .metric-dot.tone-warning,
+:root[data-theme='default'] .metric-dot.tone-warning {
   background: var(--metric-status-yellow);
 }
 
-:root:not([data-theme]) .metric-dot.status-red,
-:root[data-theme='default-dark'] .metric-dot.status-red,
-:root[data-theme='default'] .metric-dot.status-red {
+:root:not([data-theme]) .metric-dot.tone-danger,
+:root[data-theme='default-dark'] .metric-dot.tone-danger,
+:root[data-theme='default'] .metric-dot.tone-danger {
   background: var(--metric-status-red);
 }
 
@@ -280,15 +280,15 @@
   background: var(--meter-track);
 }
 
-:root:not([data-theme]) .meter-fill.green,
-:root[data-theme='default-dark'] .meter-fill.green,
-:root[data-theme='default'] .meter-fill.green {
+:root:not([data-theme]) .meter-fill.tone-success,
+:root[data-theme='default-dark'] .meter-fill.tone-success,
+:root[data-theme='default'] .meter-fill.tone-success {
   background: var(--success);
 }
 
-:root:not([data-theme]) .meter-fill.orange,
-:root[data-theme='default-dark'] .meter-fill.orange,
-:root[data-theme='default'] .meter-fill.orange {
+:root:not([data-theme]) .meter-fill.tone-warning,
+:root[data-theme='default-dark'] .meter-fill.tone-warning,
+:root[data-theme='default'] .meter-fill.tone-warning {
   background: var(--memory-warn);
 }
 
@@ -296,6 +296,12 @@
 :root[data-theme='default-dark'] .meter-fill.yellow,
 :root[data-theme='default'] .meter-fill.yellow {
   background: var(--memory-warn);
+}
+
+:root:not([data-theme]) .meter-fill.tone-danger,
+:root[data-theme='default-dark'] .meter-fill.tone-danger,
+:root[data-theme='default'] .meter-fill.tone-danger {
+  background: var(--metric-status-red);
 }
 
 :root:not([data-theme]) .meter-fill.app,
@@ -1693,19 +1699,25 @@
   background: #3a3a3a;
 }
 
-:root:not([data-theme]) .meter-fill.green,
-:root[data-theme='default-dark'] .meter-fill.green,
-:root[data-theme='default'] .meter-fill.green {
+:root:not([data-theme]) .meter-fill.tone-success,
+:root[data-theme='default-dark'] .meter-fill.tone-success,
+:root[data-theme='default'] .meter-fill.tone-success {
   background: #39d98a;
 }
 
-:root:not([data-theme]) .meter-fill.orange,
-:root[data-theme='default-dark'] .meter-fill.orange,
-:root[data-theme='default'] .meter-fill.orange,
+:root:not([data-theme]) .meter-fill.tone-warning,
+:root[data-theme='default-dark'] .meter-fill.tone-warning,
+:root[data-theme='default'] .meter-fill.tone-warning,
 :root:not([data-theme]) .meter-fill.yellow,
 :root[data-theme='default-dark'] .meter-fill.yellow,
 :root[data-theme='default'] .meter-fill.yellow {
   background: var(--memory-warn);
+}
+
+:root:not([data-theme]) .meter-fill.tone-danger,
+:root[data-theme='default-dark'] .meter-fill.tone-danger,
+:root[data-theme='default'] .meter-fill.tone-danger {
+  background: var(--metric-status-red);
 }
 
 :root:not([data-theme]) .mini-tabs span,

--- a/apps/desktop/src/renderer/styles/themes/default-light.css
+++ b/apps/desktop/src/renderer/styles/themes/default-light.css
@@ -315,15 +315,15 @@
   background: var(--metric-kernel);
 }
 
-:root[data-theme='default-light'] .metric-dot.status-green {
+:root[data-theme='default-light'] .metric-dot.tone-success {
   background: var(--metric-status-green);
 }
 
-:root[data-theme='default-light'] .metric-dot.status-yellow {
+:root[data-theme='default-light'] .metric-dot.tone-warning {
   background: var(--metric-status-yellow);
 }
 
-:root[data-theme='default-light'] .metric-dot.status-red {
+:root[data-theme='default-light'] .metric-dot.tone-danger {
   background: var(--metric-status-red);
 }
 
@@ -339,13 +339,17 @@
   background: var(--metric-kernel);
 }
 
-:root[data-theme='default-light'] .meter-fill.green {
+:root[data-theme='default-light'] .meter-fill.tone-success {
   background: var(--success);
 }
 
 :root[data-theme='default-light'] .meter-fill.yellow,
-:root[data-theme='default-light'] .meter-fill.orange {
+:root[data-theme='default-light'] .meter-fill.tone-warning {
   background: var(--warning);
+}
+
+:root[data-theme='default-light'] .meter-fill.tone-danger {
+  background: var(--metric-status-red);
 }
 
 :root[data-theme='default-light'] .network-select {


### PR DESCRIPTION
## 说明

- 这是对已回滚的 #52 的重新提交
- 之前的 #52 已经从 `main` 撤回，当前 PR 用于恢复同一批改动，并保留由你手动执行 merge 的流程

## 变更内容

- 修复系统信息侧栏在 CPU / Swap 高占用时进度条颜色丢失的问题
- 统一系统信息区域的状态色命名，改为 `tone-success / tone-warning / tone-danger`
- 保留内存分段条的 `app / cache / kernel` 结构色，并补充注释说明两套颜色协议的边界
- 将远程文件内置文本编辑器的建议大小上限从 4 MB 提高到 16 MB

## 变更原因

- CPU / Swap 进入高占用区间后会切到红色状态，但进度条 fill 缺少对应样式，导致看起来像“进度条没了”
- 系统信息的状态色命名之前存在旧协议和新协议混用，排查样式问题成本较高
- 4 MB 的内置编辑器建议上限偏小，很多纯文本日志或配置文件会被过早拦下

## 验证

- `npm run build -w @termdock/desktop`

## 关联

- 已回滚 PR：#52
