### PR TITLE
[codex] 同步 0.3.0-beta.1 workspace 版本

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/desktop",
-  "version": "0.2.0-beta.1",
+  "version": "0.3.0-beta.1",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",
@@ -29,9 +29,9 @@
   "dependencies": {
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
-    "@termdock/core": "0.2.0-beta.1",
-    "@termdock/shared": "0.2.0-beta.1",
-    "@termdock/storage": "0.2.0-beta.1",
+    "@termdock/core": "0.3.0-beta.1",
+    "@termdock/shared": "0.3.0-beta.1",
+    "@termdock/storage": "0.3.0-beta.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "termdock",
-  "version": "0.2.0-beta.1",
+  "version": "0.3.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "termdock",
-      "version": "0.2.0-beta.1",
+      "version": "0.3.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -22,13 +22,13 @@
     },
     "apps/desktop": {
       "name": "@termdock/desktop",
-      "version": "0.2.0-beta.1",
+      "version": "0.3.0-beta.1",
       "dependencies": {
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
-        "@termdock/core": "0.2.0-beta.1",
-        "@termdock/shared": "0.2.0-beta.1",
-        "@termdock/storage": "0.2.0-beta.1",
+        "@termdock/core": "0.3.0-beta.1",
+        "@termdock/shared": "0.3.0-beta.1",
+        "@termdock/storage": "0.3.0-beta.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-unicode11": "^0.9.0",
@@ -5298,17 +5298,17 @@
     },
     "packages/core": {
       "name": "@termdock/core",
-      "version": "0.2.0-beta.1"
+      "version": "0.3.0-beta.1"
     },
     "packages/shared": {
       "name": "@termdock/shared",
-      "version": "0.2.0-beta.1"
+      "version": "0.3.0-beta.1"
     },
     "packages/storage": {
       "name": "@termdock/storage",
-      "version": "0.2.0-beta.1",
+      "version": "0.3.0-beta.1",
       "dependencies": {
-        "@termdock/core": "0.2.0-beta.1"
+        "@termdock/core": "0.3.0-beta.1"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/core",
-  "version": "0.2.0-beta.1",
+  "version": "0.3.0-beta.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/shared",
-  "version": "0.2.0-beta.1",
+  "version": "0.3.0-beta.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/storage",
-  "version": "0.2.0-beta.1",
+  "version": "0.3.0-beta.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@termdock/core": "0.2.0-beta.1"
+    "@termdock/core": "0.3.0-beta.1"
   }
 }


### PR DESCRIPTION
## 变更内容

- 同步 `0.3.0-beta.1` 对应的 workspace 版本号
- 更新内部包依赖引用版本
- 更新 `package-lock.json`

## 原因

- 根版本号升级后，需要按仓库 SOP 将 workspace 与 lockfile 一并同步，避免后续 release / CI 因内部包版本不一致失败

## 验证

- `npm run sync:version`
