### PR TITLE
[codex] 修复 SSH 首次连接后终端提示符被吞掉的问题

### DIFF
--- a/apps/desktop/src/main/services/sessions/shell-cwd-integration.ts
+++ b/apps/desktop/src/main/services/sessions/shell-cwd-integration.ts
@@ -88,18 +88,10 @@ export function findSetupEchoEnd(text: string): { lineStart: number; payloadEnd:
   const cwd = parseOsc7Payload(match7[1] ?? '')
   const user = matchUser ? matchUser[1] : null
 
-  // Try to find the prompt printed after the command to suppress it as well
-  const afterPayload = searchSlice.slice(payloadEnd - needleIndex)
-  const promptMatch = /^\s*([^\r\n]*[#$%>]\s*)/.exec(afterPayload)
-  
-  if (!promptMatch && text.length < 1024) {
-    // Wait for the prompt to arrive in the buffer
-    return null
-  }
-
-  const finalPayloadEnd = payloadEnd + (promptMatch ? promptMatch[0].length : 0)
-
-  return { lineStart, payloadEnd: finalPayloadEnd, cwd, user }
+  // Keep the real shell prompt visible. We only suppress the injected setup
+  // command echo and its OSC payload, so the prompt printed after execution can
+  // render naturally on first connect and later silent refreshes.
+  return { lineStart, payloadEnd, cwd, user }
 }
 
 function parseOsc7Payload(payload: string): string | null {


### PR DESCRIPTION
## 变更内容

- 修复 SSH 首次连接后首个 shell prompt 被吞掉的问题
- 保留 cwd 注入命令和 OSC payload 的静默处理，但不再额外抑制注入后的真实终端提示符

## 问题现象

- SSH 连接成功后，欢迎信息和 `Could not chdir ...` 等文本会正常显示
- 但首个 `user@host:~$` / `#` 提示符不会立刻出现
- 需要用户额外按一次回车，shell 才会重新打印 prompt

## 根因

- cwd 注入回显清理逻辑会在识别 setup 命令和 OSC payload 后，继续尝试吞掉紧随其后的 prompt
- 这会把首次连接后的真实 shell prompt 一起误删

## 修复思路

- 只抑制 setup 命令本身和 OSC 7 / RemoteUser payload
- 保留 trailing prompt，让 shell 自然显示首次连接后的提示符

## 验证

- `npm run build -w @termdock/desktop`
- `npm run typecheck -w @termdock/desktop`
