### PR TITLE
fix: 修复终端快捷键重复触发

### DIFF
--- a/apps/desktop/src/renderer/components/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/TerminalView.tsx
@@ -563,13 +563,30 @@ export function TerminalView({
         ? event.metaKey && !event.shiftKey && event.key.toLowerCase() === 'f'
         : event.ctrlKey && !event.shiftKey && event.key.toLowerCase() === 'f'
 
+      if (matchesCopy) {
+        runCopy()
+        return false
+      }
+
+      if (matchesPaste) {
+        void runPaste()
+        return false
+      }
+
+      if (matchesFind) {
+        if (findOpenRef.current) {
+          closeFind()
+        } else {
+          openFind()
+        }
+        return false
+      }
+
       if (
         event.key === 'Control' ||
         event.key === 'Meta' ||
         event.key === 'Alt' ||
-        matchesCopy ||
-        matchesPaste ||
-        matchesFind
+        (event.key === 'Dead' && (event.metaKey || event.ctrlKey || event.altKey))
       ) {
         return false
       }
@@ -778,38 +795,6 @@ export function TerminalView({
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (document.activeElement !== terminal.textarea) {
-        return
-      }
-
-      const matchesCopy = isMac
-        ? event.metaKey && !event.shiftKey && event.key.toLowerCase() === 'c'
-        : event.ctrlKey && event.shiftKey && event.key.toLowerCase() === 'c'
-      const matchesPaste = isMac
-        ? event.metaKey && !event.shiftKey && event.key.toLowerCase() === 'v'
-        : event.ctrlKey && event.shiftKey && event.key.toLowerCase() === 'v'
-      const matchesFind = isMac
-        ? event.metaKey && !event.shiftKey && event.key.toLowerCase() === 'f'
-        : event.ctrlKey && !event.shiftKey && event.key.toLowerCase() === 'f'
-
-      if (matchesCopy) {
-        event.preventDefault()
-        runCopy()
-        return
-      }
-
-      if (matchesPaste) {
-        event.preventDefault()
-        void runPaste()
-        return
-      }
-
-      if (matchesFind) {
-        event.preventDefault()
-        if (findOpenRef.current) {
-          closeFind()
-        } else {
-          openFind()
-        }
         return
       }
 

--- a/apps/desktop/src/renderer/components/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/TerminalView.tsx
@@ -564,16 +564,22 @@ export function TerminalView({
         : event.ctrlKey && !event.shiftKey && event.key.toLowerCase() === 'f'
 
       if (matchesCopy) {
+        event.preventDefault()
+        event.stopPropagation()
         runCopy()
         return false
       }
 
       if (matchesPaste) {
+        event.preventDefault()
+        event.stopPropagation()
         void runPaste()
         return false
       }
 
       if (matchesFind) {
+        event.preventDefault()
+        event.stopPropagation()
         if (findOpenRef.current) {
           closeFind()
         } else {


### PR DESCRIPTION
## 变更说明
- 将终端复制、粘贴、查找快捷键统一收敛到 xterm 的自定义按键处理链路
- 移除外层 window keydown 中重复的复制、粘贴、查找处理，避免同一次快捷键触发两次
- 保留终端内 Cmd+C 可复制选区，同时避免重复发送或重复执行

## 验证
- npm run typecheck -w @termdock/desktop