### PR TITLE
fix(workspace): stabilize file panel alignment

### DIFF
--- a/apps/electron/src/renderer/features/workspace/SessionWorkspace.tsx
+++ b/apps/electron/src/renderer/features/workspace/SessionWorkspace.tsx
@@ -137,6 +137,8 @@ export function SessionWorkspace({
   const isResizingFilePanel = useRef(false)
   const dragStateRef = useRef<{ bottom: number; height: number; snapHeight: number | null } | null>(null)
   const layoutFrameRef = useRef<number | null>(null)
+  const isFilePanelAlignedRef = useRef(false)
+  const alignmentInitializedTabRef = useRef<string | null>(null)
   const lastExpandedFilePanelHeight = useRef(filePanelHeight)
   const appliedWorkspaceFocusMode = useRef<boolean | null>(null)
   const isFilePanelEffectivelyCollapsed = isFilePanelCollapsed && !isFileOnly
@@ -238,9 +240,11 @@ export function SessionWorkspace({
       const { bottom, height, snapHeight } = dragStateRef.current
       let nextHeight = bottom - event.clientY
 
-      if (snapHeight !== null && Math.abs(nextHeight - snapHeight) <= 10) {
+      const isSnappedToSidebar = snapHeight !== null && Math.abs(nextHeight - snapHeight) <= 10
+      if (isSnappedToSidebar) {
         nextHeight = snapHeight
       }
+      isFilePanelAlignedRef.current = isSnappedToSidebar
 
       if (dragFrame) {
         window.cancelAnimationFrame(dragFrame)
@@ -278,12 +282,31 @@ export function SessionWorkspace({
   }, [isFileOnly, setFilePanelHeight])
 
   useEffect(() => {
-    if (!shouldAlignFilePanelOnMount || isFileOnly || isFilePanelCollapsed) {
+    if (isFileOnly || isFilePanelCollapsed) {
       return
     }
+    if (alignmentInitializedTabRef.current === activeTab.id) {
+      return
+    }
+    if (shouldAlignFilePanelOnMount) {
+      // Mark the default state synchronously. Updating the initial height can
+      // flip `shouldAlignFilePanelOnMount` before the animation frame runs;
+      // the follow state must survive that render.
+      isFilePanelAlignedRef.current = true
+    }
+    alignmentInitializedTabRef.current = activeTab.id
 
     const frame = window.requestAnimationFrame(() => {
-      syncFilePanelHeight('align')
+      if (shouldAlignFilePanelOnMount) {
+        syncFilePanelHeight('align')
+        return
+      }
+
+      const fileTabsRect = workspaceRef.current?.querySelector('.file-tabs')?.getBoundingClientRect()
+      const diskHeadRect = document.querySelector('.disk-head')?.getBoundingClientRect()
+      isFilePanelAlignedRef.current = Boolean(
+        fileTabsRect && diskHeadRect && Math.abs(fileTabsRect.top - diskHeadRect.top) <= 2
+      )
     })
 
     return () => window.cancelAnimationFrame(frame)
@@ -301,7 +324,7 @@ export function SessionWorkspace({
 
       layoutFrameRef.current = window.requestAnimationFrame(() => {
         layoutFrameRef.current = null
-        syncFilePanelHeight()
+        syncFilePanelHeight(isFilePanelAlignedRef.current ? 'align' : 'clamp')
       })
     }
 

--- a/apps/electron/src/renderer/styles/features/session.css
+++ b/apps/electron/src/renderer/styles/features/session.css
@@ -769,7 +769,6 @@
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
   transition:
-    bottom 0.24s cubic-bezier(0.22, 1, 0.36, 1),
     background 0.18s ease,
     border-color 0.18s ease,
     color 0.18s ease,

--- a/apps/tauri/src/renderer/features/workspace/SessionWorkspace.tsx
+++ b/apps/tauri/src/renderer/features/workspace/SessionWorkspace.tsx
@@ -137,6 +137,8 @@ export function SessionWorkspace({
   const isResizingFilePanel = useRef(false)
   const dragStateRef = useRef<{ bottom: number; height: number; snapHeight: number | null } | null>(null)
   const layoutFrameRef = useRef<number | null>(null)
+  const isFilePanelAlignedRef = useRef(false)
+  const alignmentInitializedTabRef = useRef<string | null>(null)
   const lastExpandedFilePanelHeight = useRef(filePanelHeight)
   const appliedWorkspaceFocusMode = useRef<boolean | null>(null)
   const isFilePanelEffectivelyCollapsed = isFilePanelCollapsed && !isFileOnly
@@ -238,9 +240,11 @@ export function SessionWorkspace({
       const { bottom, height, snapHeight } = dragStateRef.current
       let nextHeight = bottom - event.clientY
 
-      if (snapHeight !== null && Math.abs(nextHeight - snapHeight) <= 10) {
+      const isSnappedToSidebar = snapHeight !== null && Math.abs(nextHeight - snapHeight) <= 10
+      if (isSnappedToSidebar) {
         nextHeight = snapHeight
       }
+      isFilePanelAlignedRef.current = isSnappedToSidebar
 
       if (dragFrame) {
         window.cancelAnimationFrame(dragFrame)
@@ -278,12 +282,31 @@ export function SessionWorkspace({
   }, [isFileOnly, setFilePanelHeight])
 
   useEffect(() => {
-    if (!shouldAlignFilePanelOnMount || isFileOnly || isFilePanelCollapsed) {
+    if (isFileOnly || isFilePanelCollapsed) {
       return
     }
+    if (alignmentInitializedTabRef.current === activeTab.id) {
+      return
+    }
+    if (shouldAlignFilePanelOnMount) {
+      // Mark the default state synchronously. Updating the initial height can
+      // flip `shouldAlignFilePanelOnMount` before the animation frame runs;
+      // the follow state must survive that render.
+      isFilePanelAlignedRef.current = true
+    }
+    alignmentInitializedTabRef.current = activeTab.id
 
     const frame = window.requestAnimationFrame(() => {
-      syncFilePanelHeight('align')
+      if (shouldAlignFilePanelOnMount) {
+        syncFilePanelHeight('align')
+        return
+      }
+
+      const fileTabsRect = workspaceRef.current?.querySelector('.file-tabs')?.getBoundingClientRect()
+      const diskHeadRect = document.querySelector('.disk-head')?.getBoundingClientRect()
+      isFilePanelAlignedRef.current = Boolean(
+        fileTabsRect && diskHeadRect && Math.abs(fileTabsRect.top - diskHeadRect.top) <= 2
+      )
     })
 
     return () => window.cancelAnimationFrame(frame)
@@ -301,7 +324,7 @@ export function SessionWorkspace({
 
       layoutFrameRef.current = window.requestAnimationFrame(() => {
         layoutFrameRef.current = null
-        syncFilePanelHeight()
+        syncFilePanelHeight(isFilePanelAlignedRef.current ? 'align' : 'clamp')
       })
     }
 

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -769,7 +769,6 @@
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
   transition:
-    bottom 0.24s cubic-bezier(0.22, 1, 0.36, 1),
     background 0.18s ease,
     border-color 0.18s ease,
     color 0.18s ease,


### PR DESCRIPTION
## Summary
- keep newly aligned file panels in the snapped alignment state during window resize
- make the file-panel drawer control follow its height anchor without delayed bottom-position animation
- keep Electron and Tauri workspace behavior and styles in parity

## Validation
- npm run typecheck
- npm run lint -- --max-warnings=0
- npm run format:check