### PR TITLE
[codex] 修复冷启动连接竞态并发布 beta.3

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/desktop",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",
@@ -30,9 +30,9 @@
   "dependencies": {
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
-    "@fileterm/core": "0.3.0-beta.2",
-    "@fileterm/shared": "0.3.0-beta.2",
-    "@fileterm/storage": "0.3.0-beta.2",
+    "@fileterm/core": "0.3.0-beta.3",
+    "@fileterm/shared": "0.3.0-beta.3",
+    "@fileterm/storage": "0.3.0-beta.3",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -592,6 +592,7 @@ export function App() {
 
   const localTabsRef = useRef(localTabs)
   const pendingHomeReplacementKeyRef = useRef<string | null>(null)
+  const pendingProfileOpenIdRef = useRef<string | null>(null)
   const hasSanitizedStoredPlaceholderRef = useRef(false)
   const desktopApi = window.fileterm
   const isWindowsDesktop = desktopApi?.platform === 'win32'
@@ -1548,7 +1549,7 @@ export function App() {
     })
   }
 
-  const handleOpenProfile = async (profileId: string) => {
+  const openProfileInCurrentWorkspace = async (profileId: string) => {
     if (!desktopApi) {
       return
     }
@@ -1577,6 +1578,30 @@ export function App() {
       setIsBusy(false)
     }
   }
+
+  const handleOpenProfile = async (profileId: string) => {
+    if (isMainWorkspaceWindow && (!hasLoadedInitialSnapshot || !hasHydratedMainTabUiState)) {
+      pendingProfileOpenIdRef.current = profileId
+      setIsBusy(true)
+      return
+    }
+
+    await openProfileInCurrentWorkspace(profileId)
+  }
+
+  useEffect(() => {
+    if (!isMainWorkspaceWindow || !hasLoadedInitialSnapshot || !hasHydratedMainTabUiState) {
+      return
+    }
+
+    const profileId = pendingProfileOpenIdRef.current
+    if (!profileId) {
+      return
+    }
+
+    pendingProfileOpenIdRef.current = null
+    void openProfileInCurrentWorkspace(profileId)
+  }, [hasHydratedMainTabUiState, hasLoadedInitialSnapshot, isMainWorkspaceWindow])
 
   const handleDeleteProfile = async (profileId: string) => {
     if (!desktopApi) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "0.3.0-beta.2",
+      "version": "0.3.0-beta.3",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -22,11 +22,11 @@
     },
     "apps/desktop": {
       "name": "@fileterm/desktop",
-      "version": "0.3.0-beta.2",
+      "version": "0.3.0-beta.3",
       "dependencies": {
-        "@fileterm/core": "0.3.0-beta.2",
-        "@fileterm/shared": "0.3.0-beta.2",
-        "@fileterm/storage": "0.3.0-beta.2",
+        "@fileterm/core": "0.3.0-beta.3",
+        "@fileterm/shared": "0.3.0-beta.3",
+        "@fileterm/storage": "0.3.0-beta.3",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@xterm/addon-fit": "^0.11.0",
@@ -5298,17 +5298,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "0.3.0-beta.2"
+      "version": "0.3.0-beta.3"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "0.3.0-beta.2"
+      "version": "0.3.0-beta.3"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "0.3.0-beta.2",
+      "version": "0.3.0-beta.3",
       "dependencies": {
-        "@fileterm/core": "0.3.0-beta.2"
+        "@fileterm/core": "0.3.0-beta.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "0.3.0-beta.2"
+    "@fileterm/core": "0.3.0-beta.3"
   }
 }


### PR DESCRIPTION
## 变更内容

- 修复冷启动阶段立即点击连接时，标签 UI 尚未恢复导致连接被作为额外标签/窗口打开的竞态。
- 将连接动作延迟到初始快照和主标签状态完成恢复后，再替换当前首页。
- 按发布规范将版本同步升级到 `0.3.0-beta.3`。

## 影响

macOS、Windows 与 Linux 共用的 renderer 启动链路均生效，不改变 main/preload IPC 边界。

## 验证

- `npm run typecheck -w @fileterm/desktop`
- `npm run build -w @fileterm/desktop`
- `git diff --check`
