### PR TITLE
[codex] 版本号升级到 0.3.0-beta.2

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/desktop",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",
@@ -29,9 +29,9 @@
   "dependencies": {
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
-    "@termdock/core": "0.3.0-beta.1",
-    "@termdock/shared": "0.3.0-beta.1",
-    "@termdock/storage": "0.3.0-beta.1",
+    "@termdock/core": "0.3.0-beta.2",
+    "@termdock/shared": "0.3.0-beta.2",
+    "@termdock/storage": "0.3.0-beta.2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "termdock",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "termdock",
-      "version": "0.3.0-beta.1",
+      "version": "0.3.0-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -22,13 +22,13 @@
     },
     "apps/desktop": {
       "name": "@termdock/desktop",
-      "version": "0.3.0-beta.1",
+      "version": "0.3.0-beta.2",
       "dependencies": {
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
-        "@termdock/core": "0.3.0-beta.1",
-        "@termdock/shared": "0.3.0-beta.1",
-        "@termdock/storage": "0.3.0-beta.1",
+        "@termdock/core": "0.3.0-beta.2",
+        "@termdock/shared": "0.3.0-beta.2",
+        "@termdock/storage": "0.3.0-beta.2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-unicode11": "^0.9.0",
@@ -5298,17 +5298,17 @@
     },
     "packages/core": {
       "name": "@termdock/core",
-      "version": "0.3.0-beta.1"
+      "version": "0.3.0-beta.2"
     },
     "packages/shared": {
       "name": "@termdock/shared",
-      "version": "0.3.0-beta.1"
+      "version": "0.3.0-beta.2"
     },
     "packages/storage": {
       "name": "@termdock/storage",
-      "version": "0.3.0-beta.1",
+      "version": "0.3.0-beta.2",
       "dependencies": {
-        "@termdock/core": "0.3.0-beta.1"
+        "@termdock/core": "0.3.0-beta.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termdock",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/core",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/shared",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termdock/storage",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@termdock/core": "0.3.0-beta.1"
+    "@termdock/core": "0.3.0-beta.2"
   }
 }


### PR DESCRIPTION
## 变更内容

- 将根目录版本号从 `0.3.0-beta.1` 升级到 `0.3.0-beta.2`
- 同步 workspace package 版本号
- 同步内部包依赖引用版本
- 更新 `package-lock.json`

## 目的

- 为 `release/0.3.0-beta.2` 分支和 `v0.3.0-beta.2` 标签发布做准备

## 验证

- `npm run sync:version`
