### PR TITLE
[codex] 修复文件区域加载遮罩覆盖不完整

### DIFF
--- a/apps/desktop/src/renderer/features/files/FileManager.tsx
+++ b/apps/desktop/src/renderer/features/files/FileManager.tsx
@@ -767,76 +767,33 @@ export function FileManager({
             onSubmit={submitRemotePath}
           />
           <div
-            ref={remoteScrollRef}
             aria-busy={showRemoteDirectoryLoading}
-            className={`file-table-shell remote-file-table-shell ${showRemoteDirectoryLoading ? 'is-loading' : ''}`}
-            onContextMenu={(event) => {
-              if (!isRemoteConnected) return
-              if (event.target !== event.currentTarget) return
-              event.preventDefault()
-              event.stopPropagation()
-              setSelectedRemotePaths([])
-              setRemoteAnchorPath(null)
-              setContextMenu({ pane: 'remote', x: event.clientX, y: event.clientY, path: null })
-            }}
-            onMouseDown={(event) => {
-              if (!isRemoteConnected) return
-              if (event.target !== event.currentTarget || event.button !== 0) return
-              isSelectingRemote.current = true
-              didDragSelect.current = false
-              remoteDragSelection.current = {
-                basePaths: event.metaKey || event.ctrlKey ? selectedRemotePaths : [],
-                startPath: null
-              }
-            }}
-            onClick={(event) => {
-              if (event.target !== event.currentTarget) return
-              if (suppressNextClearClick.current) {
-                suppressNextClearClick.current = false
-                return
-              }
-              setSelectedRemotePaths([])
-              setRemoteAnchorPath(null)
-            }}
+            className="remote-file-table-region"
           >
-            <FileTable
-              scrollRef={remoteScrollRef}
-              cutPaths={remoteCutPaths}
-              emptyText={isRemoteConnected ? t.emptyFiles : t.remoteDisconnectedDescription}
-              rows={sortedRemoteRows}
-              sortState={remoteSort}
-              selectedPaths={selectedRemotePaths}
-              onToggleSort={(field) => {
-                setRemoteSort((current) => (
-                  current.field === field
-                    ? { field, direction: current.direction === 'asc' ? 'desc' : 'asc' }
-                    : { field, direction: 'asc' }
-                ))
-              }}
-              onDragItem={(event, item) => {
+            <div
+              ref={remoteScrollRef}
+              className="file-table-shell remote-file-table-shell"
+              onContextMenu={(event) => {
                 if (!isRemoteConnected) return
-                event.dataTransfer.effectAllowed = 'copy'
-                const payload = selectedRemotePaths.includes(item.path) ? selectedRemotePaths : [item.path]
-                const previewItems = sortedRemoteRows.filter((row) => payload.includes(row.path))
-                event.dataTransfer.setData(remoteFileDragType, JSON.stringify(payload))
-                setFileDragPreview(event, previewItems.map((row) => row.name))
-              }}
-              onOpenItem={(item) => {
-                if (isRemoteConnected) {
-                  onOpenRemoteItem(item)
-                }
-              }}
-              onContextItem={(event, item) => {
-                if (!isRemoteConnected) return
+                if (event.target !== event.currentTarget) return
                 event.preventDefault()
                 event.stopPropagation()
-                if (!selectedRemotePaths.includes(item.path)) {
-                  setSelectedRemotePaths([item.path])
-                  setRemoteAnchorPath(item.path)
-                }
-                setContextMenu({ pane: 'remote', x: event.clientX, y: event.clientY, path: item.path })
+                setSelectedRemotePaths([])
+                setRemoteAnchorPath(null)
+                setContextMenu({ pane: 'remote', x: event.clientX, y: event.clientY, path: null })
               }}
-              onClearSelection={() => {
+              onMouseDown={(event) => {
+                if (!isRemoteConnected) return
+                if (event.target !== event.currentTarget || event.button !== 0) return
+                isSelectingRemote.current = true
+                didDragSelect.current = false
+                remoteDragSelection.current = {
+                  basePaths: event.metaKey || event.ctrlKey ? selectedRemotePaths : [],
+                  startPath: null
+                }
+              }}
+              onClick={(event) => {
+                if (event.target !== event.currentTarget) return
                 if (suppressNextClearClick.current) {
                   suppressNextClearClick.current = false
                   return
@@ -844,35 +801,82 @@ export function FileManager({
                 setSelectedRemotePaths([])
                 setRemoteAnchorPath(null)
               }}
-              onSelectItem={(event, item) => {
-                if (isRemoteConnected) {
-                  selectRemoteItem(event, item)
-                }
-              }}
-              onSelectionDragStart={(event, item) => {
-                if (!isRemoteConnected) return
-                setKeyboardPane('remote')
-                isSelectingRemote.current = true
-                didDragSelect.current = false
-                const startPath = event.shiftKey && remoteAnchorPath ? remoteAnchorPath : item.path
-                const basePaths = event.metaKey || event.ctrlKey ? selectedRemotePaths : []
-                remoteDragSelection.current = { basePaths, startPath }
-                suppressNextSelectionClick.current = true
-                setSelectedRemotePaths(nextSelection({
-                  anchorPath: remoteAnchorPath,
-                  currentSelection: selectedRemotePaths,
-                  event,
-                  itemPath: item.path,
-                  rows: sortedRemoteRows
-                }))
-                setRemoteAnchorPath(startPath)
-              }}
-              onSelectionDragEnter={(item) => {
-                if (isRemoteConnected) {
-                  extendRemoteDragSelection(item)
-                }
-              }}
-            />
+            >
+              <FileTable
+                scrollRef={remoteScrollRef}
+                cutPaths={remoteCutPaths}
+                emptyText={isRemoteConnected ? t.emptyFiles : t.remoteDisconnectedDescription}
+                rows={sortedRemoteRows}
+                sortState={remoteSort}
+                selectedPaths={selectedRemotePaths}
+                onToggleSort={(field) => {
+                  setRemoteSort((current) => (
+                    current.field === field
+                      ? { field, direction: current.direction === 'asc' ? 'desc' : 'asc' }
+                      : { field, direction: 'asc' }
+                  ))
+                }}
+                onDragItem={(event, item) => {
+                  if (!isRemoteConnected) return
+                  event.dataTransfer.effectAllowed = 'copy'
+                  const payload = selectedRemotePaths.includes(item.path) ? selectedRemotePaths : [item.path]
+                  const previewItems = sortedRemoteRows.filter((row) => payload.includes(row.path))
+                  event.dataTransfer.setData(remoteFileDragType, JSON.stringify(payload))
+                  setFileDragPreview(event, previewItems.map((row) => row.name))
+                }}
+                onOpenItem={(item) => {
+                  if (isRemoteConnected) {
+                    onOpenRemoteItem(item)
+                  }
+                }}
+                onContextItem={(event, item) => {
+                  if (!isRemoteConnected) return
+                  event.preventDefault()
+                  event.stopPropagation()
+                  if (!selectedRemotePaths.includes(item.path)) {
+                    setSelectedRemotePaths([item.path])
+                    setRemoteAnchorPath(item.path)
+                  }
+                  setContextMenu({ pane: 'remote', x: event.clientX, y: event.clientY, path: item.path })
+                }}
+                onClearSelection={() => {
+                  if (suppressNextClearClick.current) {
+                    suppressNextClearClick.current = false
+                    return
+                  }
+                  setSelectedRemotePaths([])
+                  setRemoteAnchorPath(null)
+                }}
+                onSelectItem={(event, item) => {
+                  if (isRemoteConnected) {
+                    selectRemoteItem(event, item)
+                  }
+                }}
+                onSelectionDragStart={(event, item) => {
+                  if (!isRemoteConnected) return
+                  setKeyboardPane('remote')
+                  isSelectingRemote.current = true
+                  didDragSelect.current = false
+                  const startPath = event.shiftKey && remoteAnchorPath ? remoteAnchorPath : item.path
+                  const basePaths = event.metaKey || event.ctrlKey ? selectedRemotePaths : []
+                  remoteDragSelection.current = { basePaths, startPath }
+                  suppressNextSelectionClick.current = true
+                  setSelectedRemotePaths(nextSelection({
+                    anchorPath: remoteAnchorPath,
+                    currentSelection: selectedRemotePaths,
+                    event,
+                    itemPath: item.path,
+                    rows: sortedRemoteRows
+                  }))
+                  setRemoteAnchorPath(startPath)
+                }}
+                onSelectionDragEnter={(item) => {
+                  if (isRemoteConnected) {
+                    extendRemoteDragSelection(item)
+                  }
+                }}
+              />
+            </div>
             {showRemoteDirectoryLoading ? (
               <div
                 aria-label={t.loadingRemoteDirectory}

--- a/apps/desktop/src/renderer/styles/features/session.css
+++ b/apps/desktop/src/renderer/styles/features/session.css
@@ -821,7 +821,15 @@
   -webkit-user-select: none;
 }
 
+.remote-file-table-region {
+  min-height: 0;
+  position: relative;
+  flex: 1;
+  overflow: hidden;
+}
+
 .remote-file-table-shell {
+  height: 100%;
   position: relative;
 }
 


### PR DESCRIPTION
## 修改内容

- 将远程文件列表的遮罩定位区域与滚动容器拆分
- 保持文件列表独立滚动，loading 遮罩固定覆盖整个列表视口
- 保留 `aria-busy`、`role="status"` 等无障碍语义

## 问题原因

loading 遮罩原本是滚动容器中的绝对定位子元素。当远程文件列表存在滚动偏移时，遮罩会随内容一起向上移动，导致列表底部部分区域未被覆盖。

## 影响

远程目录加载期间，无论文件列表此前滚动到什么位置，loading 状态都会完整覆盖文件区域。

## 验证

- `npm run typecheck -w @termdock/desktop`
- `npm run build -w @termdock/desktop`
- `git diff --check`
