### PR TITLE
fix(tauri): restore workspace interaction parity

### DIFF
--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -383,8 +383,10 @@ pub fn open_child_window(app: &AppHandle, input: OpenWindowInput) -> Result<(), 
     }
 
     let (title, width, height, min_width, min_height, decorations) = match input.kind.as_str() {
-        "connection-manager" => ("连接管理器", 860.0, 680.0, 760.0, 520.0, true),
-        "command-manager" => ("命令管理器", 860.0, 680.0, 760.0, 620.0, true),
+        // Manager windows render their own title bar. Keep the native frame
+        // disabled so macOS does not add a second traffic-light row above it.
+        "connection-manager" => ("连接管理器", 860.0, 680.0, 760.0, 520.0, false),
+        "command-manager" => ("命令管理器", 860.0, 680.0, 760.0, 620.0, false),
         "connection-form" => ("连接", 860.0, 680.0, 760.0, 620.0, false),
         "command-form" => ("命令", 860.0, 680.0, 760.0, 620.0, false),
         "file-editor" => ("编辑文件", 1220.0, 780.0, 1040.0, 620.0, false),

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -18,6 +18,7 @@
         "height": 820,
         "minWidth": 1150,
         "minHeight": 790,
+        "dragDropEnabled": true,
         "decorations": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,

--- a/apps/tauri/src/bridge/tauri-api.ts
+++ b/apps/tauri/src/bridge/tauri-api.ts
@@ -73,9 +73,39 @@ function subscribeTerminalData(listener: (payload: TerminalDataPayload) => void)
 // a later browser-only drop of the same number of files.
 void getCurrentWindow()
   .onDragDropEvent((event) => {
+    if (event.payload.type === 'enter' || event.payload.type === 'over') {
+      window.dispatchEvent(
+        new CustomEvent('fileterm:tauri-native-drag-over', {
+          detail: { position: event.payload.position }
+        })
+      )
+      return
+    }
+
     if (event.payload.type === 'drop') {
-      latestNativeDropPaths = [...event.payload.paths]
+      const paths = [...event.payload.paths]
+      latestNativeDropPaths = paths
       latestNativeDropAt = Date.now()
+
+      // WRY's DOM drop event often exposes File objects without native paths.
+      // Publish the native event directly so the renderer can upload the
+      // absolute paths without depending on the browser FileList timing.
+      window.dispatchEvent(
+        new CustomEvent('fileterm:tauri-native-drop', {
+          detail: {
+            paths,
+            position: {
+              x: event.payload.position.x,
+              y: event.payload.position.y
+            }
+          }
+        })
+      )
+
+      // The custom event is the primary path. Clear the fallback immediately
+      // so a second DOM drop callback cannot enqueue the same files twice.
+      latestNativeDropPaths = []
+      latestNativeDropAt = 0
     }
   })
   .catch(() => undefined)

--- a/apps/tauri/src/renderer/App.tsx
+++ b/apps/tauri/src/renderer/App.tsx
@@ -924,9 +924,7 @@ export function App() {
           onCreateFolder={(name) => {
             void createCommandFolder(name)
           }}
-          onDeleteFolder={(folderId) => {
-            void deleteCommandFolder(folderId)
-          }}
+          onDeleteFolder={(folderId) => deleteCommandFolder(folderId)}
           onUpdateFolder={(folderId, updates) => {
             void updateCommandFolder(folderId, updates)
           }}
@@ -939,9 +937,7 @@ export function App() {
           onUpdateCommand={(commandId, input) => {
             void saveCommandTemplate(commandId, input)
           }}
-          onDeleteCommand={(commandId) => {
-            void deleteCommandTemplate(commandId)
-          }}
+          onDeleteCommand={(commandId) => deleteCommandTemplate(commandId)}
         />
       </StandaloneWindowFrame>
     )
@@ -1050,7 +1046,7 @@ export function App() {
           <div
             className={`modal-card file-editor-modal ${themeMode === 'default-dark' ? 'file-editor-modal--dark' : ''} standalone`}
           >
-            <div className="modal-header">
+            <div className="modal-header" data-tauri-drag-region="deep">
               <div className="file-editor-title">
                 <span>{fileEditorWindowSource === 'remote' ? t.editRemoteFile : t.editLocalFile}</span>
                 <strong>{fileEditorWindowName ?? ''}</strong>

--- a/apps/tauri/src/renderer/features/commands/CommandManagerModal.tsx
+++ b/apps/tauri/src/renderer/features/commands/CommandManagerModal.tsx
@@ -5,6 +5,7 @@ import { t } from '../../i18n'
 import { CommandEditorModal, emptyCommandForm, toCommandTemplateInput } from './CommandEditorModal'
 import { AppIcon } from '../common/AppIcon'
 import { CloseButton } from '../common/CloseButton'
+import { usePointerSortFallback, type PointerSortTarget } from '../../hooks/usePointerSortFallback'
 
 type CommandTreeNode = (CommandFolder & { children: CommandTreeNode[] }) | (CommandTemplate & { children?: never })
 
@@ -27,12 +28,12 @@ export function CommandManagerModal({
   commandTemplates: CommandTemplate[]
   onClose(): void
   onCreateFolder(name: string): void
-  onDeleteFolder(folderId: string): void
+  onDeleteFolder(folderId: string): Promise<unknown> | void
   onUpdateFolder(folderId: string, updates: Partial<CommandFolder>): void
   onUpdateOrder(id: string, newParentId: string | undefined, newOrder: number): void
   onCreateCommand(input: CommandTemplateInput): void
   onUpdateCommand(commandId: string, input: CommandTemplateInput): void
-  onDeleteCommand(commandId: string): void
+  onDeleteCommand(commandId: string): Promise<unknown> | void
   standalone?: boolean
   inline?: boolean
   onActiveFolderChange?(name: string): void
@@ -51,7 +52,14 @@ export function CommandManagerModal({
   const [pendingDelete, setPendingDelete] = useState<
     { kind: 'folder'; id: string; name: string } | { kind: 'command'; id: string; name: string } | null
   >(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const suppressRowClickRef = useRef(false)
+  const dragStateRef = useRef<{
+    draggingId: string | null
+    targetId: string | null
+    position: 'top' | 'bottom' | 'inside' | null
+  }>({ draggingId: null, targetId: null, position: null })
 
   const desktopApi = window.fileterm
 
@@ -185,139 +193,170 @@ export function CommandManagerModal({
     return matches
   }, [activeBaseNodes, searchQuery])
 
-  const handleDragStart = (e: DragEvent, id: string) => {
-    e.stopPropagation()
-    suppressRowClickRef.current = true
-    setDraggingId(id)
-    e.dataTransfer.effectAllowed = 'move'
-    e.dataTransfer.setData('text/plain', id)
-  }
-
-  const handleDragOver = (e: DragEvent, targetId: string, type: 'command-folder' | 'command-template') => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (draggingId === targetId) return
-
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-    const y = e.clientY - rect.top
-    const height = rect.height
-
-    let pos: 'top' | 'bottom' | 'inside' = 'bottom'
-    if (type === 'command-folder') {
-      if (y < height * 0.25) pos = 'top'
-      else if (y > height * 0.75) pos = 'bottom'
-      else pos = 'inside'
-    } else {
-      if (y < height * 0.5) pos = 'top'
-      else pos = 'bottom'
-    }
-
-    setDragOverId(targetId)
-    setDragPosition(pos)
-  }
-
-  const handleRootDragOver = (e: DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (draggingId) {
-      setDragOverId('all')
-      setDragPosition('inside')
-    }
-  }
-
-  const handleRootDragLeave = (e: DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (dragOverId === 'all') {
-      setDragOverId(null)
-      setDragPosition(null)
-    }
-  }
-
-  const handleRootDrop = (e: DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (draggingId) {
-      const rootSiblings = tree.roots.filter((node) => node.id !== draggingId)
-      const lastRoot = rootSiblings[rootSiblings.length - 1]
-      onUpdateOrder(draggingId, undefined, (lastRoot?.order ?? 0) + 1000)
-    }
-    setDraggingId(null)
-    setDragOverId(null)
-    setDragPosition(null)
-  }
-
-  const handleDragLeave = (e: DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setDragOverId(null)
-    setDragPosition(null)
-  }
-
-  const handleDrop = (e: DragEvent, targetId: string) => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (!draggingId || draggingId === targetId) {
-      setDraggingId(null)
-      setDragOverId(null)
-      return
-    }
-
-    const draggedNode = tree.map.get(draggingId)
-    const targetNode = tree.map.get(targetId)
-    if (!draggedNode || !targetNode) return
-
-    // Prevent dropping a folder into its own descendant
-    let current: CommandTreeNode | undefined = targetNode
-    let invalid = false
-    while (current?.parentId) {
-      if (current.parentId === draggingId) {
-        invalid = true
-        break
-      }
-      current = tree.map.get(current.parentId)
-    }
-    if (invalid) {
-      setDraggingId(null)
-      setDragOverId(null)
-      return
-    }
-
-    const targetParent = targetNode.parentId ? tree.map.get(targetNode.parentId) : undefined
-    let newParentId = targetParent?.type === 'command-folder' ? targetParent.id : undefined
-    const siblings = targetParent?.type === 'command-folder' ? targetParent.children : tree.roots
-
-    let newOrder = targetNode.order ?? 0
-
-    if (dragPosition === 'inside' && targetNode.type === 'command-folder') {
-      newParentId = targetNode.id
-      const children = targetNode.children || []
-      newOrder = children.length > 0 ? (children[children.length - 1].order ?? 0) + 1000 : 1000
-      setExpandedFolders((prev) => new Set(prev).add(targetNode.id))
-    } else {
-      const targetIndex = siblings.findIndex((s) => s.id === targetId)
-      if (dragPosition === 'top') {
-        const prev = siblings[targetIndex - 1]
-        newOrder = prev ? ((prev.order ?? 0) + (targetNode.order ?? 0)) / 2 : (targetNode.order ?? 0) - 1000
-      } else if (dragPosition === 'bottom') {
-        const next = siblings[targetIndex + 1]
-        newOrder = next ? ((next.order ?? 0) + (targetNode.order ?? 0)) / 2 : (targetNode.order ?? 0) + 1000
-      }
-    }
-
-    onUpdateOrder(draggingId, newParentId, newOrder)
-    setDraggingId(null)
-    setDragOverId(null)
-    setDragPosition(null)
-  }
-
-  const handleDragEnd = () => {
+  const clearDragState = () => {
+    dragStateRef.current = { draggingId: null, targetId: null, position: null }
     setDraggingId(null)
     setDragOverId(null)
     setDragPosition(null)
     window.setTimeout(() => {
       suppressRowClickRef.current = false
     }, 0)
+  }
+
+  const setDropTarget = (targetId: string, position: 'top' | 'bottom' | 'inside') => {
+    dragStateRef.current.targetId = targetId
+    dragStateRef.current.position = position
+    setDragOverId(targetId)
+    setDragPosition(position)
+  }
+
+  const positionForTarget = (targetId: string, element: HTMLElement, clientY: number) => {
+    if (targetId === 'all') return 'inside' as const
+    if (element.closest('.connection-manager-sidebar')) return 'inside' as const
+    const targetNode = tree.map.get(targetId)
+    if (!targetNode) return null
+    const rect = element.getBoundingClientRect()
+    const y = clientY - rect.top
+    if (targetNode.type === 'command-folder') {
+      if (y < rect.height * 0.25) return 'top' as const
+      if (y > rect.height * 0.75) return 'bottom' as const
+      return 'inside' as const
+    }
+    return y < rect.height * 0.5 ? ('top' as const) : ('bottom' as const)
+  }
+
+  const moveToRoot = (id: string) => {
+    const rootSiblings = tree.roots.filter((node) => node.id !== id)
+    const lastRoot = rootSiblings[rootSiblings.length - 1]
+    onUpdateOrder(id, undefined, (lastRoot?.order ?? 0) + 1000)
+  }
+
+  const applyDrop = (activeDraggingId: string, targetId: string, activePosition: 'top' | 'bottom' | 'inside') => {
+    if (targetId === 'all') {
+      moveToRoot(activeDraggingId)
+      return
+    }
+    if (activeDraggingId === targetId) return
+    const draggedNode = tree.map.get(activeDraggingId)
+    const targetNode = tree.map.get(targetId)
+    if (!draggedNode || !targetNode) return
+
+    let current: CommandTreeNode | undefined = targetNode
+    while (current?.parentId) {
+      if (current.parentId === activeDraggingId) return
+      current = tree.map.get(current.parentId)
+    }
+
+    const targetParent = targetNode.parentId ? tree.map.get(targetNode.parentId) : undefined
+    let newParentId = targetParent?.type === 'command-folder' ? targetParent.id : undefined
+    const siblings = targetParent?.type === 'command-folder' ? targetParent.children : tree.roots
+    let newOrder = targetNode.order ?? 0
+    if (activePosition === 'inside' && targetNode.type === 'command-folder') {
+      newParentId = targetNode.id
+      const children = targetNode.children || []
+      newOrder = children.length > 0 ? (children[children.length - 1].order ?? 0) + 1000 : 1000
+      setExpandedFolders((prev) => new Set(prev).add(targetNode.id))
+    } else {
+      const targetIndex = siblings.findIndex((sibling) => sibling.id === targetId)
+      if (activePosition === 'top') {
+        const previous = siblings[targetIndex - 1]
+        newOrder = previous ? ((previous.order ?? 0) + (targetNode.order ?? 0)) / 2 : (targetNode.order ?? 0) - 1000
+      } else {
+        const next = siblings[targetIndex + 1]
+        newOrder = next ? ((next.order ?? 0) + (targetNode.order ?? 0)) / 2 : (targetNode.order ?? 0) + 1000
+      }
+    }
+    onUpdateOrder(activeDraggingId, newParentId, newOrder)
+  }
+
+  const handlePointerDown = usePointerSortFallback<string>({
+    onStart: (id) => {
+      suppressRowClickRef.current = true
+      dragStateRef.current = { draggingId: id, targetId: null, position: null }
+      setDraggingId(id)
+    },
+    onTarget: (id, target: PointerSortTarget, clientY) => {
+      if (id === target.id) return
+      const position = positionForTarget(target.id, target.element, clientY)
+      if (position) setDropTarget(target.id, position)
+    },
+    onDrop: (id, target, clientY) => {
+      if (target && id !== target.id) {
+        const position = positionForTarget(target.id, target.element, clientY)
+        if (position) applyDrop(id, target.id, position)
+      }
+      clearDragState()
+    },
+    onCancel: clearDragState
+  })
+
+  const handleDragStart = (e: DragEvent, id: string) => {
+    e.stopPropagation()
+    suppressRowClickRef.current = true
+    dragStateRef.current = { draggingId: id, targetId: null, position: null }
+    setDraggingId(id)
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', id)
+  }
+
+  const handleDragOver = (e: DragEvent, targetId: string) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (dragStateRef.current.draggingId === targetId) return
+
+    const position = positionForTarget(targetId, e.currentTarget as HTMLElement, e.clientY)
+    if (position) setDropTarget(targetId, position)
+  }
+
+  const handleRootDragOver = (e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (dragStateRef.current.draggingId) {
+      setDropTarget('all', 'inside')
+    }
+  }
+
+  const handleRootDragLeave = (e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    // WebKit can emit dragleave while moving over a child span. Keep the
+    // logical target in the ref until the next dragover/drop event.
+  }
+
+  const handleRootDrop = (e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const activeDraggingId = dragStateRef.current.draggingId
+    if (activeDraggingId) moveToRoot(activeDraggingId)
+    clearDragState()
+  }
+
+  const handleDragLeave = (e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    // See handleRootDragLeave: Tauri WRY emits nested dragleave events before
+    // the drop callback, so React state is only cleared when the drag ends.
+  }
+
+  const handleDrop = (e: DragEvent, targetId: string) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const activeDraggingId = dragStateRef.current.draggingId || e.dataTransfer.getData('text/plain') || null
+    let activePosition = dragStateRef.current.targetId === targetId ? dragStateRef.current.position : dragPosition
+    if (!activeDraggingId || activeDraggingId === targetId) {
+      clearDragState()
+      return
+    }
+
+    if (!activePosition) {
+      activePosition = positionForTarget(targetId, e.currentTarget as HTMLElement, e.clientY)
+    }
+    if (activePosition) applyDrop(activeDraggingId, targetId, activePosition)
+    clearDragState()
+  }
+
+  const handleDragEnd = () => {
+    clearDragState()
   }
 
   const openEditorWindow = (mode: 'create' | 'edit', commandId?: string) => {
@@ -352,9 +391,12 @@ export function CommandManagerModal({
       <div key={node.id}>
         <div
           className={`manager-row ${isFolder ? 'folder-row' : ''} ${dropClass} ${isDragging ? 'dragging' : ''}`}
-          draggable
+          data-fileterm-sort-id={node.id}
+          data-fileterm-sort-kind={isFolder ? 'folder' : 'command'}
+          draggable={false}
+          onPointerDown={(event) => handlePointerDown(event, node.id)}
           onDragStart={(e) => handleDragStart(e, node.id)}
-          onDragOver={(e) => handleDragOver(e, node.id, isFolder ? 'command-folder' : 'command-template')}
+          onDragOver={(e) => handleDragOver(e, node.id)}
           onDragLeave={handleDragLeave}
           onDrop={(e) => handleDrop(e, node.id)}
           onDragEnd={handleDragEnd}
@@ -545,6 +587,8 @@ export function CommandManagerModal({
                 item.id === 'all' ? 'root-drop-target' : ''
               } ${item.id === 'all' && dragOverId === 'all' ? 'drag-over' : ''}`}
               type="button"
+              data-fileterm-sort-id={item.id}
+              data-fileterm-sort-kind={item.id === 'all' ? 'root' : 'folder'}
               onClick={() => setActiveFolderId(item.id)}
               onDragOver={item.id === 'all' ? handleRootDragOver : undefined}
               onDragLeave={item.id === 'all' ? handleRootDragLeave : undefined}
@@ -688,14 +732,25 @@ export function CommandManagerModal({
         <ConfirmActionDialog
           confirmLabel={t.delete}
           description={`${t.deleteConfirmPrefix}${pendingDelete.name}${t.deleteConfirmSuffix}`}
-          onClose={() => setPendingDelete(null)}
-          onConfirm={() => {
-            if (pendingDelete.kind === 'folder') {
-              onDeleteFolder(pendingDelete.id)
-            } else {
-              onDeleteCommand(pendingDelete.id)
+          errorMessage={deleteError}
+          isSubmitting={isDeleting}
+          onClose={() => {
+            if (!isDeleting) {
+              setPendingDelete(null)
+              setDeleteError(null)
             }
-            setPendingDelete(null)
+          }}
+          onConfirm={() => {
+            const target = pendingDelete
+            setIsDeleting(true)
+            setDeleteError(null)
+            void Promise.resolve()
+              .then(() => (target.kind === 'folder' ? onDeleteFolder(target.id) : onDeleteCommand(target.id)))
+              .then(() => setPendingDelete(null))
+              .catch((error: unknown) => {
+                setDeleteError(error instanceof Error ? error.message : String(error))
+              })
+              .finally(() => setIsDeleting(false))
           }}
           title={t.delete}
         />

--- a/apps/tauri/src/renderer/features/connections/ConnectionManagerModal.tsx
+++ b/apps/tauri/src/renderer/features/connections/ConnectionManagerModal.tsx
@@ -4,6 +4,7 @@ import { ConfirmActionDialog } from '../common/ConfirmActionDialog'
 import { t } from '../../i18n'
 import { AppIcon } from '../common/AppIcon'
 import { CloseButton } from '../common/CloseButton'
+import { usePointerSortFallback, type PointerSortTarget } from '../../hooks/usePointerSortFallback'
 
 type ConnectionTreeNode =
   (ConnectionFolder & { children: ConnectionTreeNode[] }) | (ConnectionProfile & { children?: never })
@@ -30,11 +31,11 @@ export function ConnectionManagerModal({
   folders: ConnectionFolder[]
   onClose(): void
   onCreate(): void
-  onDeleteProfile(profileId: string): void
+  onDeleteProfile(profileId: string): Promise<unknown> | void
   onEditProfile(profile: ConnectionProfile): void
   onOpenProfile(profileId: string): void
   onCreateFolder(name: string): void
-  onDeleteFolder(folderId: string): void
+  onDeleteFolder(folderId: string): Promise<unknown> | void
   onUpdateFolder(folderId: string, updates: Partial<ConnectionFolder>): void
   onUpdateOrder(id: string, newParentId: string | undefined, newOrder: number): void
   standalone?: boolean
@@ -56,7 +57,14 @@ export function ConnectionManagerModal({
   const [pendingDelete, setPendingDelete] = useState<
     { kind: 'folder'; id: string; name: string } | { kind: 'profile'; id: string; name: string } | null
   >(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const suppressRowClickRef = useRef(false)
+  const dragStateRef = useRef<{
+    draggingId: string | null
+    targetId: string | null
+    position: 'top' | 'bottom' | 'inside' | null
+  }>({ draggingId: null, targetId: null, position: null })
 
   const stopInteractiveEvent = (event: React.SyntheticEvent) => {
     event.stopPropagation()
@@ -190,141 +198,174 @@ export function ConnectionManagerModal({
     return matches
   }, [activeBaseNodes, searchQuery])
 
-  const handleDragStart = (e: DragEvent, id: string) => {
-    e.stopPropagation()
-    suppressRowClickRef.current = true
-    setDraggingId(id)
-    e.dataTransfer.effectAllowed = 'move'
-    // For firefox
-    e.dataTransfer.setData('text/plain', id)
-  }
-
-  const handleDragOver = (e: DragEvent, targetId: string, type: 'folder' | 'profile') => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (draggingId === targetId) return
-
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-    const y = e.clientY - rect.top
-    const height = rect.height
-
-    let pos: 'top' | 'bottom' | 'inside' = 'bottom'
-    if (type === 'folder') {
-      if (y < height * 0.25) pos = 'top'
-      else if (y > height * 0.75) pos = 'bottom'
-      else pos = 'inside'
-    } else {
-      if (y < height * 0.5) pos = 'top'
-      else pos = 'bottom'
-    }
-
-    setDragOverId(targetId)
-    setDragPosition(pos)
-  }
-
-  const handleRootDragOver = (e: DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (draggingId) {
-      setDragOverId('all')
-      setDragPosition('inside')
-    }
-  }
-
-  const handleRootDragLeave = (e: DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (dragOverId === 'all') {
-      setDragOverId(null)
-      setDragPosition(null)
-    }
-  }
-
-  const handleRootDrop = (e: DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (draggingId) {
-      const rootSiblings = tree.roots.filter((node) => node.id !== draggingId)
-      const lastRoot = rootSiblings[rootSiblings.length - 1]
-      onUpdateOrder(draggingId, undefined, (lastRoot?.order ?? 0) + 1000)
-    }
-    setDraggingId(null)
-    setDragOverId(null)
-    setDragPosition(null)
-  }
-
-  const handleDragLeave = (e: DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setDragOverId(null)
-    setDragPosition(null)
-  }
-
-  const handleDrop = (e: DragEvent, targetId: string) => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (!draggingId || draggingId === targetId) {
-      setDraggingId(null)
-      setDragOverId(null)
-      return
-    }
-
-    const draggedNode = tree.map.get(draggingId)
-    const targetNode = tree.map.get(targetId)
-    if (!draggedNode || !targetNode) return
-
-    // Prevent dropping a folder into its own descendant
-    let current: ConnectionTreeNode | undefined = targetNode
-    let invalid = false
-    while (current?.parentId) {
-      if (current.parentId === draggingId) {
-        invalid = true
-        break
-      }
-      current = tree.map.get(current.parentId)
-    }
-    if (invalid) {
-      setDraggingId(null)
-      setDragOverId(null)
-      return
-    }
-
-    const targetParent = targetNode.parentId ? tree.map.get(targetNode.parentId) : undefined
-    let newParentId = targetParent?.type === 'folder' ? targetParent.id : undefined
-    const siblings = targetParent?.type === 'folder' ? targetParent.children : tree.roots
-
-    let newOrder = targetNode.order ?? 0
-
-    if (dragPosition === 'inside' && targetNode.type === 'folder') {
-      newParentId = targetNode.id
-      const children = targetNode.children || []
-      newOrder = children.length > 0 ? (children[children.length - 1].order ?? 0) + 1000 : 1000
-      // Auto expand when dropped inside
-      setExpandedFolders((prev) => new Set(prev).add(targetNode.id))
-    } else {
-      const targetIndex = siblings.findIndex((s) => s.id === targetId)
-      if (dragPosition === 'top') {
-        const prev = siblings[targetIndex - 1]
-        newOrder = prev ? ((prev.order ?? 0) + (targetNode.order ?? 0)) / 2 : (targetNode.order ?? 0) - 1000
-      } else if (dragPosition === 'bottom') {
-        const next = siblings[targetIndex + 1]
-        newOrder = next ? ((next.order ?? 0) + (targetNode.order ?? 0)) / 2 : (targetNode.order ?? 0) + 1000
-      }
-    }
-
-    onUpdateOrder(draggingId, newParentId, newOrder)
-    setDraggingId(null)
-    setDragOverId(null)
-    setDragPosition(null)
-  }
-
-  const handleDragEnd = () => {
+  const clearDragState = () => {
+    dragStateRef.current = { draggingId: null, targetId: null, position: null }
     setDraggingId(null)
     setDragOverId(null)
     setDragPosition(null)
     window.setTimeout(() => {
       suppressRowClickRef.current = false
     }, 0)
+  }
+
+  const setDropTarget = (targetId: string, position: 'top' | 'bottom' | 'inside') => {
+    dragStateRef.current.targetId = targetId
+    dragStateRef.current.position = position
+    setDragOverId(targetId)
+    setDragPosition(position)
+  }
+
+  const positionForTarget = (targetId: string, element: HTMLElement, clientY: number) => {
+    if (targetId === 'all') return 'inside' as const
+    if (element.closest('.connection-manager-sidebar')) return 'inside' as const
+    const targetNode = tree.map.get(targetId)
+    if (!targetNode) return null
+    const rect = element.getBoundingClientRect()
+    const y = clientY - rect.top
+    if (targetNode.type === 'folder') {
+      if (y < rect.height * 0.25) return 'top' as const
+      if (y > rect.height * 0.75) return 'bottom' as const
+      return 'inside' as const
+    }
+    return y < rect.height * 0.5 ? ('top' as const) : ('bottom' as const)
+  }
+
+  const moveToRoot = (id: string) => {
+    const rootSiblings = tree.roots.filter((node) => node.id !== id)
+    const lastRoot = rootSiblings[rootSiblings.length - 1]
+    onUpdateOrder(id, undefined, (lastRoot?.order ?? 0) + 1000)
+  }
+
+  const applyDrop = (activeDraggingId: string, targetId: string, activePosition: 'top' | 'bottom' | 'inside') => {
+    if (targetId === 'all') {
+      moveToRoot(activeDraggingId)
+      return
+    }
+    if (activeDraggingId === targetId) return
+
+    const draggedNode = tree.map.get(activeDraggingId)
+    const targetNode = tree.map.get(targetId)
+    if (!draggedNode || !targetNode) return
+
+    // Prevent dropping a folder into its own descendant.
+    let current: ConnectionTreeNode | undefined = targetNode
+    while (current?.parentId) {
+      if (current.parentId === activeDraggingId) return
+      current = tree.map.get(current.parentId)
+    }
+
+    const targetParent = targetNode.parentId ? tree.map.get(targetNode.parentId) : undefined
+    let newParentId = targetParent?.type === 'folder' ? targetParent.id : undefined
+    const siblings = targetParent?.type === 'folder' ? targetParent.children : tree.roots
+    let newOrder = targetNode.order ?? 0
+
+    if (activePosition === 'inside' && targetNode.type === 'folder') {
+      newParentId = targetNode.id
+      const children = targetNode.children || []
+      newOrder = children.length > 0 ? (children[children.length - 1].order ?? 0) + 1000 : 1000
+      setExpandedFolders((prev) => new Set(prev).add(targetNode.id))
+    } else {
+      const targetIndex = siblings.findIndex((sibling) => sibling.id === targetId)
+      if (activePosition === 'top') {
+        const previous = siblings[targetIndex - 1]
+        newOrder = previous ? ((previous.order ?? 0) + (targetNode.order ?? 0)) / 2 : (targetNode.order ?? 0) - 1000
+      } else {
+        const next = siblings[targetIndex + 1]
+        newOrder = next ? ((next.order ?? 0) + (targetNode.order ?? 0)) / 2 : (targetNode.order ?? 0) + 1000
+      }
+    }
+    onUpdateOrder(activeDraggingId, newParentId, newOrder)
+  }
+
+  const handlePointerDown = usePointerSortFallback<string>({
+    onStart: (id) => {
+      suppressRowClickRef.current = true
+      dragStateRef.current = { draggingId: id, targetId: null, position: null }
+      setDraggingId(id)
+    },
+    onTarget: (id, target: PointerSortTarget, clientY) => {
+      if (id === target.id) return
+      const position = positionForTarget(target.id, target.element, clientY)
+      if (position) setDropTarget(target.id, position)
+    },
+    onDrop: (id, target, clientY) => {
+      if (target && id !== target.id) {
+        const position = positionForTarget(target.id, target.element, clientY)
+        if (position) applyDrop(id, target.id, position)
+      }
+      clearDragState()
+    },
+    onCancel: clearDragState
+  })
+
+  const handleDragStart = (e: DragEvent, id: string) => {
+    e.stopPropagation()
+    suppressRowClickRef.current = true
+    dragStateRef.current = { draggingId: id, targetId: null, position: null }
+    setDraggingId(id)
+    e.dataTransfer.effectAllowed = 'move'
+    // For firefox
+    e.dataTransfer.setData('text/plain', id)
+  }
+
+  const handleDragOver = (e: DragEvent, targetId: string) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (dragStateRef.current.draggingId === targetId) return
+
+    const position = positionForTarget(targetId, e.currentTarget as HTMLElement, e.clientY)
+    if (position) setDropTarget(targetId, position)
+  }
+
+  const handleRootDragOver = (e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (dragStateRef.current.draggingId) {
+      setDropTarget('all', 'inside')
+    }
+  }
+
+  const handleRootDragLeave = (e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    // WebKit can emit dragleave while moving over a child span. Keep the
+    // logical target in the ref until the next dragover/drop event.
+  }
+
+  const handleRootDrop = (e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const activeDraggingId = dragStateRef.current.draggingId
+    if (activeDraggingId) moveToRoot(activeDraggingId)
+    clearDragState()
+  }
+
+  const handleDragLeave = (e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    // See handleRootDragLeave: clearing React state here races Tauri WRY's
+    // nested dragleave events and made an inside-folder drop become a no-op.
+  }
+
+  const handleDrop = (e: DragEvent, targetId: string) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const activeDraggingId = dragStateRef.current.draggingId || e.dataTransfer.getData('text/plain') || null
+    let activePosition = dragStateRef.current.targetId === targetId ? dragStateRef.current.position : dragPosition
+    if (!activeDraggingId || activeDraggingId === targetId) {
+      clearDragState()
+      return
+    }
+
+    if (!activePosition) {
+      activePosition = positionForTarget(targetId, e.currentTarget as HTMLElement, e.clientY)
+    }
+    if (activePosition) applyDrop(activeDraggingId, targetId, activePosition)
+    clearDragState()
+  }
+
+  const handleDragEnd = () => {
+    clearDragState()
   }
 
   const renderNode = (node: ConnectionTreeNode, depth: number, options: { includeChildren?: boolean } = {}) => {
@@ -343,9 +384,12 @@ export function ConnectionManagerModal({
       <div key={node.id}>
         <div
           className={`manager-row ${isFolder ? 'folder-row' : ''} ${dropClass} ${isDragging ? 'dragging' : ''}`}
-          draggable
+          data-fileterm-sort-id={node.id}
+          data-fileterm-sort-kind={isFolder ? 'folder' : 'profile'}
+          draggable={false}
+          onPointerDown={(event) => handlePointerDown(event, node.id)}
           onDragStart={(e) => handleDragStart(e, node.id)}
-          onDragOver={(e) => handleDragOver(e, node.id, isFolder ? 'folder' : 'profile')}
+          onDragOver={(e) => handleDragOver(e, node.id)}
           onDragLeave={handleDragLeave}
           onDrop={(e) => handleDrop(e, node.id)}
           onDragEnd={handleDragEnd}
@@ -540,6 +584,8 @@ export function ConnectionManagerModal({
                 item.id === 'all' ? 'root-drop-target' : ''
               } ${item.id === 'all' && dragOverId === 'all' ? 'drag-over' : ''}`}
               type="button"
+              data-fileterm-sort-id={item.id}
+              data-fileterm-sort-kind={item.id === 'all' ? 'root' : 'folder'}
               onClick={() => setActiveFolderId(item.id)}
               onDragOver={item.id === 'all' ? handleRootDragOver : undefined}
               onDragLeave={item.id === 'all' ? handleRootDragLeave : undefined}
@@ -699,14 +745,25 @@ export function ConnectionManagerModal({
         <ConfirmActionDialog
           confirmLabel={t.delete}
           description={`${t.deleteConfirmPrefix}${pendingDelete.name}${t.deleteConfirmSuffix}`}
-          onClose={() => setPendingDelete(null)}
-          onConfirm={() => {
-            if (pendingDelete.kind === 'folder') {
-              onDeleteFolder(pendingDelete.id)
-            } else {
-              onDeleteProfile(pendingDelete.id)
+          errorMessage={deleteError}
+          isSubmitting={isDeleting}
+          onClose={() => {
+            if (!isDeleting) {
+              setPendingDelete(null)
+              setDeleteError(null)
             }
-            setPendingDelete(null)
+          }}
+          onConfirm={() => {
+            const target = pendingDelete
+            setIsDeleting(true)
+            setDeleteError(null)
+            void Promise.resolve()
+              .then(() => (target.kind === 'folder' ? onDeleteFolder(target.id) : onDeleteProfile(target.id)))
+              .then(() => setPendingDelete(null))
+              .catch((error: unknown) => {
+                setDeleteError(error instanceof Error ? error.message : String(error))
+              })
+              .finally(() => setIsDeleting(false))
           }}
           title={t.delete}
         />

--- a/apps/tauri/src/renderer/features/files/FileManager.tsx
+++ b/apps/tauri/src/renderer/features/files/FileManager.tsx
@@ -826,6 +826,10 @@ export function FileManager({
             }}
             onDragOver={(event) => {
               event.preventDefault()
+              // Native Tauri drop events do not reliably share DOM coordinates
+              // with WKWebView. Record the pane that the Finder drag is over so
+              // the bridge can route its absolute paths to the correct target.
+              window.dispatchEvent(new Event('fileterm:tauri-remote-dragover'))
               if (canUseRemoteFiles) {
                 event.dataTransfer.dropEffect = 'copy'
               }

--- a/apps/tauri/src/renderer/features/ssh-keys/SshKeyManagerPage.tsx
+++ b/apps/tauri/src/renderer/features/ssh-keys/SshKeyManagerPage.tsx
@@ -1,10 +1,20 @@
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type DragEvent } from 'react'
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type DragEvent,
+  type PointerEvent as ReactPointerEvent
+} from 'react'
 import type { SshKeyMetadata } from '@fileterm/core'
 import { AppIcon } from '../common/AppIcon'
 import { ConfirmActionDialog } from '../common/ConfirmActionDialog'
 import { useSshKeyLibrary } from '../../hooks/useSshKeyLibrary'
 import { SshKeyNoteDialog } from './SshKeyNoteDialog'
 import { t } from '../../i18n'
+import { usePointerSortFallback, type PointerSortTarget } from '../../hooks/usePointerSortFallback'
 
 const SSH_KEY_MANAGER_UI_STATE = 'ssh-key-manager-ui'
 
@@ -26,6 +36,11 @@ type DragPosition = 'top' | 'bottom' | 'inside'
 type SortableItem = { kind: DragItem['kind']; id: string; fallbackOrder: number }
 
 const ROOT_DROP_TARGET_ID = '__ssh-key-root__'
+
+function readDraggedItem(value: string): DragItem | null {
+  const match = /^fileterm-ssh-key:(folder|key):(.+)$/.exec(value)
+  return match ? { kind: match[1] as DragItem['kind'], id: match[2] } : null
+}
 
 export function SshKeyManagerPage({
   onActiveFolderChange,
@@ -50,6 +65,10 @@ export function SshKeyManagerPage({
   const [pendingDelete, setPendingDelete] = useState<DeleteTarget | null>(null)
   const [dragging, setDragging] = useState<DragItem | null>(null)
   const [dragOver, setDragOver] = useState<{ id: string; kind: DragItem['kind']; position: DragPosition } | null>(null)
+  const dragStateRef = useRef<{
+    dragging: DragItem | null
+    dragOver: { id: string; kind: DragItem['kind']; position: DragPosition } | null
+  }>({ dragging: null, dragOver: null })
   const [isActionsExpanded, setIsActionsExpanded] = useState(false)
   const [isCreatingFolder, setIsCreatingFolder] = useState(false)
   const [newFolderName, setNewFolderName] = useState('')
@@ -242,31 +261,31 @@ export function SshKeyManagerPage({
   const handleDragStart = (event: DragEvent, item: DragItem) => {
     event.stopPropagation()
     suppressRowClickRef.current = true
+    dragStateRef.current = { dragging: item, dragOver: null }
     setDragging(item)
     event.dataTransfer.effectAllowed = 'move'
-    event.dataTransfer.setData('text/plain', item.id)
+    event.dataTransfer.setData('text/plain', `fileterm-ssh-key:${item.kind}:${item.id}`)
   }
 
   const handleDragOver = (event: DragEvent, target: DragItem) => {
     event.preventDefault()
     event.stopPropagation()
-    if (!dragging || dragging.id === target.id) return
+    const activeDragging = dragStateRef.current.dragging
+    if (!activeDragging || activeDragging.id === target.id) return
 
-    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
-    const y = event.clientY - rect.top
-    const height = rect.height
-    let position: DragPosition = y < height * 0.5 ? 'top' : 'bottom'
-    if (target.kind === 'folder' && dragging.kind === 'key' && y >= height * 0.25 && y <= height * 0.75) {
-      position = 'inside'
-    }
-    setDragOver({ ...target, position })
+    const position = positionForTarget(activeDragging, target, event.currentTarget as HTMLElement, event.clientY)
+    const nextDragOver = { ...target, position }
+    dragStateRef.current.dragOver = nextDragOver
+    setDragOver(nextDragOver)
   }
 
   const handleRootDragOver = (event: DragEvent) => {
     event.preventDefault()
     event.stopPropagation()
-    if (dragging?.kind === 'key') {
-      setDragOver({ id: ROOT_DROP_TARGET_ID, kind: 'folder', position: 'inside' })
+    if (dragStateRef.current.dragging?.kind === 'key') {
+      const nextDragOver = { id: ROOT_DROP_TARGET_ID, kind: 'folder' as const, position: 'inside' as const }
+      dragStateRef.current.dragOver = nextDragOver
+      setDragOver(nextDragOver)
     }
   }
 
@@ -277,6 +296,7 @@ export function SshKeyManagerPage({
   }
 
   const clearDragState = () => {
+    dragStateRef.current = { dragging: null, dragOver: null }
     setDragging(null)
     setDragOver(null)
   }
@@ -350,39 +370,110 @@ export function SshKeyManagerPage({
     persistUiState(folders, nextAssignments, nextItemOrder)
   }
 
+  const positionForTarget = (
+    dragItem: DragItem,
+    target: DragItem,
+    element: HTMLElement,
+    clientY: number
+  ): DragPosition => {
+    if (element.closest('.connection-manager-sidebar')) return 'inside'
+    const rect = element.getBoundingClientRect()
+    const y = clientY - rect.top
+    if (target.kind === 'folder' && dragItem.kind === 'key' && y >= rect.height * 0.25 && y <= rect.height * 0.75) {
+      return 'inside'
+    }
+    return y < rect.height * 0.5 ? 'top' : 'bottom'
+  }
+
+  const applyDrop = (activeDragging: DragItem, target: DragItem, position: DragPosition) => {
+    if (activeDragging.id === target.id) return
+    if (activeDragging.kind === 'key') {
+      const draggedKey = keys.find((key) => key.id === activeDragging.id)
+      if (draggedKey && target.kind === 'folder' && position === 'inside') {
+        const siblingOrders = keys
+          .filter((key) => key.id !== activeDragging.id && assignments[key.id] === target.id)
+          .map((key) => orderOf(key.id, key.importedAt))
+        const nextAssignments = { ...assignments, [activeDragging.id]: target.id }
+        const nextItemOrder = { ...itemOrder, [activeDragging.id]: Math.max(0, ...siblingOrders, 0) + 1000 }
+        persistUiState(folders, nextAssignments, nextItemOrder)
+        setExpandedFolderIds((current) => new Set(current).add(target.id))
+      } else if (draggedKey) {
+        const parentId = target.kind === 'key' ? assignments[target.id] : undefined
+        reorderItems(activeDragging, target, parentId, position)
+      }
+    } else if (activeDragging.kind === 'folder' && position !== 'inside') {
+      const targetParentId = target.kind === 'key' ? assignments[target.id] : undefined
+      if (!targetParentId) reorderItems(activeDragging, target, undefined, position)
+    }
+  }
+
+  const handlePointerDown = usePointerSortFallback<DragItem>({
+    onStart: (item) => {
+      suppressRowClickRef.current = true
+      dragStateRef.current = { dragging: item, dragOver: null }
+      setDragging(item)
+    },
+    onTarget: (item, target: PointerSortTarget, clientY) => {
+      if (target.id === ROOT_DROP_TARGET_ID) {
+        if (item.kind === 'key') {
+          const rootTarget = { id: ROOT_DROP_TARGET_ID, kind: 'folder' as const, position: 'inside' as const }
+          dragStateRef.current.dragOver = rootTarget
+          setDragOver(rootTarget)
+        }
+        return
+      }
+      if (target.kind !== 'folder' && target.kind !== 'key') return
+      const targetItem: DragItem = { id: target.id, kind: target.kind }
+      if (item.id === targetItem.id) return
+      const position = positionForTarget(item, targetItem, target.element, clientY)
+      const nextDragOver = { ...targetItem, position }
+      dragStateRef.current.dragOver = nextDragOver
+      setDragOver(nextDragOver)
+    },
+    onDrop: (item, target, clientY) => {
+      if (target?.id === ROOT_DROP_TARGET_ID) {
+        if (item.kind === 'key') moveKeyToRoot(item.id)
+      } else if (target && (target.kind === 'folder' || target.kind === 'key')) {
+        const targetItem: DragItem = { id: target.id, kind: target.kind }
+        const position = positionForTarget(item, targetItem, target.element, clientY)
+        applyDrop(item, targetItem, position)
+      }
+      clearDragState()
+    },
+    onCancel: clearDragState
+  })
+
   const handleRootDrop = (event: DragEvent) => {
     event.preventDefault()
     event.stopPropagation()
-    if (dragging?.kind === 'key') moveKeyToRoot(dragging.id)
+    const activeDragging = dragStateRef.current.dragging ?? readDraggedItem(event.dataTransfer.getData('text/plain'))
+    if (activeDragging?.kind === 'key') moveKeyToRoot(activeDragging.id)
     clearDragState()
   }
 
   const handleDrop = (event: DragEvent, target: DragItem) => {
     event.preventDefault()
     event.stopPropagation()
-    if (!dragging || dragging.id === target.id || !dragOver) {
+    const activeDragging = dragStateRef.current.dragging ?? readDraggedItem(event.dataTransfer.getData('text/plain'))
+    if (!activeDragging || activeDragging.id === target.id) {
       clearDragState()
       return
     }
 
-    if (dragging.kind === 'key') {
-      const draggedKey = keys.find((key) => key.id === dragging.id)
-      if (draggedKey && target.kind === 'folder' && dragOver.position === 'inside') {
-        const siblingOrders = keys
-          .filter((key) => key.id !== dragging.id && assignments[key.id] === target.id)
-          .map((key) => orderOf(key.id, key.importedAt))
-        const nextAssignments = { ...assignments, [dragging.id]: target.id }
-        const nextItemOrder = { ...itemOrder, [dragging.id]: Math.max(0, ...siblingOrders, 0) + 1000 }
-        persistUiState(folders, nextAssignments, nextItemOrder)
-        setExpandedFolderIds((current) => new Set(current).add(target.id))
-      } else if (draggedKey && (target.kind === 'key' || target.kind === 'folder')) {
-        const parentId = target.kind === 'key' ? assignments[target.id] : undefined
-        reorderItems(dragging, target, parentId, dragOver.position)
-      }
-    } else if (dragging.kind === 'folder' && dragOver.position !== 'inside') {
-      const targetParentId = target.kind === 'key' ? assignments[target.id] : undefined
-      if (!targetParentId) reorderItems(dragging, target, undefined, dragOver.position)
+    let activeDragOver = dragStateRef.current.dragOver
+    if (!activeDragOver || activeDragOver.id !== target.id) {
+      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
+      const y = event.clientY - rect.top
+      const position: DragPosition =
+        target.kind === 'folder' && activeDragging.kind === 'key' && y >= rect.height * 0.25 && y <= rect.height * 0.75
+          ? 'inside'
+          : y < rect.height * 0.5
+            ? 'top'
+            : 'bottom'
+      activeDragOver = { ...target, position }
     }
+
+    applyDrop(activeDragging, target, activeDragOver.position)
     clearDragState()
   }
 
@@ -454,7 +545,8 @@ export function SshKeyManagerPage({
     <SshKeyRow
       key={key.id}
       className={`${className} ${isKeyDragOver(key.id)}`.trim()}
-      draggable
+      draggable={false}
+      onPointerDown={(event) => handlePointerDown(event, { kind: 'key', id: key.id })}
       item={key}
       onDragStart={(event) => handleDragStart(event, { kind: 'key', id: key.id })}
       onDragOver={(event) => handleDragOver(event, { kind: 'key', id: key.id })}
@@ -500,6 +592,8 @@ export function SshKeyManagerPage({
               dragOver?.id === ROOT_DROP_TARGET_ID ? 'drag-over' : ''
             }`}
             type="button"
+            data-fileterm-sort-id={ROOT_DROP_TARGET_ID}
+            data-fileterm-sort-kind="root"
             onClick={() => setActiveFolderId('all')}
             onDragOver={handleRootDragOver}
             onDragLeave={handleRootDragLeave}
@@ -517,6 +611,8 @@ export function SshKeyManagerPage({
               key={folder.id}
               className={`connection-manager-sidebar-item ${activeFolderId === folder.id ? 'active' : ''}`}
               type="button"
+              data-fileterm-sort-id={folder.id}
+              data-fileterm-sort-kind="folder"
               onClick={() => setActiveFolderId(folder.id)}
             >
               <span className="connection-manager-sidebar-icon">
@@ -589,7 +685,10 @@ export function SshKeyManagerPage({
                           role="button"
                           tabIndex={0}
                           className={`manager-row folder-row ssh-key-folder-row ${folderDragClass}`.trim()}
-                          draggable
+                          data-fileterm-sort-id={folder.id}
+                          data-fileterm-sort-kind="folder"
+                          draggable={false}
+                          onPointerDown={(event) => handlePointerDown(event, { kind: 'folder', id: folder.id })}
                           onDragStart={(event) => handleDragStart(event, { kind: 'folder', id: folder.id })}
                           onDragOver={(event) => handleDragOver(event, { kind: 'folder', id: folder.id })}
                           onDragLeave={(event) => {
@@ -779,7 +878,8 @@ function SshKeyRow({
   onDragOver,
   onDragLeave,
   onDrop,
-  onDragEnd
+  onDragEnd,
+  onPointerDown
 }: {
   item: SshKeyMetadata
   className?: string
@@ -791,11 +891,15 @@ function SshKeyRow({
   onDragLeave?(event: DragEvent): void
   onDrop?(event: DragEvent): void
   onDragEnd?(): void
+  onPointerDown?(event: ReactPointerEvent): void
 }) {
   return (
     <div
       className={`manager-row ssh-key-manager-row${className ? ` ${className}` : ''}`}
       draggable={draggable}
+      data-fileterm-sort-id={item.id}
+      data-fileterm-sort-kind="key"
+      onPointerDown={onPointerDown}
       onDragStart={onDragStart}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}

--- a/apps/tauri/src/renderer/features/transfers/TransferPopover.tsx
+++ b/apps/tauri/src/renderer/features/transfers/TransferPopover.tsx
@@ -163,6 +163,7 @@ export function TransferPopover({
         {visibleTransfers.length ? (
           visibleTransfers.map((transfer) => {
             const transferSizeText = getTransferSizeText(transfer)
+            const progress = Math.round(Math.max(0, Math.min(100, Number(transfer.progress) || 0)))
             return (
               <div className={`transfer-row transfer-${transfer.status}`} key={transfer.id}>
                 <div className="transfer-row-head">
@@ -230,14 +231,14 @@ export function TransferPopover({
                       transfer.direction === 'upload' ? t.upload : t.download,
                       transferSizeText,
                       transfer.speed,
-                      `${transfer.progress}%`
+                      `${progress}%`
                     ]
                       .filter(Boolean)
                       .join(' · ')}
                   </span>
                 </div>
                 <i className="transfer-progress">
-                  <b style={{ width: `${transfer.progress}%` }} />
+                  <b style={{ width: `${progress}%` }} />
                 </i>
                 {transfer.message ? <small title={transfer.message}>{transfer.message}</small> : null}
               </div>

--- a/apps/tauri/src/renderer/hooks/useFileOperations.ts
+++ b/apps/tauri/src/renderer/hooks/useFileOperations.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, type Dispatch, type DragEvent, type SetStateAction } from 'react'
+import { useEffect, useRef, useState, type Dispatch, type DragEvent, type SetStateAction } from 'react'
 import type {
   ConnectionProfile,
   FileTermDesktopApi,
@@ -260,6 +260,34 @@ export function useFileOperations({
   const [rootAccessDialog, setRootAccessDialog] = useState<RootAccessDialogState | null>(null)
   const [rootAccessDialogError, setRootAccessDialogError] = useState<string | null>(null)
   const [isRootAccessSubmitting, setIsRootAccessSubmitting] = useState(false)
+  const nativeRemoteDropTargetAtRef = useRef(0)
+  const nativeDropConsumedAtRef = useRef(0)
+
+  useEffect(() => {
+    const markRemoteDropTarget = () => {
+      nativeRemoteDropTargetAtRef.current = Date.now()
+    }
+
+    const markNativeRemoteDropTarget = (event: Event) => {
+      const position = (event as CustomEvent<{ position?: { x?: number; y?: number } }>).detail?.position
+      if (typeof position?.x !== 'number' || typeof position.y !== 'number') return
+      const ratio = window.devicePixelRatio || 1
+      const targets = [
+        document.elementFromPoint(position.x, position.y),
+        document.elementFromPoint(position.x / ratio, position.y / ratio)
+      ]
+      if (targets.some((target) => target?.closest('.remote-pane'))) {
+        nativeRemoteDropTargetAtRef.current = Date.now()
+      }
+    }
+
+    window.addEventListener('fileterm:tauri-remote-dragover', markRemoteDropTarget)
+    window.addEventListener('fileterm:tauri-native-drag-over', markNativeRemoteDropTarget)
+    return () => {
+      window.removeEventListener('fileterm:tauri-remote-dragover', markRemoteDropTarget)
+      window.removeEventListener('fileterm:tauri-native-drag-over', markNativeRemoteDropTarget)
+    }
+  }, [])
 
   useEffect(() => {
     if (!fileClipboard) {
@@ -822,11 +850,62 @@ export function useFileOperations({
     }
   }
 
+  useEffect(() => {
+    const handleNativeDrop = (event: Event) => {
+      const detail = (event as CustomEvent).detail as {
+        paths?: unknown
+        position?: { x?: unknown; y?: unknown } | null
+      }
+      const paths = Array.isArray(detail?.paths)
+        ? detail.paths.filter((path): path is string => typeof path === 'string' && path.length > 0)
+        : []
+      const position = detail?.position
+      if (!paths.length || !position || typeof position.x !== 'number' || typeof position.y !== 'number') {
+        return
+      }
+
+      // Finder dragover marks the remote pane explicitly. Keep both raw and
+      // high-DPI-adjusted coordinate probes as a fallback: Tauri's macOS
+      // position unit differs between WebKit/runtime versions.
+      const targetMarkedByDragOver = Date.now() - nativeRemoteDropTargetAtRef.current < 1_500
+      const ratio = window.devicePixelRatio || 1
+      const targets = [
+        document.elementFromPoint(position.x, position.y),
+        document.elementFromPoint(position.x / ratio, position.y / ratio)
+      ]
+      if (!targetMarkedByDragOver && !targets.some((target) => target?.closest('.remote-pane'))) {
+        return
+      }
+      nativeRemoteDropTargetAtRef.current = 0
+      nativeDropConsumedAtRef.current = Date.now()
+
+      void (async () => {
+        try {
+          onBusyChange(true)
+          await uploadLocalPaths(paths)
+        } catch (error) {
+          reportStatusError('上传文件', error)
+        } finally {
+          onBusyChange(false)
+        }
+      })()
+    }
+
+    window.addEventListener('fileterm:tauri-native-drop', handleNativeDrop)
+    return () => window.removeEventListener('fileterm:tauri-native-drop', handleNativeDrop)
+  }, [activeSession, activeTab, desktopApi, onBusyChange, reportStatusError, uploadLocalPaths])
+
   const handleDropUpload = async (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault()
     const localPaths = extractDroppedLocalPaths(event, desktopApi)
 
     if (!localPaths.length || !desktopApi || !activeTab || !activeSession) {
+      // The native event may have already started this Finder upload. Do not
+      // overwrite that success path with a misleading "desktop only" notice
+      // when WebKit follows it with an empty DOM FileList.
+      if (Date.now() - nativeDropConsumedAtRef.current < 1_500) {
+        return
+      }
       onStatusMessage(t.desktopOnlyUpload)
       return
     }

--- a/apps/tauri/src/renderer/hooks/usePointerSortFallback.ts
+++ b/apps/tauri/src/renderer/hooks/usePointerSortFallback.ts
@@ -1,0 +1,169 @@
+import { useEffect, useRef, type PointerEvent as ReactPointerEvent } from 'react'
+
+export type PointerSortTarget = {
+  id: string
+  kind: string
+  element: HTMLElement
+}
+
+type PointerSortState<T> = {
+  source: T
+  sourceElement: HTMLElement
+  pressX: number
+  pressY: number
+  originLeft: number
+  originTop: number
+  dragStartX: number
+  dragStartY: number
+  active: boolean
+} | null
+
+const TARGET_SELECTOR = '[data-fileterm-sort-id]'
+const INTERACTIVE_SELECTOR = 'button, input, textarea, select, a, [contenteditable="true"]'
+
+/**
+ * Tauri's macOS WebView does not consistently complete HTML5 drag/drop for
+ * in-page sortable rows. This uses pointer movement as the authoritative
+ * local-sort path while leaving native drag/drop available for external files.
+ */
+export function usePointerSortFallback<T>({
+  onStart,
+  onTarget,
+  onDrop,
+  onCancel
+}: {
+  onStart(source: T): void
+  onTarget(source: T, target: PointerSortTarget, clientY: number): void
+  onDrop(source: T, target: PointerSortTarget | null, clientY: number): void
+  onCancel(): void
+}) {
+  const stateRef = useRef<PointerSortState<T>>(null)
+  const ghostRef = useRef<HTMLElement | null>(null)
+  const callbacksRef = useRef({ onStart, onTarget, onDrop, onCancel })
+  callbacksRef.current = { onStart, onTarget, onDrop, onCancel }
+
+  useEffect(() => {
+    const resolveTarget = (clientX: number, clientY: number): PointerSortTarget | null => {
+      const element = document.elementFromPoint(clientX, clientY)?.closest<HTMLElement>(TARGET_SELECTOR)
+      if (!element) return null
+      const id = element.dataset.filetermSortId
+      const kind = element.dataset.filetermSortKind
+      return id && kind ? { id, kind, element } : null
+    }
+
+    const removeGhost = () => {
+      ghostRef.current?.remove()
+      ghostRef.current = null
+      document.documentElement.classList.remove('fileterm-pointer-sorting')
+    }
+
+    const moveGhost = (state: NonNullable<PointerSortState<T>>, clientX: number, clientY: number) => {
+      const ghost = ghostRef.current
+      if (!ghost) return
+      ghost.style.transform = `translate3d(${Math.round(state.originLeft + clientX - state.dragStartX)}px, ${Math.round(state.originTop + clientY - state.dragStartY)}px, 0)`
+    }
+
+    const createGhost = (sourceElement: HTMLElement, clientX: number, clientY: number) => {
+      removeGhost()
+      const rect = sourceElement.getBoundingClientRect()
+      const computed = window.getComputedStyle(sourceElement)
+      const ghost = sourceElement.cloneNode(true) as HTMLElement
+      ghost.classList.add('fileterm-pointer-sort-ghost')
+      ghost.setAttribute('aria-hidden', 'true')
+      Object.assign(ghost.style, {
+        position: 'fixed',
+        inset: '0 auto auto 0',
+        display: computed.display,
+        width: `${rect.width}px`,
+        height: `${rect.height}px`,
+        gridTemplateColumns: computed.gridTemplateColumns,
+        columnGap: computed.columnGap,
+        padding: computed.padding,
+        border: computed.border,
+        borderRadius: computed.borderRadius,
+        background: computed.background,
+        color: computed.color,
+        font: computed.font,
+        boxSizing: computed.boxSizing,
+        opacity: '0.78',
+        pointerEvents: 'none',
+        zIndex: '2147483647',
+        overflow: 'hidden',
+        boxShadow: '0 3px 10px rgb(0 0 0 / 18%)',
+        transition: 'none',
+        willChange: 'transform'
+      })
+      document.body.appendChild(ghost)
+      ghostRef.current = ghost
+      const state = stateRef.current
+      if (state) moveGhost(state, clientX, clientY)
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const state = stateRef.current
+      if (!state) return
+
+      if (!state.active) {
+        const dx = event.clientX - state.pressX
+        const dy = event.clientY - state.pressY
+        if (dx * dx + dy * dy < 25) return
+        state.active = true
+        // Match Chromium's native drag image: when dragging actually starts,
+        // its left/top still match the source row; later movement translates
+        // the image by the cursor's delta from this exact start frame.
+        state.dragStartX = event.clientX
+        state.dragStartY = event.clientY
+        createGhost(state.sourceElement, event.clientX, event.clientY)
+        document.documentElement.classList.add('fileterm-pointer-sorting')
+        callbacksRef.current.onStart(state.source)
+      }
+
+      moveGhost(state, event.clientX, event.clientY)
+      const target = resolveTarget(event.clientX, event.clientY)
+      if (target) callbacksRef.current.onTarget(state.source, target, event.clientY)
+    }
+
+    const handlePointerUp = (event: PointerEvent) => {
+      const state = stateRef.current
+      if (!state) return
+      stateRef.current = null
+      removeGhost()
+      if (!state.active) return
+      callbacksRef.current.onDrop(state.source, resolveTarget(event.clientX, event.clientY), event.clientY)
+    }
+
+    const handlePointerCancel = () => {
+      if (!stateRef.current) return
+      stateRef.current = null
+      removeGhost()
+      callbacksRef.current.onCancel()
+    }
+
+    window.addEventListener('pointermove', handlePointerMove, true)
+    window.addEventListener('pointerup', handlePointerUp, true)
+    window.addEventListener('pointercancel', handlePointerCancel, true)
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove, true)
+      window.removeEventListener('pointerup', handlePointerUp, true)
+      window.removeEventListener('pointercancel', handlePointerCancel, true)
+      removeGhost()
+    }
+  }, [])
+
+  return (event: ReactPointerEvent, source: T) => {
+    if (event.button !== 0 || !event.isPrimary) return
+    if (event.target instanceof Element && event.target.closest(INTERACTIVE_SELECTOR)) return
+    const rect = event.currentTarget.getBoundingClientRect()
+    stateRef.current = {
+      source,
+      sourceElement: event.currentTarget as HTMLElement,
+      pressX: event.clientX,
+      pressY: event.clientY,
+      originLeft: rect.left,
+      originTop: rect.top,
+      dragStartX: event.clientX,
+      dragStartY: event.clientY,
+      active: false
+    }
+  }
+}

--- a/apps/tauri/src/renderer/hooks/useWorkspaceIpcSync.ts
+++ b/apps/tauri/src/renderer/hooks/useWorkspaceIpcSync.ts
@@ -52,6 +52,16 @@ function useLatestRef<T>(value: T) {
   return ref
 }
 
+function isUploadPermissionFailure(transfer: TransferTask) {
+  if (transfer.direction !== 'upload' || !['failed', 'paused', 'interrupted'].includes(transfer.status)) {
+    return false
+  }
+
+  return /permission[\s_-]*denied|access[\s_-]*denied|operation[\s_-]*not[\s_-]*permitted|not[\s_-]*permitted|authorization[\s_-]*failed|\b(?:eacces|eperm)\b|权限不足|没有权限|无权|拒绝访问/i.test(
+    transfer.message ?? ''
+  )
+}
+
 export function useWorkspaceIpcSync({
   desktopApi,
   isMainWorkspaceWindow,
@@ -77,6 +87,7 @@ export function useWorkspaceIpcSync({
   const onErrorRef = useLatestRef(onError)
   const onStatusMessageRef = useLatestRef(onStatusMessage)
   const nextWindowCloseRequestIdRef = useRef(0)
+  const notifiedTransferFailuresRef = useRef(new Map<string, string>())
 
   const applySnapshot = useCallback((snapshot: WorkspaceSnapshot) => {
     setWorkspace(snapshot)
@@ -256,12 +267,26 @@ export function useWorkspaceIpcSync({
     const pendingMetrics: SessionMetricsUpdate[] = []
     const pendingTransfers: TransferTask[] = []
 
+    const processTransferUpdate = (transfer: TransferTask) => {
+      if (isMainWorkspaceWindow && isUploadPermissionFailure(transfer)) {
+        const notificationKey = `${transfer.status}:${transfer.updatedAt ?? ''}:${transfer.message ?? ''}`
+        if (notifiedTransferFailuresRef.current.get(transfer.id) !== notificationKey) {
+          notifiedTransferFailuresRef.current.set(transfer.id, notificationKey)
+          onStatusMessageRef.current(t.uploadPermissionDenied)
+        }
+      } else if (!['failed', 'paused', 'interrupted'].includes(transfer.status)) {
+        notifiedTransferFailuresRef.current.delete(transfer.id)
+      }
+
+      applyTransferUpdate(transfer)
+    }
+
     const flushPendingUpdates = () => {
       for (const payload of pendingMetrics.splice(0)) {
         applySessionMetrics(payload)
       }
       for (const transfer of pendingTransfers.splice(0)) {
-        applyTransferUpdate(transfer)
+        processTransferUpdate(transfer)
       }
     }
 
@@ -300,7 +325,7 @@ export function useWorkspaceIpcSync({
         pendingTransfers.push(transfer)
         return
       }
-      applyTransferUpdate(transfer)
+      processTransferUpdate(transfer)
     })
 
     const hydrateWorkspace = async () => {

--- a/apps/tauri/src/renderer/i18n.ts
+++ b/apps/tauri/src/renderer/i18n.ts
@@ -281,6 +281,8 @@ const zhCN = {
   transferFinalizing: '正在替换目标文件',
   noTransferTasks: '暂无传输任务',
   uploadFailed: '上传失败',
+  uploadPermissionDenied:
+    '上传失败：当前账号没有向目标目录写入的权限。请切换到有写入权限的目录，或使用 root 文件访问模式后重试。',
   downloadFailed: '下载失败',
   uploadCanceled: '上传已终止',
   downloadCanceled: '下载已终止',
@@ -766,6 +768,8 @@ const enUS: typeof zhCN = {
   transferFinalizing: 'Replacing target file',
   noTransferTasks: 'No transfer tasks',
   uploadFailed: 'Upload Failed',
+  uploadPermissionDenied:
+    'Upload failed: the current account does not have write permission for the target directory. Choose a writable directory or retry with root file access.',
   downloadFailed: 'Download Failed',
   uploadCanceled: 'Upload Canceled',
   downloadCanceled: 'Download Canceled',

--- a/apps/tauri/src/renderer/main.tsx
+++ b/apps/tauri/src/renderer/main.tsx
@@ -13,8 +13,10 @@ const initialWindowMode = new URLSearchParams(window.location.search).get('windo
 document.documentElement.dataset.runtime = 'tauri'
 document.documentElement.classList.toggle('tauri-standalone-window', initialWindowMode !== 'main')
 
-// Global window dragging handler for Tauri custom titlebars
-window.addEventListener('mousedown', (e) => {
+// Global window dragging handler for Tauri custom titlebars. Capture the event
+// before Monaco/child controls can stop propagation; the drag-region checks
+// below still keep buttons, tabs, and editable content interactive.
+const handleWindowMouseDown = (e: MouseEvent) => {
   // Only trigger dragging on left-click
   if (e.button !== 0) return
 
@@ -57,13 +59,13 @@ window.addEventListener('mousedown', (e) => {
   }
 
   if (isDragRegion) {
-    try {
-      getCurrentWindow().startDragging()
-    } catch (err) {
-      console.error('Failed to start window dragging:', err)
-    }
+    void getCurrentWindow()
+      .startDragging()
+      .catch((err) => console.error('Failed to start window dragging:', err))
   }
-})
+}
+
+window.addEventListener('mousedown', handleWindowMouseDown, true)
 
 window.fileterm = createTauriApi()
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/apps/tauri/src/renderer/styles/features/confirm-dialog.css
+++ b/apps/tauri/src/renderer/styles/features/confirm-dialog.css
@@ -59,6 +59,13 @@
     color 0.18s ease;
 }
 
+.confirm-action-dialog__button .button-spinner {
+  display: inline-block;
+  flex: 0 0 auto;
+  box-sizing: border-box;
+  vertical-align: middle;
+}
+
 .confirm-action-dialog__button--secondary {
   border: 1px solid var(--dialog-button-secondary-border);
   background: var(--dialog-button-secondary-bg);

--- a/apps/tauri/src/renderer/styles/features/modal-components.css
+++ b/apps/tauri/src/renderer/styles/features/modal-components.css
@@ -724,6 +724,13 @@
   background-color: var(--text-main);
 }
 
+/* Pointer-sort previews replace Chromium's native drag image in Tauri. The
+   target row's hover rail must not show through the semi-transparent preview. */
+:root.fileterm-pointer-sorting .manager-row:hover::before,
+.fileterm-pointer-sort-ghost::before {
+  background-color: transparent !important;
+}
+
 .manager-row:hover {
   background-color: var(--bg-hover);
 }


### PR DESCRIPTION
## What changed

- Restored Tauri-specific window, manager, drag-and-drop, and file-editor interaction parity.
- Restored manager ordering, folder moves, delete loading feedback, and native Finder uploads.
- Added concise transfer progress and an upload-permission banner for SFTP permission failures.

## Impact

Electron remains the default application and is not changed by this PR. The diff is limited to the Tauri app.

## Validation

- `npm run typecheck`
- `npm run lint --max-warnings=0`
- `npm run format:check`
- `npm run test:electron`
- `npm run test:tauri`
- `npm run test:transfers:protocol -w @fileterm/electron`
- `npm run build:renderer -w @fileterm/tauri`