### PR TITLE
[codex] 桌面端 UI 细节修复与标题栏对齐优化

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1081,7 +1081,7 @@ export function App() {
   const showSidebar = activeTab !== null && activeSession !== null && !isHomeWorkspaceVisible
   const resolvedSidebarWidth = isSystemSidebarCollapsed ? 44 : sidebarWidth
   const brandWidth = isHomeTabActive
-    ? resolvedSidebarWidth
+    ? isSystemSidebarCollapsed ? 214 : resolvedSidebarWidth
     : showSidebar && !isSystemSidebarCollapsed
       ? sidebarWidth
       : 214
@@ -3145,7 +3145,7 @@ export function App() {
   return (
     <>
       <div
-        className={`fs-shell ${isWindowsDesktop ? 'has-window-menubar' : ''} ${isHomeWorkspaceVisible ? 'is-home-active' : ''} ${isSystemSidebarCollapsed ? 'is-sidebar-collapsed' : ''}`}
+        className={`fs-shell ${isWindowsDesktop ? 'has-window-menubar' : ''} ${isHomeWorkspaceVisible ? 'is-home-active' : ''} ${isSystemSidebarCollapsed ? 'is-sidebar-collapsed' : ''} ${isResizingSidebar ? 'is-resizing-sidebar' : ''}`}
         style={{
           '--sidebar-width': `${resolvedSidebarWidth}px`,
           '--brand-width': `${brandWidth}px`

--- a/apps/desktop/src/renderer/features/files/FileEditorModal.tsx
+++ b/apps/desktop/src/renderer/features/files/FileEditorModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react'
 import Editor, { loader, type Monaco, type OnMount } from '@monaco-editor/react'
 import OpenCC from 'opencc-js'
 import * as monacoEditor from 'monaco-editor'
@@ -125,8 +125,6 @@ export function FileEditorModal({
   const characterCount = content.length
   const currentEncoding = findEncodingOption(encoding)
   const currentLanguage = languages.find((option) => option.id === language)?.label ?? language
-  const fileTree = useMemo(() => buildFileTree(file.path, file.name), [file.path, file.name])
-
   const handleMount: OnMount = (editor, monaco) => {
     editorRef.current = editor
     monacoRef.current = monaco
@@ -246,7 +244,13 @@ export function FileEditorModal({
           {isDirty ? <b>{t.fileEditorUnsaved}</b> : null}
         </div>
         <div className="file-editor-header-actions">
-          <button className={`file-editor-save-button ${isDirty ? 'is-dirty' : ''}`} disabled={!isDirty || isBusy || isSaving} onClick={() => onSave(content, encoding)} type="button">
+          <button
+            aria-busy={isSaving}
+            className={`file-editor-save-button ${isDirty ? 'is-dirty' : ''} ${isSaving ? 'is-saving' : ''}`}
+            disabled={!isDirty || isBusy || isSaving}
+            onClick={() => onSave(content, encoding)}
+            type="button"
+          >
             {isSaving ? <span aria-hidden="true" className="button-spinner" /> : null}
             <span>{isSaving ? t.saving : t.save}</span>
           </button>
@@ -257,37 +261,6 @@ export function FileEditorModal({
       </div>
 
       <div className="file-editor-workspace">
-        <aside className="file-editor-explorer">
-          <div className="file-editor-explorer-head">
-            <span>{t.file}</span>
-            <strong>{file.source === 'remote' ? t.remoteHost : t.localComputer}</strong>
-          </div>
-          <div className="file-editor-tree scrollbar-scroll" aria-label={t.file}>
-            {fileTree.directories.map((node) => (
-              <div
-                className="file-editor-tree-row is-directory"
-                key={`${node.depth}-${node.label}`}
-                style={{ '--tree-depth': node.depth } as CSSProperties}
-                title={node.path}
-              >
-                <AppIcon name="folder" size={14} />
-                <span>{node.label}</span>
-              </div>
-            ))}
-            <button
-              className="file-editor-tree-row is-file is-active"
-              style={{ '--tree-depth': fileTree.file.depth } as CSSProperties}
-              title={file.path}
-              type="button"
-              onClick={() => editorRef.current?.focus()}
-            >
-              <AppIcon name={language === 'json' || file.name.endsWith('.json') ? 'code' : 'file'} size={14} />
-              <span>{fileTree.file.label}</span>
-              {isDirty ? <i aria-label={t.fileEditorUnsaved} /> : null}
-            </button>
-          </div>
-        </aside>
-
         <section className="file-editor-main">
           <div className="file-editor-toolbar">
             <div className="file-editor-menubar">
@@ -410,31 +383,6 @@ export function FileEditorModal({
   }
 
   return <div className="modal-backdrop">{contentNode}</div>
-}
-
-function buildFileTree(path: string, fallbackName: string) {
-  const normalizedPath = path.replace(/\\/g, '/')
-  const isAbsolute = normalizedPath.startsWith('/')
-  const parts = normalizedPath.split('/').filter(Boolean)
-  const fileLabel = parts.at(-1) ?? fallbackName
-  const directoryParts = parts.slice(0, -1)
-  const directories = [
-    ...(isAbsolute ? [{ label: '/', path: '/', depth: 0 }] : []),
-    ...directoryParts.map((label, index) => ({
-      label,
-      path: `${isAbsolute ? '/' : ''}${directoryParts.slice(0, index + 1).join('/')}`,
-      depth: index + (isAbsolute ? 1 : 0)
-    }))
-  ]
-
-  return {
-    directories,
-    file: {
-      label: fileLabel,
-      path: normalizedPath,
-      depth: directories.length
-    }
-  }
 }
 
 function EditorMenuButton({

--- a/apps/desktop/src/renderer/features/files/FileTables.tsx
+++ b/apps/desktop/src/renderer/features/files/FileTables.tsx
@@ -273,7 +273,6 @@ export function LocalFileTable({
               <FileNameCell
                 iconName={iconName}
                 item={row}
-                showMeta={row.name !== '..'}
                 draggable={row.name !== '..'}
                 onDragStart={(event) => onDragItem(event, row)}
               />
@@ -291,19 +290,15 @@ function FileNameCell({
   draggable,
   iconName,
   item,
-  showMeta = false,
   onDragStart
 }: {
   draggable: boolean
   iconName: ReturnType<typeof getDisplayFileIconName>
   item: LocalFileItem | RemoteFileItem
-  showMeta?: boolean
   onDragStart(event: DragEvent<HTMLElement>): void
 }) {
-  const meta = item.type === 'file' ? item.size : getDisplayFileTypeLabel(item)
-
   return (
-    <span className={`file-name-cell ${showMeta ? 'has-meta' : ''}`} title={`${item.name}${showMeta ? ` · ${meta}` : ''}`}>
+    <span className="file-name-cell" title={item.name}>
       <span
         className={`file-icon ${draggable ? 'is-draggable' : ''}`}
         draggable={draggable}
@@ -315,7 +310,6 @@ function FileNameCell({
       </span>
       <span className="file-row-text">
         <span className="file-row-main">{item.name}</span>
-        {showMeta ? <span className="file-row-meta">{meta}</span> : null}
       </span>
     </span>
   )

--- a/apps/desktop/src/renderer/features/layout/TabBar.tsx
+++ b/apps/desktop/src/renderer/features/layout/TabBar.tsx
@@ -49,6 +49,11 @@ export function TabBar({
   return (
       <header className="fs-tabbar">
         <div className="titlebar-brand">
+          <div className="window-controls-decorator" aria-hidden="true">
+            <span className="dot dot-close" />
+            <span className="dot dot-minimize" />
+            <span className="dot dot-maximize" />
+          </div>
           <strong>{t.appTitle}</strong>
         </div>
         <div className="titlebar-tabarea">

--- a/apps/desktop/src/renderer/features/workspace/HomeWorkspace.tsx
+++ b/apps/desktop/src/renderer/features/workspace/HomeWorkspace.tsx
@@ -103,23 +103,18 @@ export function HomeWorkspace({
 
   return (
     <section className={`home-workspace ${isSidebarCollapsed ? 'is-sidebar-collapsed' : ''}`}>
+      <div className="home-tabs-bar">
+        <TabBar {...tabBarProps} />
+      </div>
+
       {/* SideNavBar Component */}
       <aside className={`home-sidebar ${isSidebarCollapsed ? 'is-collapsed' : ''}`}>
-        <div className="sidebar-drag-handle" />
-        {/* macOS style Window Controls */}
-        <div className="window-controls-decorator">
-          <div className="dot dot-close"></div>
-          <div className="dot dot-minimize"></div>
-          <div className="dot dot-maximize"></div>
-        </div>
-
-        {/* Brand Header */}
-        {!isWindows && (
+        {!isWindows ? (
           <div className="sidebar-brand">
             <h2 className="brand-title">TermDock</h2>
             <span className="brand-version">v{desktopApi?.appVersion ?? '—'}</span>
           </div>
-        )}
+        ) : null}
 
         {/* Navigation Section */}
         <nav className="sidebar-nav">
@@ -196,9 +191,6 @@ export function HomeWorkspace({
 
       {/* Main Content Area */}
       <main className="home-main-content">
-        <div className="home-tabs-bar">
-          <TabBar {...tabBarProps} />
-        </div>
         <div className="home-content-body scrollbar-scroll">
           {activeTab === 'overview' && (
             <div key="overview" className="page-transition" data-nav-direction={navDirection}>

--- a/apps/desktop/src/renderer/styles/features/file-editor.css
+++ b/apps/desktop/src/renderer/styles/features/file-editor.css
@@ -98,6 +98,16 @@
   cursor: not-allowed;
 }
 
+.file-editor-modal .modal-header .file-editor-save-button.is-saving,
+.file-editor-modal .modal-header .file-editor-save-button.is-saving:hover:disabled {
+  border-color: transparent;
+  background: var(--button-primary-bg);
+  color: var(--button-primary-text);
+  cursor: progress;
+  opacity: 1;
+  transform: none;
+}
+
 .file-editor-modal .modal-header .file-editor-save-button:hover:disabled {
   background: var(--file-editor-button-bg);
   border-color: var(--border-light);
@@ -106,6 +116,12 @@
 
 .file-editor-save-button span {
   white-space: nowrap;
+}
+
+.file-editor-save-button .button-spinner {
+  display: inline-block;
+  flex: 0 0 auto;
+  box-sizing: border-box;
 }
 
 .file-editor-modal .modal-header .file-editor-close-button.icon-button {
@@ -139,7 +155,6 @@
 .file-editor-window textarea,
 .file-editor-window .file-editor-menubar,
 .file-editor-window .file-editor-workspace,
-.file-editor-window .file-editor-explorer,
 .file-editor-window .file-editor-toolbar,
 .file-editor-window .file-editor-body,
 .file-editor-window .file-editor-statusbar,
@@ -201,8 +216,7 @@
   flex-wrap: wrap;
   gap: 6px;
   padding: 0;
-  border-top: 1px solid transparent;
-  border-bottom: 1px solid transparent;
+  border: 0;
 }
 
 .file-editor-menu-anchor,
@@ -287,108 +301,10 @@
 }
 
 .file-editor-workspace {
-  display: grid;
-  grid-template-columns: 238px minmax(0, 1fr);
+  display: flex;
   flex: 1 1 auto;
   min-height: 0;
-  border-top: 1px solid var(--border-light);
-}
-
-.file-editor-explorer {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  min-height: 0;
-  border-right: 1px solid var(--border-light);
-  background: var(--surface-inset);
-}
-
-.file-editor-explorer-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  height: 42px;
-  padding: 0 12px;
-  border-bottom: 1px solid var(--border-light);
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.file-editor-explorer-head span,
-.file-editor-explorer-head strong {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.file-editor-explorer-head strong {
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: none;
-  letter-spacing: 0;
-}
-
-.file-editor-tree {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow: auto;
-  padding: 8px 6px;
-}
-
-.file-editor-tree-row {
-  --tree-depth: 0;
-  display: grid;
-  grid-template-columns: 16px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 7px;
-  width: 100%;
-  min-height: 30px;
-  padding: 0 8px 0 calc(8px + var(--tree-depth) * 13px);
-  border: 0;
-  border-radius: 5px;
-  background: transparent;
-  color: var(--text-muted);
-  font: inherit;
-  font-size: 12px;
-  font-weight: 500;
-  text-align: left;
-  box-sizing: border-box;
-}
-
-.file-editor-tree-row svg {
-  color: var(--text-soft);
-}
-
-.file-editor-tree-row span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.file-editor-tree-row.is-file {
-  cursor: pointer;
-}
-
-.file-editor-tree-row.is-file:hover,
-.file-editor-tree-row.is-active {
-  background: var(--surface-hover);
-  color: var(--text-main);
-}
-
-.file-editor-tree-row.is-active svg {
-  color: var(--accent-primary);
-}
-
-.file-editor-tree-row i {
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  background: var(--accent-primary);
+  border-top: 0;
 }
 
 .file-editor-main {
@@ -396,6 +312,7 @@
   flex-direction: column;
   min-width: 0;
   min-height: 0;
+  width: 100%;
 }
 
 .file-editor-toolbar {
@@ -405,7 +322,7 @@
   gap: 12px;
   min-height: 42px;
   padding: 6px 12px;
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 0;
 }
 
 .file-editor-body {
@@ -473,10 +390,6 @@
   .file-editor-window .file-editor-modal.standalone .modal-header {
     padding: 0 14px;
     box-sizing: border-box;
-  }
-
-  .file-editor-workspace {
-    grid-template-columns: 204px minmax(0, 1fr);
   }
 
   .file-editor-toolbar,
@@ -553,10 +466,6 @@
   .file-editor-menubar-button,
   .file-editor-status-button {
     flex: 0 0 auto;
-  }
-
-  .file-editor-workspace {
-    grid-template-columns: 156px minmax(0, 1fr);
   }
 
   .file-editor-toolbar {

--- a/apps/desktop/src/renderer/styles/features/home.css
+++ b/apps/desktop/src/renderer/styles/features/home.css
@@ -5,7 +5,9 @@
 }
 
 .home-workspace {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--sidebar-width, 214px) minmax(0, 1fr);
+  grid-template-rows: 48px minmax(0, 1fr);
   width: 100%;
   height: 100%;
   background-color: var(--bg-main) !important;
@@ -17,9 +19,11 @@
 
 /* Sidebar Styling */
 .home-sidebar {
+  grid-column: 1;
+  grid-row: 2;
   position: relative;
-  width: var(--sidebar-width, 214px);
-  height: 100%;
+  width: auto;
+  height: auto;
   background-color: var(--bg-sidebar);
   border-right: 1px solid var(--border-light);
   padding: 24px 16px 16px 16px;
@@ -30,15 +34,15 @@
   transition: width 0.24s linear, min-width 0.24s linear, padding 0.24s linear;
 }
 
-/* macOS Window Controls Decorator */
+/* Browser preview decoration; Electron uses native platform controls. */
 .window-controls-decorator {
   display: none;
   gap: 8px;
-  margin-bottom: 24px;
-  padding-left: 4px;
 }
 
-:root[data-platform='browser'] .window-controls-decorator {
+:root[data-platform='browser'] .titlebar-brand .window-controls-decorator {
+  position: absolute;
+  left: 16px;
   display: flex;
 }
 
@@ -60,31 +64,30 @@
   background-color: var(--traffic-maximize);
 }
 
-/* Brand Header */
 .sidebar-brand {
   margin-bottom: 32px;
   padding-left: 6px;
 }
 
 .brand-title {
+  margin: 0;
+  color: var(--text-main);
   font-size: 21px;
   font-weight: 400;
-  color: var(--text-main);
-  margin: 0;
   letter-spacing: -0.015em;
   text-shadow: var(--brand-title-shadow);
 }
 
 .brand-version {
-  font-size: 10px;
-  color: var(--text-muted);
-  background-color: var(--bg-hover);
-  padding: 2px 6px;
-  border-radius: 4px;
   display: inline-block;
   margin-top: 5px;
-  font-family: 'Geist Mono', 'JetBrains Mono', Monaco, monospace;
+  padding: 2px 6px;
   border: 1px solid var(--border-light);
+  border-radius: 4px;
+  background-color: var(--bg-hover);
+  color: var(--text-muted);
+  font-family: 'Geist Mono', 'JetBrains Mono', Monaco, monospace;
+  font-size: 10px;
   letter-spacing: 0.02em;
 }
 
@@ -162,9 +165,7 @@
   align-items: center;
 }
 
-.home-sidebar.is-collapsed .sidebar-brand,
-.home-sidebar.is-collapsed .brand-title,
-.home-sidebar.is-collapsed .brand-version {
+.home-sidebar.is-collapsed .sidebar-brand {
   display: none;
 }
 
@@ -215,9 +216,10 @@
 
 /* Right Main Content Panel */
 .home-main-content {
-  flex: 1;
+  grid-column: 2;
+  grid-row: 2;
   min-width: 0;
-  height: 100%;
+  height: auto;
   background-color: var(--bg-main);
   padding: 0;
   box-sizing: border-box;
@@ -746,67 +748,20 @@
   grid-template-rows: 32px 0px minmax(0, 1fr) 0px !important;
 }
 
-.fs-shell.has-window-menubar.is-home-active .home-sidebar {
-  padding-top: 8px !important;
-}
-
-/* Adjust macOS sidebar top padding to leave space for native traffic lights when titlebar is hidden */
-:root[data-platform='darwin'] .is-home-active .home-sidebar {
-  border-right: 0;
-  padding-top: 48px;
-  position: relative;
-}
-
-:root[data-platform='darwin'] .is-home-active .home-sidebar::after {
-  content: "";
-  position: absolute;
-  top: 48px;
-  right: 0;
-  bottom: 0;
-  width: 1px;
-  background: var(--border-light);
-  pointer-events: none;
-}
-
-:root[data-platform='darwin'] .is-home-active .home-sidebar::before {
-  content: "";
-  position: absolute;
-  top: 48px;
-  right: 0;
-  left: 0;
-  height: 1px;
-  background: var(--border-light);
-  pointer-events: none;
-}
-
-:root[data-platform='darwin'] .is-home-active .sidebar-drag-handle {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 48px;
-  -webkit-app-region: drag !important;
-  z-index: 5;
-}
-
-/* Inline TabBar in Home main content top */
+/* Home reuses the same titlebar structure as session workspaces. */
 .home-tabs-bar {
+  grid-column: 1 / -1;
+  grid-row: 1;
   margin: 0;
-  margin-bottom: 24px;
   padding: 0;
   width: 100%;
   flex-shrink: 0;
 }
 
-.home-tabs-bar .titlebar-brand {
-  display: none !important;
-}
-
 .home-tabs-bar .fs-tabbar {
   background: var(--bg-sidebar) !important;
-  border-bottom: 1px solid var(--border-light);
   height: 48px;
-  grid-template-columns: 1fr !important;
+  grid-template-columns: var(--brand-width, 214px) minmax(0, 1fr) !important;
   -webkit-app-region: drag !important;
   width: 100%;
 }
@@ -815,15 +770,6 @@
   grid-template-columns: minmax(0, 1fr) auto !important;
 }
 
-.home-tabs-bar .fs-tabs {
-  padding-left: calc(var(--brand-width, 214px) - var(--sidebar-width, 214px)) !important;
-  transition: padding-left 0.24s linear;
-}
-
-.home-workspace.is-sidebar-collapsed .home-tabs-bar .fs-tabs {
-  padding-left: 8px !important;
-}
-
-:root[data-platform='darwin'] .home-workspace.is-sidebar-collapsed .home-tabs-bar .fs-tabs {
-  padding-left: 26px !important;
+.home-tabs-bar .titlebar-brand strong {
+  display: none;
 }

--- a/apps/desktop/src/renderer/styles/features/overview.css
+++ b/apps/desktop/src/renderer/styles/features/overview.css
@@ -1,6 +1,6 @@
 /* Overview Page Styles */
 .overview-page {
-  padding: 15px 38px 24px;
+  padding: 32px 38px 24px;
   display: flex;
   flex-direction: column;
   gap: 30px;

--- a/apps/desktop/src/renderer/styles/features/session.css
+++ b/apps/desktop/src/renderer/styles/features/session.css
@@ -997,7 +997,7 @@
 }
 
 .fs-file-table.compact td {
-  height: 36px;
+  height: 24px;
 }
 
 .fs-file-table.compact th {
@@ -1043,29 +1043,17 @@
 }
 
 .file-row-text {
-  display: inline-flex;
-  flex-direction: column;
+  display: inline-block;
   min-width: 0;
   max-width: 100%;
   line-height: 1.15;
 }
 
-.file-row-main,
-.file-row-meta {
+.file-row-main {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.file-row-meta {
-  margin-top: 2px;
-  color: var(--file-row-meta, var(--text-muted));
-  font-size: 11px;
-}
-
-.file-name-cell:not(.has-meta) .file-row-text {
-  display: inline-block;
 }
 
 .file-icon.is-draggable {

--- a/apps/desktop/src/renderer/styles/features/shell.css
+++ b/apps/desktop/src/renderer/styles/features/shell.css
@@ -117,18 +117,6 @@
   border-right: 1px solid var(--border-light);
 }
 
-.fs-sidebar::before {
-  content: "";
-  position: absolute;
-  top: -1px;
-  right: 0;
-  left: 0;
-  z-index: 20;
-  height: 1px;
-  background: var(--border-light);
-  pointer-events: none;
-}
-
 .fs-sidebar.is-collapsed {
   grid-template-rows: 1fr;
 }

--- a/apps/desktop/src/renderer/styles/features/workstation-skin.css
+++ b/apps/desktop/src/renderer/styles/features/workstation-skin.css
@@ -33,6 +33,14 @@ textarea:focus-visible,
   transition: width 0.24s linear, min-width 0.24s linear;
 }
 
+.fs-shell.is-resizing-sidebar,
+.fs-shell.is-resizing-sidebar .fs-sidebar,
+.fs-shell.is-resizing-sidebar .home-sidebar,
+.fs-shell.is-resizing-sidebar .fs-tabbar,
+.fs-shell.is-resizing-sidebar .fs-tabs {
+  transition: none;
+}
+
 .fs-shell.has-window-menubar .fs-sidebar {
   grid-row: 3 / 5;
 }
@@ -185,7 +193,7 @@ textarea:focus-visible,
 .connection-summary {
   display: flex;
   flex-direction: column;
-  gap: 30px;
+  gap: 10px;
   margin: -12px -12px 10px;
   padding: 14px 16px;
   min-width: 0;
@@ -282,15 +290,18 @@ textarea:focus-visible,
   transition: height 0.3s ease;
 }
 
-.collapsed-resource-fill.status-green {
+.collapsed-resource-fill.status-green,
+.collapsed-resource-fill.tone-success {
   background: var(--metric-status-green);
 }
 
-.collapsed-resource-fill.status-yellow {
+.collapsed-resource-fill.status-yellow,
+.collapsed-resource-fill.tone-warning {
   background: var(--metric-status-yellow);
 }
 
-.collapsed-resource-fill.status-red {
+.collapsed-resource-fill.status-red,
+.collapsed-resource-fill.tone-danger {
   background: var(--metric-status-red);
 }
 

--- a/apps/desktop/src/renderer/styles/themes/default-dark.css
+++ b/apps/desktop/src/renderer/styles/themes/default-dark.css
@@ -64,7 +64,6 @@
   --surface-inset-border: rgba(255, 255, 255, 0.04);
   --surface-table-head: rgba(255, 255, 255, 0.045);
   --surface-nested: rgba(255, 255, 255, 0.035);
-  --file-row-meta: #8f949d;
   --floating-drawer-expanded-bg: rgba(28, 28, 30, 0.75);
   --floating-drawer-expanded-border: rgba(255, 255, 255, 0.08);
   --floating-drawer-shadow: 0 4px 12px rgba(0, 0, 0, 0.25), 0 1px 3px rgba(0, 0, 0, 0.15);

--- a/apps/desktop/src/renderer/styles/themes/default-light.css
+++ b/apps/desktop/src/renderer/styles/themes/default-light.css
@@ -53,7 +53,6 @@
   --surface-inset-border: rgba(15, 23, 42, 0.06);
   --surface-table-head: rgba(15, 23, 42, 0.04);
   --surface-nested: rgba(15, 23, 42, 0.035);
-  --file-row-meta: #64748b;
   --floating-drawer-expanded-bg: rgba(255, 255, 255, 0.9);
   --floating-drawer-expanded-border: rgba(15, 23, 42, 0.1);
   --floating-drawer-shadow: 0 10px 26px rgba(15, 23, 42, 0.14), 0 1px 2px rgba(15, 23, 42, 0.1);


### PR DESCRIPTION
## 变更说明

- 修复首页与会话页标题栏、标签栏、红绿灯避让之间的对齐问题。
- 优化侧边栏拖动时的跟手性，减少拖动过程中的过渡干扰。
- 收紧文件区域行高、IP 区块间距和多处分隔线表现，统一桌面端列表密度。
- 精简 Monaco 文件编辑器侧栏与重复线条，补齐保存中的 loading 态。

## 修复原因

这轮改动主要针对截图反馈中的视觉细节问题。此前首页、会话区、文件区和编辑器弹窗在边线、间距、标题栏占位和 loading 表现上不够一致，导致桌面端界面看起来有偏移感和冗余感。

## 影响范围

- 桌面端 renderer 的首页布局与顶部标签栏。
- 会话页 shell / 文件面板的布局密度与边线。
- 远程文件编辑弹窗的结构与交互反馈。

## 验证

- npm run typecheck -w @termdock/desktop
- git diff --check
