### PR TITLE
CI: upgrade release artifact actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           npx electron-builder --mac --${{ matrix.arch }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: FileTerm-macOS-${{ matrix.arch }}
           path: |
@@ -132,7 +132,7 @@ jobs:
           npx electron-builder --win --${{ matrix.arch }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: FileTerm-Windows-${{ matrix.arch }}
           path: |
@@ -148,7 +148,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
 
       - name: Clean up stale draft releases
         shell: bash


### PR DESCRIPTION
Updates release artifact upload and download actions to their Node 24 runtimes, preventing GitHub Actions Node 20 deprecation warnings during the 1.0.0 packaging workflow.\n\nValidation: npm run format:check