### PR TITLE
[codex] 版本号升级到 0.3.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termdock",
-  "version": "0.2.0-beta.1",
+  "version": "0.3.0-beta.1",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",


### PR DESCRIPTION
## 变更内容

- 将根目录版本号从 `0.2.0-beta.1` 升级到 `0.3.0-beta.1`
- 按仓库发布规范执行 `npm run sync:version`

## 目的

- 为 `release/0.3.0-beta.1` 分支和 `v0.3.0-beta.1` 标签发布做准备

## 验证

- `npm run sync:version`
