### PR TITLE
[codex] 优化终端命令栏滚动与排版

### DIFF
--- a/apps/desktop/src/renderer/features/terminal/TerminalDock.tsx
+++ b/apps/desktop/src/renderer/features/terminal/TerminalDock.tsx
@@ -574,6 +574,7 @@ export function TerminalDock({
             disabled={activeTab.sessionType !== 'ssh'}
             placeholder={placeholderText}
             rows={1}
+            wrap="off"
             value={command}
             onChange={(event) => setCommand(event.currentTarget.value)}
             onKeyDown={handleInputKeyDown}

--- a/apps/desktop/src/renderer/styles/features/session.css
+++ b/apps/desktop/src/renderer/styles/features/session.css
@@ -522,18 +522,18 @@
 .terminal-dock-input-shell textarea {
   width: 100%;
   min-width: 0;
-  min-height: 24px;
-  max-height: 96px;
+  height: 24px;
   padding: 4px;
   border: none;
   resize: none;
-  field-sizing: content;
+  overflow-x: auto;
   overflow-y: auto;
   background: transparent;
   color: var(--text-main);
   font-family: "SF Mono", Menlo, Consolas, monospace;
-  font-size: 12px;
-  line-height: 16px;
+  font-size: 11px;
+  line-height: 14px;
+  white-space: pre;
   transition: color 0.15s ease;
 }
 
@@ -544,6 +544,7 @@
 .terminal-dock-actions {
   display: flex;
   align-items: center;
+  align-self: end;
   gap: 6px;
 }
 


### PR DESCRIPTION
## 修改内容

- 将终端命令输入区固定为紧凑的单行高度
- 保留真实多行内容，并支持输入区内部上下滚动
- 禁止软换行，超长命令支持横向滚动
- 将历史、选项及工具图标固定对齐到底部
- 缩小命令文字字号和行高，使工具栏视觉密度更一致

## 原因

多行命令输入区自动增高后会遮挡较多终端内容，右侧操作区也会停留在垂直中间。固定高度并使用双向滚动可以保留多行命令能力，同时维持紧凑稳定的终端工作区布局。

## 影响

粘贴多行命令时，命令栏高度保持不变；用户可以上下查看各行、左右查看长命令，发送时原有换行仍被保留。

## 验证

- `npm run typecheck -w @termdock/desktop`
- `npm run build:renderer -w @termdock/desktop`
- `git diff --check`
- macOS 手动验证多行滚动和命令发送
