### PR TITLE
fix: harden tab workspace state

### DIFF
--- a/apps/desktop/src/main/ipc/local-files-handlers.ts
+++ b/apps/desktop/src/main/ipc/local-files-handlers.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, dialog, ipcMain } from 'electron'
 import type { OpenDialogOptions } from 'electron'
 import type { PermissionChangeOptions } from '@fileterm/core'
+import { appError, appLog } from '../services/app-logger.js'
 import type { IpcServices } from './types.js'
 
 export function registerLocalFilesHandlers(services: IpcServices) {
@@ -48,8 +49,18 @@ export function registerLocalFilesHandlers(services: IpcServices) {
       defaultPath,
       properties: ['openFile', 'openDirectory', 'multiSelections', 'createDirectory']
     }
-    const result = window ? await dialog.showOpenDialog(window, options) : await dialog.showOpenDialog(options)
-    return result.canceled ? [] : result.filePaths
+    try {
+      const result = window ? await dialog.showOpenDialog(window, options) : await dialog.showOpenDialog(options)
+      appLog('[FileTerm][Local] Select files completed', {
+        defaultPath,
+        canceled: result.canceled,
+        count: result.filePaths.length
+      })
+      return result.canceled ? [] : result.filePaths
+    } catch (error) {
+      appError('[FileTerm][Local] Select files failed', { defaultPath, error: describeLocalError(error) })
+      throw error
+    }
   })
 
   ipcMain.handle('localFiles:selectDirectory', async (event, defaultPath?: string) => {
@@ -58,7 +69,37 @@ export function registerLocalFilesHandlers(services: IpcServices) {
       defaultPath: defaultPath || app.getPath('downloads'),
       properties: ['openDirectory', 'createDirectory']
     }
-    const result = window ? await dialog.showOpenDialog(window, options) : await dialog.showOpenDialog(options)
-    return result.canceled ? null : (result.filePaths[0] ?? null)
+    try {
+      const result = window ? await dialog.showOpenDialog(window, options) : await dialog.showOpenDialog(options)
+      appLog('[FileTerm][Local] Select directory completed', {
+        defaultPath: options.defaultPath,
+        canceled: result.canceled,
+        selectedPath: result.filePaths[0] ?? null
+      })
+      return result.canceled ? null : (result.filePaths[0] ?? null)
+    } catch (error) {
+      appError('[FileTerm][Local] Select directory failed', {
+        defaultPath: options.defaultPath,
+        error: describeLocalError(error)
+      })
+      throw error
+    }
   })
+}
+
+function describeLocalError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return error
+  }
+
+  const filesystemError = error as NodeJS.ErrnoException
+  return {
+    name: error.name,
+    message: error.message,
+    code: filesystemError.code,
+    errno: filesystemError.errno,
+    syscall: filesystemError.syscall,
+    path: filesystemError.path,
+    stack: error.stack
+  }
 }

--- a/apps/desktop/src/main/services/local-files-service.ts
+++ b/apps/desktop/src/main/services/local-files-service.ts
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import type { LocalFileItem, PermissionChangeOptions } from '@fileterm/core'
 import { decodeBuffer, encodeText } from './text-encoding.js'
+import { appError, appLog, appWarn } from './app-logger.js'
 
 function formatSize(bytes: number) {
   if (bytes < 1024) return `${bytes} B`
@@ -29,22 +30,43 @@ export class LocalFilesService {
   readonly initialPath = os.homedir()
 
   async listDirectory(dirPath = this.initialPath): Promise<{ path: string; items: LocalFileItem[] }> {
-    const entries = await readdir(dirPath, { withFileTypes: true })
-    const rows = await Promise.all(
-      entries.map(async (entry) => {
-        const fullPath = path.join(dirPath, entry.name)
-        const info = await stat(fullPath)
-        return {
-          path: fullPath,
-          name: entry.name,
-          type: entry.isDirectory() ? 'folder' : 'file',
-          modified: formatDate(info.mtime),
-          size: entry.isDirectory() ? '-' : formatSize(info.size),
-          permission: formatPermissionBits(info.mode, entry.isDirectory()),
-          ownerGroup: typeof info.uid === 'number' && typeof info.gid === 'number' ? `${info.uid}/${info.gid}` : ''
-        } satisfies LocalFileItem
-      })
-    )
+    appLog('[FileTerm][Local] Listing directory', { path: dirPath, home: this.initialPath, platform: process.platform })
+
+    let entries
+    try {
+      entries = await readdir(dirPath, { withFileTypes: true })
+    } catch (error) {
+      appError('[FileTerm][Local] Failed to read directory', { path: dirPath, error: describeFsError(error) })
+      throw error
+    }
+
+    const rows: LocalFileItem[] = (
+      (await Promise.all(
+        entries.map(async (entry) => {
+          const fullPath = path.join(dirPath, entry.name)
+          try {
+            const info = await stat(fullPath)
+            return {
+              path: fullPath,
+              name: entry.name,
+              type: entry.isDirectory() ? 'folder' : 'file',
+              modified: formatDate(info.mtime),
+              size: entry.isDirectory() ? '-' : formatSize(info.size),
+              permission: formatPermissionBits(info.mode, entry.isDirectory()),
+              ownerGroup: typeof info.uid === 'number' && typeof info.gid === 'number' ? `${info.uid}/${info.gid}` : ''
+            } satisfies LocalFileItem
+          } catch (error) {
+            appWarn('[FileTerm][Local] Skipped inaccessible directory entry', {
+              directory: dirPath,
+              path: fullPath,
+              name: entry.name,
+              error: describeFsError(error)
+            })
+            return null
+          }
+        })
+      )) as Array<LocalFileItem | null>
+    ).filter((item): item is LocalFileItem => item !== null)
 
     rows.sort((a, b) => {
       if (a.type !== b.type) {
@@ -60,75 +82,107 @@ export class LocalFilesService {
   }
 
   async readFile(filePath: string, encoding = 'utf-8'): Promise<string> {
-    const buffer = await readFile(filePath)
-    return decodeBuffer(buffer, encoding)
+    return this.withLocalLog('Read file', { path: filePath, encoding }, async () => {
+      const buffer = await readFile(filePath)
+      return decodeBuffer(buffer, encoding)
+    })
   }
 
   async writeFile(filePath: string, content: string, encoding = 'utf-8'): Promise<void> {
-    await writeFile(filePath, encodeText(content, encoding))
+    await this.withLocalLog('Write file', { path: filePath, encoding, bytes: Buffer.byteLength(content) }, () =>
+      writeFile(filePath, encodeText(content, encoding))
+    )
   }
 
   async createDirectory(dirPath: string, name: string): Promise<void> {
-    await mkdir(path.join(dirPath, name), { recursive: true })
+    const targetPath = path.join(dirPath, name)
+    await this.withLocalLog('Create directory', { directory: dirPath, name, path: targetPath }, async () => {
+      await mkdir(targetPath, { recursive: true })
+    })
   }
 
   async createFile(dirPath: string, name: string): Promise<void> {
     const targetPath = path.join(dirPath, name)
-    await mkdir(path.dirname(targetPath), { recursive: true })
-    await writeFile(targetPath, '', 'utf8')
+    return this.withLocalLog('Create file', { directory: dirPath, name, path: targetPath }, async () => {
+      await mkdir(path.dirname(targetPath), { recursive: true })
+      await writeFile(targetPath, '', 'utf8')
+    })
   }
 
   async copyPath(sourcePath: string, destinationPath: string): Promise<void> {
-    if (sourcePath === destinationPath) {
-      return
-    }
-    await mkdir(path.dirname(destinationPath), { recursive: true })
-    await cp(sourcePath, destinationPath, {
-      recursive: true,
-      errorOnExist: true,
-      force: false,
-      preserveTimestamps: true
+    return this.withLocalLog('Copy path', { sourcePath, destinationPath }, async () => {
+      if (sourcePath === destinationPath) {
+        return
+      }
+      await mkdir(path.dirname(destinationPath), { recursive: true })
+      await cp(sourcePath, destinationPath, {
+        recursive: true,
+        errorOnExist: true,
+        force: false,
+        preserveTimestamps: true
+      })
     })
   }
 
   async movePath(sourcePath: string, destinationPath: string): Promise<void> {
-    if (sourcePath === destinationPath) {
-      return
-    }
-    await mkdir(path.dirname(destinationPath), { recursive: true })
-    try {
-      await rename(sourcePath, destinationPath)
-    } catch (error) {
-      if (!isCrossDeviceRenameError(error)) {
-        throw error
+    return this.withLocalLog('Move path', { sourcePath, destinationPath }, async () => {
+      if (sourcePath === destinationPath) {
+        return
       }
-      await this.copyPath(sourcePath, destinationPath)
-      await rm(sourcePath, { recursive: true, force: true })
-    }
+      await mkdir(path.dirname(destinationPath), { recursive: true })
+      try {
+        await rename(sourcePath, destinationPath)
+      } catch (error) {
+        if (!isCrossDeviceRenameError(error)) {
+          throw error
+        }
+        await this.copyPath(sourcePath, destinationPath)
+        await rm(sourcePath, { recursive: true, force: true })
+      }
+    })
   }
 
   async renamePath(targetPath: string, newName: string): Promise<void> {
-    await rename(targetPath, path.join(path.dirname(targetPath), newName))
+    const destinationPath = path.join(path.dirname(targetPath), newName)
+    return this.withLocalLog('Rename path', { path: targetPath, newName, destinationPath }, () =>
+      rename(targetPath, destinationPath)
+    )
   }
 
   async deletePath(targetPath: string): Promise<void> {
-    await rm(targetPath, { recursive: true, force: true })
+    return this.withLocalLog('Delete path', { path: targetPath }, () =>
+      rm(targetPath, { recursive: true, force: true })
+    )
   }
 
   async changePermissions(targetPath: string, options: PermissionChangeOptions): Promise<void> {
-    const parsedMode = parseMode(options.mode)
-    await chmod(targetPath, parsedMode)
+    return this.withLocalLog('Change permissions', { path: targetPath, options }, async () => {
+      const parsedMode = parseMode(options.mode)
+      await chmod(targetPath, parsedMode)
 
-    if (!options.recursive) {
-      return
+      if (!options.recursive) {
+        return
+      }
+
+      const targetInfo = await stat(targetPath)
+      if (!targetInfo.isDirectory()) {
+        return
+      }
+
+      await this.applyPermissionsRecursively(targetPath, parsedMode, options.applyTo ?? 'all')
+    })
+  }
+
+  private async withLocalLog<T>(operation: string, details: Record<string, unknown>, action: () => Promise<T>) {
+    appLog(`[FileTerm][Local] ${operation} started`, details)
+    try {
+      const result = await action()
+      appLog(`[FileTerm][Local] ${operation} completed`, details)
+      return result
+    } catch (error) {
+      appError(`[FileTerm][Local] ${operation} failed`, { ...details, error: describeFsError(error) })
+      throw error
     }
-
-    const targetInfo = await stat(targetPath)
-    if (!targetInfo.isDirectory()) {
-      return
-    }
-
-    await this.applyPermissionsRecursively(targetPath, parsedMode, options.applyTo ?? 'all')
   }
 
   private async applyPermissionsRecursively(
@@ -151,6 +205,23 @@ export class LocalFilesService {
         await this.applyPermissionsRecursively(fullPath, mode, applyTo)
       }
     }
+  }
+}
+
+function describeFsError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return error
+  }
+
+  const filesystemError = error as NodeJS.ErrnoException
+  return {
+    name: error.name,
+    message: error.message,
+    code: filesystemError.code,
+    errno: filesystemError.errno,
+    syscall: filesystemError.syscall,
+    path: filesystemError.path,
+    stack: error.stack
   }
 }
 

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,4 +1,15 @@
-import { Suspense, lazy, useEffect, useMemo, useRef, useState, type CSSProperties, type FormEvent } from 'react'
+import {
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FormEvent,
+  type SetStateAction
+} from 'react'
 import {
   type CommandExecutionOptions,
   type ConnectionFormMode,
@@ -18,6 +29,15 @@ import { ConnectionModal } from './features/connections/ConnectionModal'
 const FileEditorModal = lazy(() =>
   import('./features/files/FileEditorModal').then((m) => ({ default: m.FileEditorModal }))
 )
+
+function retainOpenTabUiState<T>(state: Record<string, T>, openTabIds: Set<string>) {
+  const entries = Object.entries(state)
+  if (entries.every(([tabId]) => openTabIds.has(tabId))) {
+    return state
+  }
+
+  return Object.fromEntries(entries.filter(([tabId]) => openTabIds.has(tabId)))
+}
 import { CloseButton } from './features/common/CloseButton'
 import { ConfirmActionDialog } from './features/common/ConfirmActionDialog'
 import type { SendScope } from './features/common/session-send-targets'
@@ -92,12 +112,14 @@ export function App() {
 
   const [error, setError] = useState<string | null>(null)
   const [isBusy, setIsBusy] = useState(false)
+  const [isWorkspaceTransitionActive, setIsWorkspaceTransitionActive] = useState(true)
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => readInitialTheme(searchParams))
   const [locale, setLocaleState] = useState<AppLocale>(() => readInitialLocale(searchParams))
   const [isFileEditorDiscardConfirmOpen, setIsFileEditorDiscardConfirmOpen] = useState(false)
 
   const [sidebarWidth, setSidebarWidth] = useState(214)
-  const [isWorkspaceFocusMode, setIsWorkspaceFocusMode] = useState(false)
+  const [filePanelHeights, setFilePanelHeights] = useState<Record<string, number>>({})
+  const [workspaceFocusModes, setWorkspaceFocusModes] = useState<Record<string, boolean>>({})
   const [isResizingSidebar, setIsResizingSidebar] = useState(false)
 
   const desktopApi = window.fileterm
@@ -189,6 +211,57 @@ export function App() {
     onCloseCurrentWindow: closeCurrentWindow,
     onRequestQuit: requestQuitApp
   })
+
+  const activeFilePanelHeight = activeTab ? (filePanelHeights[activeTab.id] ?? 218) : 218
+  const shouldAlignFilePanelOnMount = activeTab
+    ? !Object.prototype.hasOwnProperty.call(filePanelHeights, activeTab.id)
+    : false
+  const isWorkspaceFocusMode = activeTab ? (workspaceFocusModes[activeTab.id] ?? false) : false
+  const activeTabId = activeTab?.id ?? null
+  const setActiveFilePanelHeight = useCallback(
+    (next: SetStateAction<number>) => {
+      if (!activeTabId) {
+        return
+      }
+
+      const tabId = activeTabId
+      setFilePanelHeights((currentHeights) => {
+        const currentHeight = currentHeights[tabId] ?? 218
+        const nextHeight = typeof next === 'function' ? next(currentHeight) : next
+        if (currentHeight === nextHeight) {
+          return currentHeights
+        }
+        return { ...currentHeights, [tabId]: nextHeight }
+      })
+    },
+    [activeTabId]
+  )
+
+  useEffect(() => {
+    setIsWorkspaceTransitionActive(false)
+    const frame = window.requestAnimationFrame(() => {
+      setIsWorkspaceTransitionActive(true)
+    })
+
+    return () => window.cancelAnimationFrame(frame)
+  }, [activeWorkspaceOrderKey])
+
+  useEffect(() => {
+    const openTabIds = new Set(visibleWorkspaceTabs.map((tab) => tab.id))
+    setFilePanelHeights((currentHeights) => retainOpenTabUiState(currentHeights, openTabIds))
+    setWorkspaceFocusModes((currentModes) => retainOpenTabUiState(currentModes, openTabIds))
+  }, [visibleWorkspaceTabs])
+
+  useEffect(() => {
+    if (!activeTabId || isHomeWorkspaceVisible) {
+      return
+    }
+
+    setIsSystemSidebarCollapsed(isWorkspaceFocusMode)
+    if (!isWorkspaceFocusMode) {
+      setSidebarWidth(214)
+    }
+  }, [activeTabId, isHomeWorkspaceVisible, isWorkspaceFocusMode, setIsSystemSidebarCollapsed])
 
   // 3. Workspace Modals Hook
   const {
@@ -969,7 +1042,9 @@ export function App() {
     },
     onToggleWorkspaceFocus: () => {
       const nextFocusMode = !isWorkspaceFocusMode
-      setIsWorkspaceFocusMode(nextFocusMode)
+      if (activeTab) {
+        setWorkspaceFocusModes((currentModes) => ({ ...currentModes, [activeTab.id]: nextFocusMode }))
+      }
       setIsSystemSidebarCollapsed(nextFocusMode)
       if (!nextFocusMode) {
         setSidebarWidth(214)
@@ -1019,8 +1094,8 @@ export function App() {
           ) : null}
           <div className="workspace-stage">
             <div
-              key={activeWorkspaceOrderKey}
-              className="workspace-stage-transition"
+              key={activeLocalTab ? activeWorkspaceOrderKey : 'session-workspace'}
+              className={`workspace-stage-transition ${isWorkspaceTransitionActive ? 'is-transitioning' : ''}`}
               data-nav-direction={workspaceNavDirection}
             >
               <WorkspaceStage
@@ -1029,6 +1104,9 @@ export function App() {
                 activeProfile={activeProfile}
                 activeSession={activeSession}
                 activeTab={activeTab}
+                filePanelHeight={activeFilePanelHeight}
+                onFilePanelHeightChange={setActiveFilePanelHeight}
+                shouldAlignFilePanelOnMount={shouldAlignFilePanelOnMount}
                 sendTargets={sessionSendTargets}
                 terminalDockSendScope={activeTerminalDockSendState.scope}
                 terminalDockSelectedTabIds={activeTerminalDockSendState.selectedTabIds}

--- a/apps/desktop/src/renderer/components/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/TerminalView.tsx
@@ -139,6 +139,11 @@ export const TerminalView = memo(function TerminalView({
   const lastTerminalOutputAtRef = useRef(0)
   const awaitingCommandCompletionRef = useRef(false)
   const pendingPromptResizeRef = useRef(false)
+  const tabIdRef = useRef(tabId)
+  const onStatusRef = useRef(onStatus)
+  const activeTerminalTabIdRef = useRef<string | null>(null)
+  tabIdRef.current = tabId
+  onStatusRef.current = onStatus
   const [hasSelection, setHasSelection] = useState(false)
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
   const [findOpen, setFindOpen] = useState(false)
@@ -503,7 +508,13 @@ export const TerminalView = memo(function TerminalView({
       return
     }
 
-    void window.fileterm?.resizeTerminal(tabId, nextSize.cols, nextSize.rows, nextSize.width, nextSize.height)
+    void window.fileterm?.resizeTerminal(
+      tabIdRef.current,
+      nextSize.cols,
+      nextSize.rows,
+      nextSize.width,
+      nextSize.height
+    )
   }
 
   useEffect(() => {
@@ -627,7 +638,7 @@ export const TerminalView = memo(function TerminalView({
           ? await window.fileterm.readClipboardText()
           : ((await navigator.clipboard?.readText?.()) ?? '')
         const encoded = encodeBase64Utf8(clipboardText)
-        await window.fileterm?.writeTerminal(tabId, `\u001b]52;${parsed.target || 'c'};${encoded}\u0007`)
+        await window.fileterm?.writeTerminal(tabIdRef.current, `\u001b]52;${parsed.target || 'c'};${encoded}\u0007`)
         return true
       }
 
@@ -646,9 +657,11 @@ export const TerminalView = memo(function TerminalView({
 
     syncTerminalSize(fitAddon, terminal)
 
-    if (bootTextRef.current) {
-      replaceTerminalWithTranscript(terminal, bootTextRef.current)
+    bootTextRef.current = bootText
+    if (bootText) {
+      replaceTerminalWithTranscript(terminal, bootText)
     }
+    activeTerminalTabIdRef.current = tabIdRef.current
 
     const resize = (force = false, freezeCols = false, preserveVisibleBuffer = false) => {
       syncTerminalSize(fitAddon, terminal, { force, freezeCols, preserveVisibleBuffer })
@@ -708,7 +721,7 @@ export const TerminalView = memo(function TerminalView({
       }
       clearEphemeralHighlight()
       setContextMenu(null)
-      void window.fileterm?.writeTerminal(tabId, data)
+      void window.fileterm?.writeTerminal(tabIdRef.current, data)
     })
 
     const onSelectionDispose = terminal.onSelectionChange(() => {
@@ -716,7 +729,7 @@ export const TerminalView = memo(function TerminalView({
     })
 
     const offData = window.fileterm?.onTerminalData(({ tabId: nextTabId, chunk }) => {
-      if (nextTabId === tabId) {
+      if (nextTabId === tabIdRef.current) {
         lastTerminalOutputAtRef.current = Date.now()
         const shouldTrimHydratedBacklog = Date.now() < suppressHydratedChunksUntilRef.current
         if (shouldTrimHydratedBacklog) {
@@ -741,8 +754,8 @@ export const TerminalView = memo(function TerminalView({
     })
 
     const offState = window.fileterm?.onTerminalState(({ tabId: nextTabId, summary, transcript, connected }) => {
-      if (nextTabId === tabId) {
-        onStatus?.(localizeTerminalText(summary))
+      if (nextTabId === tabIdRef.current) {
+        onStatusRef.current?.(localizeTerminalText(summary))
         const isDisconnecting = wasConnectedRef.current && !connected
         if (isDisconnecting) {
           preserveVisibleBufferRef.current = true
@@ -884,8 +897,8 @@ export const TerminalView = memo(function TerminalView({
     window.addEventListener('fileterm:terminal-find', handleTerminalFind)
 
     // Ask the main process for the actual PTY size once the terminal is mounted.
-    if (!bootedTabs.current.has(tabId)) {
-      bootedTabs.current.add(tabId)
+    if (!bootedTabs.current.has(tabIdRef.current)) {
+      bootedTabs.current.add(tabIdRef.current)
       resize()
     }
 
@@ -935,7 +948,33 @@ export const TerminalView = memo(function TerminalView({
       terminalRef.current = null
       terminal.dispose()
     }
-  }, [isMac, onStatus, tabId])
+  }, [isMac])
+
+  useEffect(() => {
+    bootTextRef.current = bootText
+    if (activeTerminalTabIdRef.current === tabId) {
+      return
+    }
+
+    activeTerminalTabIdRef.current = tabId
+    const terminal = terminalRef.current
+    const host = hostRef.current
+    if (!terminal || !host) {
+      return
+    }
+
+    wasConnectedRef.current = connected
+    preserveVisibleBufferRef.current = false
+    awaitingCommandCompletionRef.current = false
+    pendingPromptResizeRef.current = false
+    replaceTerminalWithTranscript(terminal, bootText)
+    lastSyncedSizeRef.current = null
+
+    const { width, height } = host.getBoundingClientRect()
+    if (width > 0 && height > 0) {
+      void window.fileterm?.resizeTerminal(tabId, terminal.cols, terminal.rows, Math.floor(width), Math.floor(height))
+    }
+  }, [bootText, connected, tabId])
 
   useEffect(() => {
     bootTextRef.current = bootText

--- a/apps/desktop/src/renderer/features/workspace/SessionWorkspace.tsx
+++ b/apps/desktop/src/renderer/features/workspace/SessionWorkspace.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState, type CSSProperties, type DragEvent } from 'react'
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type Dispatch,
+  type DragEvent,
+  type SetStateAction
+} from 'react'
 import type {
   CommandExecutionOptions,
   CommandFolder,
@@ -20,6 +28,9 @@ const DEFAULT_FILE_PANEL_HEIGHT = 218
 export function SessionWorkspace({
   activeTab,
   activeSession,
+  filePanelHeight,
+  onFilePanelHeightChange,
+  shouldAlignFilePanelOnMount,
   sendTargets,
   terminalDockSendScope,
   terminalDockSelectedTabIds,
@@ -65,6 +76,9 @@ export function SessionWorkspace({
 }: {
   activeTab: WorkspaceTab
   activeSession: SessionSnapshot
+  filePanelHeight: number
+  onFilePanelHeightChange: Dispatch<SetStateAction<number>>
+  shouldAlignFilePanelOnMount: boolean
   sendTargets: SessionSendTarget[]
   terminalDockSendScope: SendScope
   terminalDockSelectedTabIds: string[]
@@ -115,15 +129,14 @@ export function SessionWorkspace({
   isWorkspaceFocusMode: boolean
 }) {
   const isFileOnly = activeTab.layout === 'file-only'
-  const [filePanelHeight, setFilePanelHeight] = useState(DEFAULT_FILE_PANEL_HEIGHT)
+  const setFilePanelHeight = onFilePanelHeightChange
   const [isFilePanelCollapsed, setIsFilePanelCollapsed] = useState(false)
+  const [isFilePanelDragging, setIsFilePanelDragging] = useState(false)
   const workspaceRef = useRef<HTMLElement | null>(null)
   const isResizingFilePanel = useRef(false)
-  const hasUserResizedFilePanel = useRef(false)
-  const isSnappedToDiskHead = useRef(false)
   const dragStateRef = useRef<{ bottom: number; height: number; snapHeight: number | null } | null>(null)
   const layoutFrameRef = useRef<number | null>(null)
-  const lastExpandedFilePanelHeight = useRef(DEFAULT_FILE_PANEL_HEIGHT)
+  const lastExpandedFilePanelHeight = useRef(filePanelHeight)
   const appliedWorkspaceFocusMode = useRef<boolean | null>(null)
   const isFilePanelEffectivelyCollapsed = isFilePanelCollapsed && !isFileOnly
   const effectiveFilePanelHeight = isFilePanelEffectivelyCollapsed ? 0 : filePanelHeight
@@ -134,7 +147,7 @@ export function SessionWorkspace({
     return Math.min(maxHeight, Math.max(minHeight, nextHeight))
   }
 
-  const syncFilePanelHeight = (mode: 'align' | 'clamp') => {
+  const syncFilePanelHeight = (mode: 'align' | 'clamp' = 'clamp') => {
     if (isFileOnly || isFilePanelCollapsed || !workspaceRef.current || isResizingFilePanel.current) {
       return
     }
@@ -149,9 +162,7 @@ export function SessionWorkspace({
       if (diskHeadRect) {
         const nextHeight = workspaceRect.bottom - diskHeadRect.top
         const clampedHeight = clampFilePanelHeight(workspaceRect.height, nextHeight)
-
         setFilePanelHeight((prev) => (prev === clampedHeight ? prev : clampedHeight))
-        isSnappedToDiskHead.current = true
         return
       }
     }
@@ -182,6 +193,7 @@ export function SessionWorkspace({
         lastExpandedFilePanelHeight.current = filePanelHeight
       }
       isResizingFilePanel.current = false
+      setIsFilePanelDragging(false)
       dragStateRef.current = null
       setIsFilePanelCollapsed(true)
       return
@@ -192,11 +204,31 @@ export function SessionWorkspace({
   }, [isFileOnly, isWorkspaceFocusMode])
 
   useEffect(() => {
+    isResizingFilePanel.current = false
+    dragStateRef.current = null
+    setIsFilePanelDragging(false)
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+  }, [activeTab.id])
+
+  useEffect(() => {
     if (isFileOnly) {
       return
     }
 
     let dragFrame: number | null = null
+
+    const stopFilePanelDragging = () => {
+      isResizingFilePanel.current = false
+      dragStateRef.current = null
+      if (dragFrame) {
+        window.cancelAnimationFrame(dragFrame)
+        dragFrame = null
+      }
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      setIsFilePanelDragging(false)
+    }
 
     const onMouseMove = (event: globalThis.MouseEvent) => {
       if (!isResizingFilePanel.current || !dragStateRef.current) {
@@ -206,12 +238,9 @@ export function SessionWorkspace({
       const { bottom, height, snapHeight } = dragStateRef.current
       let nextHeight = bottom - event.clientY
 
-      let isSnapped = false
       if (snapHeight !== null && Math.abs(nextHeight - snapHeight) <= 10) {
         nextHeight = snapHeight
-        isSnapped = true
       }
-      isSnappedToDiskHead.current = isSnapped
 
       if (dragFrame) {
         window.cancelAnimationFrame(dragFrame)
@@ -226,47 +255,39 @@ export function SessionWorkspace({
     }
 
     const onMouseUp = () => {
-      isResizingFilePanel.current = false
-      dragStateRef.current = null
-      if (dragFrame) {
-        window.cancelAnimationFrame(dragFrame)
-        dragFrame = null
-      }
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
+      stopFilePanelDragging()
     }
 
     window.addEventListener('mousemove', onMouseMove)
     window.addEventListener('mouseup', onMouseUp)
+    window.addEventListener('blur', onMouseUp)
+    document.addEventListener('mouseup', onMouseUp)
 
     return () => {
       window.removeEventListener('mousemove', onMouseMove)
       window.removeEventListener('mouseup', onMouseUp)
+      window.removeEventListener('blur', onMouseUp)
+      document.removeEventListener('mouseup', onMouseUp)
       if (dragFrame) {
         window.cancelAnimationFrame(dragFrame)
       }
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
+      setIsFilePanelDragging(false)
     }
-  }, [isFileOnly])
+  }, [isFileOnly, setFilePanelHeight])
 
   useEffect(() => {
-    hasUserResizedFilePanel.current = false
-  }, [activeTab.id])
-
-  useEffect(() => {
-    if (isFileOnly || isFilePanelCollapsed) {
+    if (!shouldAlignFilePanelOnMount || isFileOnly || isFilePanelCollapsed) {
       return
     }
 
     const frame = window.requestAnimationFrame(() => {
-      if (!hasUserResizedFilePanel.current || isSnappedToDiskHead.current) {
-        syncFilePanelHeight('align')
-      }
+      syncFilePanelHeight('align')
     })
 
     return () => window.cancelAnimationFrame(frame)
-  }, [isFileOnly, isFilePanelCollapsed, activeTab.id])
+  }, [activeTab.id, isFileOnly, isFilePanelCollapsed, shouldAlignFilePanelOnMount])
 
   useEffect(() => {
     if (isFileOnly || isFilePanelCollapsed || !workspaceRef.current) {
@@ -280,8 +301,7 @@ export function SessionWorkspace({
 
       layoutFrameRef.current = window.requestAnimationFrame(() => {
         layoutFrameRef.current = null
-        const mode = !hasUserResizedFilePanel.current || isSnappedToDiskHead.current ? 'align' : 'clamp'
-        syncFilePanelHeight(mode)
+        syncFilePanelHeight()
       })
     }
 
@@ -300,7 +320,7 @@ export function SessionWorkspace({
       resizeObserver.disconnect()
       window.removeEventListener('resize', syncAfterLayout)
     }
-  }, [isFileOnly, isFilePanelCollapsed, activeTab.id])
+  }, [isFileOnly, isFilePanelCollapsed, setFilePanelHeight])
 
   const handleToggleFilePanelCollapsed = () => {
     if (isFilePanelCollapsed) {
@@ -319,7 +339,7 @@ export function SessionWorkspace({
 
   return (
     <section
-      className={`session-workspace ${isFileOnly ? 'file-only' : ''} ${isFilePanelEffectivelyCollapsed ? 'file-panel-collapsed' : ''}`}
+      className={`session-workspace ${isFileOnly ? 'file-only' : ''} ${isFilePanelEffectivelyCollapsed ? 'file-panel-collapsed' : ''} ${isFilePanelDragging ? 'is-file-panel-dragging' : ''}`}
       ref={workspaceRef}
       style={{ '--file-panel-height': `${effectiveFilePanelHeight}px` } as CSSProperties}
     >
@@ -357,9 +377,10 @@ export function SessionWorkspace({
       {!isFileOnly && !isFilePanelCollapsed ? (
         <div
           className="session-split-resizer"
-          onMouseDown={() => {
+          onMouseDown={(event) => {
+            event.preventDefault()
             isResizingFilePanel.current = true
-            hasUserResizedFilePanel.current = true
+            setIsFilePanelDragging(true)
 
             if (workspaceRef.current) {
               const rect = workspaceRef.current.getBoundingClientRect()

--- a/apps/desktop/src/renderer/features/workspace/WorkspaceStage.tsx
+++ b/apps/desktop/src/renderer/features/workspace/WorkspaceStage.tsx
@@ -10,7 +10,7 @@ import type {
   SessionSnapshot,
   WorkspaceTab
 } from '@fileterm/core'
-import type { DragEvent } from 'react'
+import type { Dispatch, DragEvent, SetStateAction } from 'react'
 import type { SendScope, SessionSendTarget } from '../common/session-send-targets'
 import type { TabBarProps } from '../layout/TabBar'
 import { SystemInfoWorkspace } from '../system/SystemInfoWorkspace'
@@ -28,6 +28,9 @@ export function WorkspaceStage({
   activeProfile,
   activeSession,
   activeTab,
+  filePanelHeight,
+  onFilePanelHeightChange,
+  shouldAlignFilePanelOnMount,
   sendTargets,
   terminalDockSendScope,
   terminalDockSelectedTabIds,
@@ -102,6 +105,9 @@ export function WorkspaceStage({
   activeProfile: ConnectionProfile | null
   activeSession: SessionSnapshot | null
   activeTab: WorkspaceTab | null
+  filePanelHeight: number
+  onFilePanelHeightChange: Dispatch<SetStateAction<number>>
+  shouldAlignFilePanelOnMount: boolean
   sendTargets: SessionSendTarget[]
   terminalDockSendScope: SendScope
   terminalDockSelectedTabIds: string[]
@@ -184,9 +190,11 @@ export function WorkspaceStage({
   if (activeTab && activeSession && !activeLocalTab) {
     return (
       <SessionWorkspace
-        key={activeTab.id}
         activeSession={activeSession}
         activeTab={activeTab}
+        filePanelHeight={filePanelHeight}
+        onFilePanelHeightChange={onFilePanelHeightChange}
+        shouldAlignFilePanelOnMount={shouldAlignFilePanelOnMount}
         sendTargets={sendTargets}
         terminalDockSendScope={terminalDockSendScope}
         terminalDockSelectedTabIds={terminalDockSelectedTabIds}

--- a/apps/desktop/src/renderer/hooks/useWorkspaceIpcSync.ts
+++ b/apps/desktop/src/renderer/hooks/useWorkspaceIpcSync.ts
@@ -343,9 +343,9 @@ export function useWorkspaceIpcSync({
           setLocalPath(path)
           setLocalItems(withParentRow(path, items))
         })
-        .catch(() => {
+        .catch((error: unknown) => {
           if (!canceled) {
-            onStatusMessageRef.current(t.localLoadFailed)
+            onErrorRef.current('读取本机目录', error)
           }
         })
     }

--- a/apps/desktop/src/renderer/styles/features/session.css
+++ b/apps/desktop/src/renderer/styles/features/session.css
@@ -12,6 +12,10 @@
   grid-template-rows: 1fr;
 }
 
+.session-workspace.is-file-panel-dragging {
+  transition: none;
+}
+
 .terminal-area {
   position: relative;
   min-height: 0;

--- a/apps/desktop/src/renderer/styles/features/shell.css
+++ b/apps/desktop/src/renderer/styles/features/shell.css
@@ -978,6 +978,9 @@
   flex: 1 1 auto;
   min-width: 0;
   min-height: 0;
+}
+
+.workspace-stage-transition.is-transitioning > * {
   animation: workspace-stage-fade-in 0.24s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 


### PR DESCRIPTION
## Summary

- Preserve per-tab workspace UI state for file panel height and terminal focus mode.
- Stabilize file panel dragging, initial alignment, and tab-switch animation behavior.
- Reuse the xterm instance across tab switches while routing input, output, state, and PTY resize events to the active tab.
- Add structured logging and per-entry fault tolerance for local file operations.

## Root cause

Workspace state and terminal lifecycle were coupled to tab remounts or stale tab closures, causing layout resets, drag state leakage, terminal content mismatches, and expensive tab-switch work.

## Validation

- `npm run typecheck -w @fileterm/desktop`
- `npm run lint -- --max-warnings=0`
- `npm run format:check`
- `npm test -w @fileterm/desktop` (48 unit tests, 6 controller tests)
