### PR TITLE
[codex] Adjust Windows home title branding

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -3184,10 +3184,6 @@ export function App() {
             <div className="window-menu-items">
               <button type="button" onClick={(e) => {
                 const rect = e.currentTarget.getBoundingClientRect()
-                void desktopApi?.showWindowMenu('app', Math.round(rect.left), Math.round(rect.bottom))
-              }} style={{ fontWeight: 600, color: 'var(--text-main, #ffffff)' }}>FileTerm</button>
-              <button type="button" onClick={(e) => {
-                const rect = e.currentTarget.getBoundingClientRect()
                 void desktopApi?.showWindowMenu('file', Math.round(rect.left), Math.round(rect.bottom))
               }}>File</button>
               <button type="button" onClick={(e) => {

--- a/apps/desktop/src/renderer/features/layout/TabBar.tsx
+++ b/apps/desktop/src/renderer/features/layout/TabBar.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import type { WorkspaceTab } from '@fileterm/core'
 import { tabStatusClass } from '../../app/app-utils'
 import { t } from '../../i18n'
@@ -16,6 +17,7 @@ export type TabContextTarget =
 export function TabBar({
   activeHomeTabId,
   activeSessionTabId,
+  homeBrandContent,
   isWorkspaceFocusMode,
   onAddHomeTab,
   onActivateHome,
@@ -32,6 +34,7 @@ export function TabBar({
 }: {
   activeHomeTabId: string | null
   activeSessionTabId: string | null
+  homeBrandContent?: ReactNode
   isWorkspaceFocusMode: boolean
   onAddHomeTab(): void
   onActivateHome(id: string): void
@@ -50,13 +53,19 @@ export function TabBar({
 
   return (
       <header className="fs-tabbar">
-        <div className="titlebar-brand">
+        <div className={`titlebar-brand ${homeBrandContent ? 'has-home-brand-content' : ''}`}>
           <div className="window-controls-decorator" aria-hidden="true">
             <span className="dot dot-close" />
             <span className="dot dot-minimize" />
             <span className="dot dot-maximize" />
           </div>
-          <strong>{t.appTitle}</strong>
+          {homeBrandContent ? (
+            <div className="titlebar-home-brand" aria-hidden="true">
+              {homeBrandContent}
+            </div>
+          ) : (
+            <strong>{t.appTitle}</strong>
+          )}
         </div>
         <div className="titlebar-tabarea">
         <div

--- a/apps/desktop/src/renderer/features/workspace/HomeWorkspace.tsx
+++ b/apps/desktop/src/renderer/features/workspace/HomeWorkspace.tsx
@@ -88,6 +88,12 @@ export function HomeWorkspace({
 
   const desktopApi = window.fileterm
   const isWindows = desktopApi?.platform === 'win32'
+  const homeBrandContent = isWindows ? (
+    <>
+      <strong>{desktopApi?.appName ?? 'FileTerm'}</strong>
+      <span>v{desktopApi?.appVersion ?? '0.0.0'}</span>
+    </>
+  ) : undefined
 
   const handleOpenNewConnection = () => {
     if (desktopApi) {
@@ -104,7 +110,7 @@ export function HomeWorkspace({
   return (
     <section className={`home-workspace ${isSidebarCollapsed ? 'is-sidebar-collapsed' : ''}`}>
       <div className="home-tabs-bar">
-        <TabBar {...tabBarProps} />
+        <TabBar {...tabBarProps} homeBrandContent={homeBrandContent} />
       </div>
 
       {/* SideNavBar Component */}

--- a/apps/desktop/src/renderer/styles/features/home.css
+++ b/apps/desktop/src/renderer/styles/features/home.css
@@ -770,6 +770,10 @@
   grid-template-columns: minmax(0, 1fr) auto !important;
 }
 
-.home-tabs-bar .titlebar-brand strong {
+.home-tabs-bar .titlebar-brand.has-home-brand-content {
+  justify-content: center;
+}
+
+.home-tabs-bar .titlebar-brand:not(.has-home-brand-content) strong {
   display: none;
 }

--- a/apps/desktop/src/renderer/styles/features/shell.css
+++ b/apps/desktop/src/renderer/styles/features/shell.css
@@ -703,6 +703,10 @@
   border-right: 1px solid var(--border-light);
 }
 
+.titlebar-brand.has-home-brand-content {
+  gap: 8px;
+}
+
 :root[data-platform='darwin'] .titlebar-brand {
   padding-left: 86px;
 }
@@ -722,6 +726,36 @@
 .titlebar-tabarea {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.titlebar-home-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.titlebar-home-brand strong,
+.titlebar-home-brand span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.titlebar-home-brand strong {
+  font-family: "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  line-height: 1;
+}
+
+.titlebar-home-brand span {
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 500;
+  opacity: 0.68;
 }
 
 .tabbar-folder-button,

--- a/apps/desktop/src/renderer/styles/features/workstation-skin.css
+++ b/apps/desktop/src/renderer/styles/features/workstation-skin.css
@@ -98,6 +98,18 @@ textarea:focus-visible,
   grid-template-columns: minmax(0, 1fr) auto;
 }
 
+.titlebar-home-brand {
+  gap: 8px;
+}
+
+.titlebar-home-brand strong {
+  font-size: 14px;
+}
+
+.titlebar-home-brand span {
+  font-size: 11px;
+}
+
 .tabbar-folder-button {
   width: 48px;
 }


### PR DESCRIPTION
## What changed
- removed the extra `FileTerm` button from the Windows top-left menu row so the menu starts with `File`
- added `FileTerm` plus the current app version into the Home tab title area on Windows, in the blank slot to the left of the first tab
- kept the brand placement scoped to the Home workspace so normal session tabs and other windows keep their existing layout

## Why
The Windows layout was showing the brand twice in the top area, and the requested Home-page branding needed to live in the left title slot rather than the tab bar's right-side empty space.

## Impact
- Windows main window top chrome now matches the intended menu layout more closely
- Home workspace gets a clearer branded title area with version context
- macOS behavior is preserved because the new brand content is only injected for the Windows Home workspace path

## Validation
- `npm run typecheck -w @fileterm/desktop`
- runtime smoke check reached Electron preload successfully during local dev verification