### PR TITLE
fix: align Tauri parity and manager interactions

### DIFF
--- a/apps/electron/src/main/services/sessions/ssh-session-controller.ts
+++ b/apps/electron/src/main/services/sessions/ssh-session-controller.ts
@@ -1563,8 +1563,9 @@ fi
 
   async refreshSystemMetrics(): Promise<SystemMetrics | undefined> {
     const profile = this.profile as SshProfile
-    if (profile.enableExecChannel === false) {
-      return this.metrics
+    if (profile.enableExecChannel === false || profile.enableResourceMonitoring === false) {
+      this.metrics = undefined
+      return undefined
     }
 
     if (this.metricsRefreshPromise) {

--- a/apps/electron/src/main/services/workspace/workspace-session-runtime.ts
+++ b/apps/electron/src/main/services/workspace/workspace-session-runtime.ts
@@ -897,6 +897,11 @@ export class WorkspaceSessionRuntime extends EventEmitter<WorkspaceSessionRuntim
   private startMetricsPolling(tabId: string, controller: LiveSshSessionController) {
     if (!this.shouldPollMetrics(controller)) {
       this.stopMetricsPolling(tabId)
+      const current = this.sessions.get(tabId)
+      if (current?.systemMetrics) {
+        this.sessions.set(tabId, { ...current, systemMetrics: undefined })
+        this.emitMetricsForTab(tabId)
+      }
       return
     }
     const existing = this.metricsPollers.get(tabId)
@@ -922,7 +927,7 @@ export class WorkspaceSessionRuntime extends EventEmitter<WorkspaceSessionRuntim
 
   private shouldPollMetrics(controller: LiveSshSessionController) {
     const profile = controller['profile']
-    return profile.type !== 'ssh' || (profile.enableExecChannel !== false && profile.enableResourceMonitoring !== false)
+    return profile.type === 'ssh' && profile.enableExecChannel !== false && profile.enableResourceMonitoring !== false
   }
 
   private async refreshMetricsForTab(tabId: string, controller: LiveSshSessionController) {

--- a/apps/electron/src/preload/preload.cts
+++ b/apps/electron/src/preload/preload.cts
@@ -45,6 +45,8 @@ const api: FileTermDesktopApi = {
   arch: typeof process !== 'undefined' ? process.arch : 'unknown',
   appVersion: process.env['FILETERM_APP_VERSION'] ?? '0.0.0',
   appName: 'FileTerm',
+  runtimeName: 'Electron',
+  runtimeVersion: typeof process !== 'undefined' ? process.versions.electron : 'unknown',
   isDesktop: true,
   getUpdateStatus: () => ipcRenderer.invoke('app:getUpdateStatus'),
   checkForUpdates: () => ipcRenderer.invoke('app:checkForUpdates'),

--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -247,6 +247,8 @@ export function App() {
     : false
   const activeWorkspaceFocusKey = activeTab?.id ?? effectiveActiveLocalTabId
   const isWorkspaceFocusMode = activeWorkspaceFocusKey ? (workspaceFocusModes[activeWorkspaceFocusKey] ?? false) : false
+  const isResourceMonitoringAvailable =
+    activeProfile?.type === 'ssh' && activeProfile.enableResourceMonitoring !== false
   const activeTabId = activeTab?.id ?? null
   const setActiveFilePanelHeight = useCallback(
     (next: SetStateAction<number>) => {
@@ -287,11 +289,17 @@ export function App() {
       return
     }
 
-    setIsSystemSidebarCollapsed(isWorkspaceFocusMode)
+    setIsSystemSidebarCollapsed(isWorkspaceFocusMode || !isResourceMonitoringAvailable)
     if (!isWorkspaceFocusMode) {
       setSidebarWidth(214)
     }
-  }, [activeWorkspaceFocusKey, isHomeWorkspaceVisible, isWorkspaceFocusMode, setIsSystemSidebarCollapsed])
+  }, [
+    activeWorkspaceFocusKey,
+    isHomeWorkspaceVisible,
+    isResourceMonitoringAvailable,
+    isWorkspaceFocusMode,
+    setIsSystemSidebarCollapsed
+  ])
 
   // 3. Workspace Modals Hook
   const {
@@ -1134,12 +1142,8 @@ export function App() {
           <SystemSidebarShell
             activeProfile={activeProfile}
             activeSession={activeSession}
-            collapsed={
-              isSystemSidebarCollapsed ||
-              (activeProfile?.type === 'ssh' && activeProfile.enableResourceMonitoring === false)
-            }
-            showResourceMeters={activeProfile?.type !== 'ssh' || activeProfile.enableResourceMonitoring !== false}
-            showToggle={activeProfile?.type !== 'ssh' || activeProfile.enableResourceMonitoring !== false}
+            collapsed={isSystemSidebarCollapsed}
+            showResourceMeters={isResourceMonitoringAvailable}
             isResizing={isResizingSidebar}
             onOpenSystemInfo={openSystemInfo}
             onResizeStart={() => setIsResizingSidebar(true)}

--- a/apps/electron/src/renderer/features/commands/CommandManagerModal.tsx
+++ b/apps/electron/src/renderer/features/commands/CommandManagerModal.tsx
@@ -5,6 +5,8 @@ import { t } from '../../i18n'
 import { CommandEditorModal, emptyCommandForm, toCommandTemplateInput } from './CommandEditorModal'
 import { AppIcon } from '../common/AppIcon'
 import { CloseButton } from '../common/CloseButton'
+import { ManagerInlineFolderRow } from '../common/ManagerInlineFolderRow'
+import { managerDropClass, resolveManagerDropPosition } from '../common/manager-drag'
 
 type CommandTreeNode = (CommandFolder & { children: CommandTreeNode[] }) | (CommandTemplate & { children?: never })
 
@@ -198,19 +200,7 @@ export function CommandManagerModal({
     e.stopPropagation()
     if (draggingId === targetId) return
 
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-    const y = e.clientY - rect.top
-    const height = rect.height
-
-    let pos: 'top' | 'bottom' | 'inside' = 'bottom'
-    if (type === 'command-folder') {
-      if (y < height * 0.25) pos = 'top'
-      else if (y > height * 0.75) pos = 'bottom'
-      else pos = 'inside'
-    } else {
-      if (y < height * 0.5) pos = 'top'
-      else pos = 'bottom'
-    }
+    const pos = resolveManagerDropPosition(e.currentTarget as HTMLElement, e.clientY, type === 'command-folder')
 
     setDragOverId(targetId)
     setDragPosition(pos)
@@ -343,10 +333,7 @@ export function CommandManagerModal({
     const isDragOver = dragOverId === node.id
     const isDragging = draggingId === node.id
 
-    let dropClass = ''
-    if (isDragOver && dragPosition) {
-      dropClass = `drop-${dragPosition}`
-    }
+    const dropClass = managerDropClass(isDragOver, dragPosition)
 
     return (
       <div key={node.id}>
@@ -568,36 +555,17 @@ export function CommandManagerModal({
             </div>
             <div className="manager-body connection-manager-body">
               {isCreatingFolder && resolvedActiveFolderId === 'all' && (
-                <div className="manager-row folder-row">
-                  <span className="manager-name-cell">
-                    <span className="folder-icon manager-folder-toggle">
-                      <AppIcon name="chevron-right" size={12} />
-                    </span>
-                    <input
-                      type="text"
-                      autoFocus
-                      value={newFolderName}
-                      onChange={(e) => setNewFolderName(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && newFolderName.trim()) {
-                          onCreateFolder(newFolderName.trim())
-                          setIsCreatingFolder(false)
-                        } else if (e.key === 'Escape') {
-                          setIsCreatingFolder(false)
-                        }
-                      }}
-                      onBlur={() => {
-                        if (newFolderName.trim()) onCreateFolder(newFolderName.trim())
-                        setIsCreatingFolder(false)
-                      }}
-                      className="manager-inline-input"
-                      placeholder={t.folderName}
-                    />
-                  </span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span></span>
-                </div>
+                <ManagerInlineFolderRow
+                  afterNameCells={['--', '--', null]}
+                  placeholder={t.folderName}
+                  value={newFolderName}
+                  onChange={setNewFolderName}
+                  onCommit={onCreateFolder}
+                  onDismiss={() => {
+                    setIsCreatingFolder(false)
+                    setNewFolderName('')
+                  }}
+                />
               )}
               {visibleNodes.map((node) => renderNode(node, 0, { includeChildren: !isSearching }))}
               {visibleNodes.length === 0 && !(isCreatingFolder && resolvedActiveFolderId === 'all') && (

--- a/apps/electron/src/renderer/features/common/ManagerInlineFolderRow.tsx
+++ b/apps/electron/src/renderer/features/common/ManagerInlineFolderRow.tsx
@@ -1,0 +1,71 @@
+import { useRef, type ReactNode } from 'react'
+import { AppIcon } from './AppIcon'
+
+export function ManagerInlineFolderRow({
+  value,
+  placeholder,
+  afterNameCells,
+  className = '',
+  onChange,
+  onCommit,
+  onDismiss
+}: {
+  value: string
+  placeholder: string
+  afterNameCells: ReactNode[]
+  className?: string
+  onChange(value: string): void
+  onCommit(name: string): boolean | void | Promise<boolean | void>
+  onDismiss(): void
+}) {
+  const isCommittingRef = useRef(false)
+
+  const commit = async () => {
+    if (isCommittingRef.current) return
+    const name = value.trim()
+    if (!name) {
+      onDismiss()
+      return
+    }
+
+    isCommittingRef.current = true
+    try {
+      const result = await onCommit(name)
+      if (result !== false) onDismiss()
+    } finally {
+      isCommittingRef.current = false
+    }
+  }
+
+  return (
+    <div className={`manager-row folder-row ${className}`.trim()}>
+      <span className="manager-name-cell">
+        <span className="folder-icon manager-folder-toggle">
+          <AppIcon name="chevron-right" size={12} />
+        </span>
+        <input
+          autoFocus
+          aria-label={placeholder}
+          className="manager-inline-input"
+          placeholder={placeholder}
+          type="text"
+          value={value}
+          onBlur={() => void commit()}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault()
+              void commit()
+            } else if (event.key === 'Escape') {
+              event.preventDefault()
+              onDismiss()
+            }
+          }}
+        />
+      </span>
+      {afterNameCells.map((cell, index) => (
+        <span key={index}>{cell}</span>
+      ))}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/features/common/manager-drag.ts
+++ b/apps/electron/src/renderer/features/common/manager-drag.ts
@@ -1,0 +1,20 @@
+export type ManagerDropPosition = 'top' | 'bottom' | 'inside'
+
+export function resolveManagerDropPosition(
+  element: HTMLElement,
+  clientY: number,
+  canDropInside: boolean
+): ManagerDropPosition {
+  const rect = element.getBoundingClientRect()
+  const y = clientY - rect.top
+  if (canDropInside) {
+    if (y < rect.height * 0.25) return 'top'
+    if (y > rect.height * 0.75) return 'bottom'
+    return 'inside'
+  }
+  return y < rect.height * 0.5 ? 'top' : 'bottom'
+}
+
+export function managerDropClass(isActiveTarget: boolean, position: ManagerDropPosition | null) {
+  return isActiveTarget && position ? `drop-${position}` : ''
+}

--- a/apps/electron/src/renderer/features/connections/ConnectionManagerModal.tsx
+++ b/apps/electron/src/renderer/features/connections/ConnectionManagerModal.tsx
@@ -4,6 +4,8 @@ import { ConfirmActionDialog } from '../common/ConfirmActionDialog'
 import { t } from '../../i18n'
 import { AppIcon } from '../common/AppIcon'
 import { CloseButton } from '../common/CloseButton'
+import { ManagerInlineFolderRow } from '../common/ManagerInlineFolderRow'
+import { managerDropClass, resolveManagerDropPosition } from '../common/manager-drag'
 
 type ConnectionTreeNode =
   (ConnectionFolder & { children: ConnectionTreeNode[] }) | (ConnectionProfile & { children?: never })
@@ -204,19 +206,7 @@ export function ConnectionManagerModal({
     e.stopPropagation()
     if (draggingId === targetId) return
 
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-    const y = e.clientY - rect.top
-    const height = rect.height
-
-    let pos: 'top' | 'bottom' | 'inside' = 'bottom'
-    if (type === 'folder') {
-      if (y < height * 0.25) pos = 'top'
-      else if (y > height * 0.75) pos = 'bottom'
-      else pos = 'inside'
-    } else {
-      if (y < height * 0.5) pos = 'top'
-      else pos = 'bottom'
-    }
+    const pos = resolveManagerDropPosition(e.currentTarget as HTMLElement, e.clientY, type === 'folder')
 
     setDragOverId(targetId)
     setDragPosition(pos)
@@ -334,10 +324,7 @@ export function ConnectionManagerModal({
     const isDragOver = dragOverId === node.id
     const isDragging = draggingId === node.id
 
-    let dropClass = ''
-    if (isDragOver && dragPosition) {
-      dropClass = `drop-${dragPosition}`
-    }
+    const dropClass = managerDropClass(isDragOver, dragPosition)
 
     return (
       <div key={node.id}>
@@ -566,39 +553,26 @@ export function ConnectionManagerModal({
             </div>
             <div className="manager-body connection-manager-body">
               {isCreatingFolder && resolvedActiveFolderId === 'all' && (
-                <div className="manager-row folder-row">
-                  <span className="manager-name-cell">
-                    <span className="folder-icon manager-folder-toggle">
-                      <AppIcon name="chevron-right" size={12} />
-                    </span>
-                    <input
-                      type="text"
-                      autoFocus
-                      value={newFolderName}
-                      onChange={(e) => setNewFolderName(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && newFolderName.trim()) {
-                          onCreateFolder(newFolderName.trim())
-                          setIsCreatingFolder(false)
-                        } else if (e.key === 'Escape') {
-                          setIsCreatingFolder(false)
-                        }
-                      }}
-                      onBlur={() => {
-                        if (newFolderName.trim()) onCreateFolder(newFolderName.trim())
-                        setIsCreatingFolder(false)
-                      }}
-                      className="manager-inline-input"
-                      placeholder={t.folderName}
-                    />
-                  </span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span className="manager-type-badge is-folder">{t.homeFolderType}</span>
-                  <span>--</span>
-                  <span></span>
-                </div>
+                <ManagerInlineFolderRow
+                  afterNameCells={[
+                    '--',
+                    '--',
+                    '--',
+                    <span className="manager-type-badge is-folder" key="type">
+                      {t.homeFolderType}
+                    </span>,
+                    '--',
+                    null
+                  ]}
+                  placeholder={t.folderName}
+                  value={newFolderName}
+                  onChange={setNewFolderName}
+                  onCommit={onCreateFolder}
+                  onDismiss={() => {
+                    setIsCreatingFolder(false)
+                    setNewFolderName('')
+                  }}
+                />
               )}
               {visibleNodes.map((node) => renderNode(node, 0, { includeChildren: !isSearching }))}
               {visibleNodes.length === 0 && !(isCreatingFolder && resolvedActiveFolderId === 'all') && (

--- a/apps/electron/src/renderer/features/settings/SettingsModal.tsx
+++ b/apps/electron/src/renderer/features/settings/SettingsModal.tsx
@@ -67,7 +67,9 @@ export function SettingsModal({
     const platform = desktopApi?.platform ?? 'unknown'
     const arch = desktopApi?.arch ?? 'unknown'
     if (platform === 'darwin') {
-      return arch === 'arm64' ? 'macOS (Apple Silicon)' : 'macOS (Intel)'
+      if (arch === 'arm64') return 'macOS (Apple Silicon)'
+      if (arch === 'x64' || arch === 'x86_64') return 'macOS (Intel)'
+      return `macOS (${arch})`
     }
     if (platform === 'win32') {
       return arch === 'arm64' ? 'Windows (ARM)' : `Windows (${arch})`
@@ -429,8 +431,8 @@ export function SettingsModal({
                     <span className="info-value">v{desktopApi?.appVersion ?? '—'}</span>
                   </div>
                   <div className="about-info-item">
-                    <span className="info-label">Electron</span>
-                    <span className="info-value">v42.4.0</span>
+                    <span className="info-label">{desktopApi?.runtimeName ?? '—'}</span>
+                    <span className="info-value">v{desktopApi?.runtimeVersion ?? '—'}</span>
                   </div>
                   <div className="about-info-item">
                     <span className="info-label">{t.environmentInfo}</span>

--- a/apps/electron/src/renderer/features/ssh-keys/SshKeyManagerPage.tsx
+++ b/apps/electron/src/renderer/features/ssh-keys/SshKeyManagerPage.tsx
@@ -2,6 +2,8 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type DragE
 import type { SshKeyMetadata } from '@fileterm/core'
 import { AppIcon } from '../common/AppIcon'
 import { ConfirmActionDialog } from '../common/ConfirmActionDialog'
+import { ManagerInlineFolderRow } from '../common/ManagerInlineFolderRow'
+import { managerDropClass, resolveManagerDropPosition, type ManagerDropPosition } from '../common/manager-drag'
 import { useSshKeyLibrary } from '../../hooks/useSshKeyLibrary'
 import { SshKeyNoteDialog } from './SshKeyNoteDialog'
 import { t } from '../../i18n'
@@ -22,7 +24,7 @@ type SshKeyManagerUiState = {
 
 type DeleteTarget = { kind: 'folder' | 'key'; id: string; name: string }
 type DragItem = { kind: 'folder' | 'key'; id: string }
-type DragPosition = 'top' | 'bottom' | 'inside'
+type DragPosition = ManagerDropPosition
 type SortableItem = { kind: DragItem['kind']; id: string; fallbackOrder: number }
 
 const ROOT_DROP_TARGET_ID = '__ssh-key-root__'
@@ -166,11 +168,8 @@ export function SshKeyManagerPage({
     onStatsChange?.({ keyCount: keys.length, folderCount: folders.length })
   }, [folders.length, keys.length, onStatsChange])
 
-  const finishFolderCreation = () => {
-    const name = newFolderName.trim()
-    setIsCreatingFolder(false)
-    setNewFolderName('')
-    if (!name || folders.some((folder) => folder.name === name)) return
+  const finishFolderCreation = (name: string) => {
+    if (folders.some((folder) => folder.name === name)) return false
 
     const folder = { id: createId('ssh-folder'), name }
     const rootOrders = [
@@ -183,6 +182,7 @@ export function SshKeyManagerPage({
       ...itemOrder,
       [folder.id]: Math.max(0, ...rootOrders) + 1000
     })
+    return true
   }
 
   const saveFolderRename = () => {
@@ -252,13 +252,11 @@ export function SshKeyManagerPage({
     event.stopPropagation()
     if (!dragging || dragging.id === target.id) return
 
-    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
-    const y = event.clientY - rect.top
-    const height = rect.height
-    let position: DragPosition = y < height * 0.5 ? 'top' : 'bottom'
-    if (target.kind === 'folder' && dragging.kind === 'key' && y >= height * 0.25 && y <= height * 0.75) {
-      position = 'inside'
-    }
+    const position = resolveManagerDropPosition(
+      event.currentTarget as HTMLElement,
+      event.clientY,
+      target.kind === 'folder' && dragging.kind === 'key'
+    )
     setDragOver({ ...target, position })
   }
 
@@ -435,13 +433,11 @@ export function SshKeyManagerPage({
   const folderForKey = (keyId: string) => assignments[keyId] ?? ''
 
   const isFolderDragOver = (folderId: string) => {
-    if (!dragOver || dragOver.id !== folderId) return ''
-    return `drop-${dragOver.position}`
+    return managerDropClass(dragOver?.id === folderId, dragOver?.position ?? null)
   }
 
   const isKeyDragOver = (keyId: string) => {
-    if (!dragOver || dragOver.id !== keyId) return ''
-    return `drop-${dragOver.position}`
+    return managerDropClass(dragOver?.id === keyId, dragOver?.position ?? null)
   }
 
   const openNewKeyDialog = () => {
@@ -541,35 +537,18 @@ export function SshKeyManagerPage({
             <div className="manager-body connection-manager-body">
               {error && !noteDialog ? <div className="ssh-key-manager-error">{error}</div> : null}
               {isCreatingFolder && activeFolderId === 'all' ? (
-                <div className="manager-row folder-row ssh-key-folder-create-row">
-                  <span className="ssh-key-folder-name-cell">
-                    <span className="folder-icon manager-folder-toggle">
-                      <AppIcon name="chevron-right" size={12} />
-                    </span>
-                    <input
-                      autoFocus
-                      aria-label="文件夹名称"
-                      className="manager-inline-input"
-                      placeholder="文件夹名称"
-                      type="text"
-                      value={newFolderName}
-                      onChange={(event) => setNewFolderName(event.target.value)}
-                      onBlur={finishFolderCreation}
-                      onKeyDown={(event) => {
-                        if (event.key === 'Enter') finishFolderCreation()
-                        if (event.key === 'Escape') {
-                          setIsCreatingFolder(false)
-                          setNewFolderName('')
-                        }
-                      }}
-                    />
-                  </span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span />
-                </div>
+                <ManagerInlineFolderRow
+                  afterNameCells={['--', '--', '--', '--', null]}
+                  className="ssh-key-folder-create-row"
+                  placeholder={t.folderName}
+                  value={newFolderName}
+                  onChange={setNewFolderName}
+                  onCommit={finishFolderCreation}
+                  onDismiss={() => {
+                    setIsCreatingFolder(false)
+                    setNewFolderName('')
+                  }}
+                />
               ) : null}
               {activeFolderId === 'all'
                 ? rootItems.map((rootItem) => {

--- a/apps/electron/src/renderer/features/system/SystemSidebar.tsx
+++ b/apps/electron/src/renderer/features/system/SystemSidebar.tsx
@@ -20,7 +20,6 @@ export function SystemSidebar({
   activeSession,
   collapsed,
   showResourceMeters,
-  showToggle,
   onOpenSystemInfo,
   onToggleCollapsed
 }: {
@@ -28,7 +27,6 @@ export function SystemSidebar({
   activeSession: SessionSnapshot | null
   collapsed: boolean
   showResourceMeters: boolean
-  showToggle: boolean
   onOpenSystemInfo(): void
   onToggleCollapsed(): void
 }) {
@@ -62,31 +60,29 @@ export function SystemSidebar({
 
   return (
     <div className={`system-sidebar-layout ${collapsed ? 'is-collapsed' : ''}`}>
-      {showToggle ? (
-        <button
-          aria-label={collapsed ? t.showSystemSidebar : t.hideSystemSidebar}
-          className={`system-sidebar-toggle ${collapsed ? 'is-collapsed' : ''}`}
-          onClick={onToggleCollapsed}
-          title={collapsed ? t.showSystemSidebar : t.hideSystemSidebar}
-          type="button"
+      <button
+        aria-label={collapsed ? t.showSystemSidebar : t.hideSystemSidebar}
+        className={`system-sidebar-toggle ${collapsed ? 'is-collapsed' : ''}`}
+        onClick={onToggleCollapsed}
+        title={collapsed ? t.showSystemSidebar : t.hideSystemSidebar}
+        type="button"
+      >
+        <svg
+          className="system-sidebar-toggle-icon"
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
         >
-          <svg
-            className="system-sidebar-toggle-icon"
-            width="14"
-            height="14"
-            viewBox="0 0 16 16"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <rect x="1.5" y="1.5" width="13" height="13" rx="2.5" />
-            <path d="M5.25 1.5V14.5" />
-          </svg>
-        </button>
-      ) : null}
+          <rect x="1.5" y="1.5" width="13" height="13" rx="2.5" />
+          <path d="M5.25 1.5V14.5" />
+        </svg>
+      </button>
       {!collapsed ? (
         <>
           <section className="sys-card">

--- a/apps/electron/src/renderer/features/system/SystemSidebarShell.tsx
+++ b/apps/electron/src/renderer/features/system/SystemSidebarShell.tsx
@@ -7,7 +7,6 @@ export function SystemSidebarShell({
   activeSession,
   collapsed,
   showResourceMeters,
-  showToggle,
   isResizing,
   onOpenSystemInfo,
   onResizeStart,
@@ -18,7 +17,6 @@ export function SystemSidebarShell({
   activeSession: SessionSnapshot | null
   collapsed: boolean
   showResourceMeters: boolean
-  showToggle: boolean
   isResizing: boolean
   onOpenSystemInfo(): void
   onResizeStart(): void
@@ -32,7 +30,6 @@ export function SystemSidebarShell({
         activeSession={activeSession}
         collapsed={collapsed}
         showResourceMeters={showResourceMeters}
-        showToggle={showToggle}
         onOpenSystemInfo={onOpenSystemInfo}
         onToggleCollapsed={() => {
           const nextCollapsed = !collapsed

--- a/apps/electron/src/renderer/features/workspace/SshTunnelPanel.tsx
+++ b/apps/electron/src/renderer/features/workspace/SshTunnelPanel.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import type { SshForwardRule, SshTunnelSnapshot } from '@fileterm/core'
 import { AppIcon } from '../common/AppIcon'
 import { CloseButton } from '../common/CloseButton'
+import { ConfirmActionDialog } from '../common/ConfirmActionDialog'
 
 const initialDraft = (): SshForwardRule => ({
   id: globalThis.crypto.randomUUID(),
@@ -215,9 +216,9 @@ function TunnelEditorDialog({ children, onClose }: { children: ReactNode; onClos
         role="dialog"
       >
         <header className="ssh-tunnel-dialog-header">
-          <div>
+          <div className="ssh-tunnel-dialog-title">
+            <AppIcon name="connections" size={16} />
             <span id="ssh-tunnel-dialog-title">新增运行时隧道</span>
-            <p>只在当前 SSH 工作区生效，关闭连接后自动停止。</p>
           </div>
           <CloseButton aria-label="关闭新增隧道窗口" onClick={onClose} size="compact" />
         </header>
@@ -242,6 +243,8 @@ function TunnelRow({
 }) {
   const running = tunnel.status === 'running' || tunnel.status === 'starting'
   const target = tunnel.kind === 'dynamic' ? 'SOCKS5' : `${tunnel.targetHost}:${tunnel.targetPort}`
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
   const update = async (action: () => Promise<SshTunnelSnapshot[]>) => {
     try {
       onChange(await action())
@@ -250,40 +253,64 @@ function TunnelRow({
       onError(cause instanceof Error ? cause.message : String(cause))
     }
   }
+
+  const deleteTunnel = async () => {
+    setIsDeleting(true)
+    try {
+      onChange(await window.fileterm!.deleteSshTunnel(tabId, tunnel.id))
+      onError(null)
+      setIsDeleteConfirmOpen(false)
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
   return (
-    <article className="ssh-tunnel-row">
-      <span className={`ssh-tunnel-status is-${tunnel.status}`} aria-label={tunnel.status} />
-      <div className="ssh-tunnel-description">
-        <strong>{tunnel.name || `${tunnel.kind.toUpperCase()} ${tunnel.bindPort}`}</strong>
-        <span>
-          {tunnel.kind.toUpperCase()} · {tunnel.bindHost}:{tunnel.bindPort} → {target}
-        </span>
-        {tunnel.error ? <em>{tunnel.error}</em> : null}
-      </div>
-      <span className="ssh-tunnel-state">{tunnel.status}</span>
-      <div className="ssh-tunnel-actions">
-        <button
-          type="button"
-          onClick={() =>
-            void update(() =>
-              running
-                ? window.fileterm!.stopSshTunnel(tabId, tunnel.id)
-                : window.fileterm!.startSshTunnel(tabId, tunnel.id)
-            )
-          }
-        >
-          {running ? '停止' : '启动'}
-        </button>
-        {tunnel.runtimeOnly ? (
+    <>
+      <article className="ssh-tunnel-row">
+        <span className={`ssh-tunnel-status is-${tunnel.status}`} aria-label={tunnel.status} />
+        <div className="ssh-tunnel-description">
+          <strong>{tunnel.name || `${tunnel.kind.toUpperCase()} ${tunnel.bindPort}`}</strong>
+          <span>
+            {tunnel.kind.toUpperCase()} · {tunnel.bindHost}:{tunnel.bindPort} → {target}
+          </span>
+          {tunnel.error ? <em>{tunnel.error}</em> : null}
+        </div>
+        <span className="ssh-tunnel-state">{tunnel.status}</span>
+        <div className="ssh-tunnel-actions">
           <button
             type="button"
-            className="danger"
-            onClick={() => void update(() => window.fileterm!.deleteSshTunnel(tabId, tunnel.id))}
+            onClick={() =>
+              void update(() =>
+                running
+                  ? window.fileterm!.stopSshTunnel(tabId, tunnel.id)
+                  : window.fileterm!.startSshTunnel(tabId, tunnel.id)
+              )
+            }
           >
-            删除
+            {running ? '停止' : '启动'}
           </button>
-        ) : null}
-      </div>
-    </article>
+          {tunnel.runtimeOnly ? (
+            <button type="button" className="danger" onClick={() => setIsDeleteConfirmOpen(true)}>
+              删除
+            </button>
+          ) : null}
+        </div>
+      </article>
+      {isDeleteConfirmOpen ? (
+        <ConfirmActionDialog
+          confirmLabel="删除"
+          description={`确定删除隧道“${tunnel.name || `${tunnel.kind.toUpperCase()} ${tunnel.bindPort}`}”吗？删除后 ${tunnel.bindHost}:${tunnel.bindPort} 的监听会立即停止，且无法恢复。`}
+          isSubmitting={isDeleting}
+          onClose={() => {
+            if (!isDeleting) setIsDeleteConfirmOpen(false)
+          }}
+          onConfirm={() => void deleteTunnel()}
+          title="删除隧道"
+        />
+      ) : null}
+    </>
   )
 }

--- a/apps/electron/src/renderer/styles/features/session.css
+++ b/apps/electron/src/renderer/styles/features/session.css
@@ -2707,29 +2707,29 @@
   color: var(--text-main);
   font-family: var(--font-mono, monospace);
 }
-.ssh-tunnel-dialog {
+.modal-card.ssh-tunnel-dialog {
   width: min(560px, calc(100vw - 40px));
-  padding: 0;
+  padding: 0 !important;
+  overflow: hidden;
 }
 .ssh-tunnel-dialog-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 18px 20px 14px;
+  min-height: 48px;
+  padding: 0 16px;
   border-bottom: 1px solid var(--border-light);
 }
-.ssh-tunnel-dialog-header span {
-  display: block;
+.ssh-tunnel-dialog-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   color: var(--text-main);
-  font-size: 15px;
-  font-weight: 600;
 }
-.ssh-tunnel-dialog-header p {
-  margin: 4px 0 0;
-  color: var(--text-muted);
-  font-size: 12px;
-  line-height: 1.5;
+.ssh-tunnel-dialog-title > span {
+  font-size: 13px;
+  font-weight: 500;
 }
 .ssh-tunnel-form {
   display: grid;
@@ -2781,6 +2781,9 @@
   grid-column: 1 / -1;
   align-self: end;
   justify-content: end;
+  margin: 6px -20px -20px;
+  padding: 16px 20px;
+  border-top: 1px solid var(--border-light);
 }
 .ssh-tunnel-form-actions .flat-button {
   min-width: 76px;

--- a/apps/electron/src/renderer/styles/features/ssh-keys.css
+++ b/apps/electron/src/renderer/styles/features/ssh-keys.css
@@ -139,8 +139,8 @@
 }
 
 .ssh-key-folder-create-row {
-  min-height: 48px !important;
-  height: 48px !important;
+  min-height: 36px !important;
+  height: 36px !important;
   color: var(--text-main);
   box-sizing: border-box;
 }
@@ -149,7 +149,7 @@
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
 }
 
 .ssh-key-folder-row {
@@ -159,11 +159,6 @@
 
 .ssh-key-folder-row strong {
   font-weight: 500;
-}
-
-.ssh-key-folder-row.drop-inside {
-  background: var(--selection-bg) !important;
-  box-shadow: inset 3px 0 0 var(--accent-primary);
 }
 
 .ssh-key-nested-row {
@@ -182,25 +177,6 @@
 .ssh-key-empty-folder span {
   grid-column: 1 / -1;
   padding-left: 28px;
-}
-
-.ssh-key-folder-create-row input {
-  width: 100%;
-  min-width: 0;
-  max-width: 280px;
-  padding: 4px 8px;
-  border: 1px solid var(--accent-primary);
-  border-radius: 6px;
-  outline: 0;
-  background: var(--input-bg);
-  color: var(--text-main);
-  font: inherit;
-  font-size: 13px;
-  box-sizing: border-box;
-}
-
-.ssh-key-folder-create-row input:focus {
-  box-shadow: 0 0 0 2px var(--accent-focus-ring);
 }
 
 .ssh-private-key-field {

--- a/apps/electron/src/renderer/styles/themes/default-dark.css
+++ b/apps/electron/src/renderer/styles/themes/default-dark.css
@@ -1335,6 +1335,7 @@
 :root[data-theme='default-dark'] .manager-row.drop-inside,
 :root[data-theme='default'] .manager-row.drop-inside {
   background: var(--selection-bg);
+  box-shadow: inset 3px 0 0 var(--accent-primary);
 }
 
 :root:not([data-theme]) .folder-row,
@@ -3170,5 +3171,36 @@
 :root:not([data-theme]) .ssh-key-import-dialog .ssh-key-import-dialog__file-name,
 :root[data-theme='default-dark'] .ssh-key-import-dialog .ssh-key-import-dialog__file-name,
 :root[data-theme='default'] .ssh-key-import-dialog .ssh-key-import-dialog__file-name {
+  background: #1a1a1a !important;
+}
+
+/* Runtime tunnel editor follows the command editor's neutral dark surface hierarchy. */
+:root:not([data-theme]) .ssh-tunnel-dialog,
+:root[data-theme='default-dark'] .ssh-tunnel-dialog,
+:root[data-theme='default'] .ssh-tunnel-dialog,
+:root:not([data-theme]) .ssh-tunnel-form,
+:root[data-theme='default-dark'] .ssh-tunnel-form,
+:root[data-theme='default'] .ssh-tunnel-form {
+  background: #1b1b1b !important;
+}
+
+:root:not([data-theme]) .ssh-tunnel-form-actions,
+:root[data-theme='default-dark'] .ssh-tunnel-form-actions,
+:root[data-theme='default'] .ssh-tunnel-form-actions {
+  background: #1b1b1b !important;
+}
+
+:root:not([data-theme]) .ssh-tunnel-dialog-header,
+:root[data-theme='default-dark'] .ssh-tunnel-dialog-header,
+:root[data-theme='default'] .ssh-tunnel-dialog-header {
+  background: #242424 !important;
+}
+
+:root:not([data-theme]) .ssh-tunnel-form input,
+:root[data-theme='default-dark'] .ssh-tunnel-form input,
+:root[data-theme='default'] .ssh-tunnel-form input,
+:root:not([data-theme]) .ssh-tunnel-form select,
+:root[data-theme='default-dark'] .ssh-tunnel-form select,
+:root[data-theme='default'] .ssh-tunnel-form select {
   background: #1a1a1a !important;
 }

--- a/apps/electron/src/renderer/styles/themes/default-light.css
+++ b/apps/electron/src/renderer/styles/themes/default-light.css
@@ -941,7 +941,11 @@
   background: #eef2f7;
 }
 
-:root[data-theme='default-light'] .manager-row.drop-inside,
+:root[data-theme='default-light'] .manager-row.drop-inside {
+  background: var(--selection-bg);
+  box-shadow: inset 3px 0 0 var(--accent-primary);
+}
+
 :root[data-theme='default-light'] .folder-row {
   background: rgba(148, 163, 184, 0.08);
 }

--- a/apps/electron/test/controllers/ssh-session-controller.test.mjs
+++ b/apps/electron/test/controllers/ssh-session-controller.test.mjs
@@ -384,3 +384,17 @@ test('SSH controller injects shell setup only after a confirmed Linux probe', as
   )
   await controller.disconnect()
 })
+
+test('SSH controller does not collect metrics when resource monitoring is disabled', async () => {
+  const exec = new FakeSshClient()
+  const controller = createController(createProfile({ enableExecChannel: true, enableResourceMonitoring: false }), {
+    main: new FakeSshClient(),
+    exec,
+    sftp: new FakeSshClient(),
+    transfer: new FakeSshClient()
+  })
+
+  assert.equal(await controller.refreshSystemMetrics(), undefined)
+  assert.equal(exec.connectCalls.length, 0)
+  assert.equal(exec.execCommands.length, 0)
+})

--- a/apps/tauri/src-tauri/src/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/mod.rs
@@ -116,9 +116,50 @@ pub fn app_get_platform() -> String {
     std::env::consts::OS.to_string()
 }
 
+fn canonical_arch(arch: &str) -> String {
+    match arch {
+        "aarch64" => "arm64".to_string(),
+        "x86_64" => "x64".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn resolve_native_arch(platform: &str, process_arch: &str, macos_arm64_capable: bool) -> String {
+    if platform == "macos" && macos_arm64_capable {
+        return "arm64".to_string();
+    }
+
+    canonical_arch(process_arch)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_arm64_capable() -> bool {
+    std::process::Command::new("/usr/sbin/sysctl")
+        .args(["-n", "hw.optional.arm64"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .is_some_and(|value| value.trim() == "1")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn macos_arm64_capable() -> bool {
+    false
+}
+
 #[tauri::command]
 pub fn app_get_arch() -> String {
-    std::env::consts::ARCH.to_string()
+    resolve_native_arch(
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        macos_arm64_capable(),
+    )
+}
+
+#[tauri::command]
+pub fn app_get_runtime_version() -> String {
+    tauri::VERSION.to_string()
 }
 
 #[tauri::command]
@@ -207,44 +248,57 @@ pub fn app_set_ui_preferences(app: AppHandle, input: UiPreferencesInput) -> Resu
     Ok(())
 }
 
+fn normalize_ui_state(value: Value) -> Result<serde_json::Map<String, Value>, AppError> {
+    match value {
+        Value::Object(mut object) => {
+            let mut states = object
+                .remove("values")
+                .and_then(|value| value.as_object().cloned())
+                .unwrap_or_default();
+            object.remove("version");
+            states.extend(object);
+            Ok(states)
+        }
+        Value::Array(items) => Ok(items
+            .into_iter()
+            .filter_map(|item| {
+                let key = item.get("key")?.as_str()?.to_string();
+                let value = item.get("value")?.clone();
+                Some((key, value))
+            })
+            .collect()),
+        _ => Err(AppError::Serialization("UI 状态文件格式无效".to_string())),
+    }
+}
+
+fn read_ui_state(app: &AppHandle) -> Result<serde_json::Map<String, Value>, AppError> {
+    normalize_ui_state(crate::storage::read_json_object(app, "ui-state.json")?)
+}
+
+fn write_ui_state(app: &AppHandle, states: serde_json::Map<String, Value>) -> Result<(), AppError> {
+    write_json_object(app, "ui-state.json", &Value::Object(states))
+}
+
 #[tauri::command]
 pub fn app_get_ui_state_item(app: AppHandle, key: String) -> Result<Option<String>, AppError> {
-    let states = read_json_array(&app, "ui-state.json")?;
-    for state in states {
-        if state.get("key").and_then(|k| k.as_str()) == Some(&key) {
-            return Ok(state.get("value").and_then(|v| v.as_str()).map(ToString::to_string));
-        }
-    }
-    Ok(None)
+    Ok(read_ui_state(&app)?
+        .get(&key)
+        .and_then(Value::as_str)
+        .map(ToString::to_string))
 }
 
 #[tauri::command]
 pub fn app_set_ui_state_item(app: AppHandle, key: String, value: String) -> Result<(), AppError> {
-    let mut states = read_json_array(&app, "ui-state.json")?;
-    let mut found = false;
-    for state in &mut states {
-        if state.get("key").and_then(|k| k.as_str()) == Some(&key) {
-            if let Some(obj) = state.as_object_mut() {
-                obj.insert("value".to_string(), Value::String(value.clone()));
-                found = true;
-                break;
-            }
-        }
-    }
-    if !found {
-        states.push(serde_json::json!({ "key": key, "value": value }));
-    }
-    write_json_array(&app, "ui-state.json", &states)
+    let mut states = read_ui_state(&app)?;
+    states.insert(key, Value::String(value));
+    write_ui_state(&app, states)
 }
 
 #[tauri::command]
 pub fn app_remove_ui_state_item(app: AppHandle, key: String) -> Result<(), AppError> {
-    let states = read_json_array(&app, "ui-state.json")?;
-    let next_states: Vec<Value> = states
-        .into_iter()
-        .filter(|state| state.get("key").and_then(|k| k.as_str()) != Some(&key))
-        .collect();
-    write_json_array(&app, "ui-state.json", &next_states)
+    let mut states = read_ui_state(&app)?;
+    states.remove(&key);
+    write_ui_state(&app, states)
 }
 
 #[tauri::command]
@@ -586,6 +640,10 @@ pub fn app_open_window(
     crate::open_child_window(&app, input)
 }
 
+fn renderer_approved_close_should_destroy(window_label: &str) -> bool {
+    window_label != "main"
+}
+
 #[tauri::command]
 pub async fn app_window_action(
     app: AppHandle,
@@ -616,13 +674,23 @@ pub async fn app_window_action(
             );
         }
         "close" => {
-            // User confirmed close in the renderer — bypass the
-            // `CloseRequested` guard (which would re-emit
-            // `app:window-close-request` and loop forever) by destroying the
-            // window directly via the raw handle. `window.close()` re-fires
-            // `CloseRequested`, so we use `window.destroy()` instead.
-            crate::resolve_file_editor_close(&app, &window);
-            let _ = window.destroy();
+            if !renderer_approved_close_should_destroy(window.label()) {
+                // Match Electron: closing the last workspace item requests a
+                // normal main-window close. The CloseRequested guard decides
+                // whether to hide to tray, quit, or cancel.
+                let _ = window.close();
+            } else {
+                // A child renderer has already approved this close. Destroy it
+                // directly so file-editor CloseRequested does not ask twice.
+                crate::resolve_file_editor_close(&app, &window);
+                let _ = window.destroy();
+            }
+        }
+        "hide" => {
+            crate::hide_main_window_and_children(&app);
+        }
+        "request-quit" => {
+            crate::request_main_window_close(&app, true);
         }
         "quit" => {
             // Quit the entire app. Used by the renderer when the user
@@ -874,6 +942,9 @@ pub async fn app_open_profile(
             shell_user: None,
             connected: false,
             system_metrics: None,
+            capabilities: crate::services::workspace::ConnectionCapabilities::for_session_type(
+                profile_type,
+            ),
         });
     }
 
@@ -1754,6 +1825,68 @@ mod command_template_tests {
                 "cn-north".to_string(),
             ]),
             "deploy api --region cn-north --empty="
+        );
+    }
+}
+
+#[cfg(test)]
+mod architecture_tests {
+    use super::resolve_native_arch;
+
+    #[test]
+    fn reports_apple_silicon_when_x64_process_runs_under_rosetta() {
+        assert_eq!(resolve_native_arch("macos", "x86_64", true), "arm64");
+    }
+
+    #[test]
+    fn canonicalizes_native_rust_architecture_names() {
+        assert_eq!(resolve_native_arch("macos", "aarch64", true), "arm64");
+        assert_eq!(resolve_native_arch("macos", "x86_64", false), "x64");
+        assert_eq!(resolve_native_arch("linux", "x86_64", false), "x64");
+    }
+}
+
+#[cfg(test)]
+mod window_lifecycle_tests {
+    use super::renderer_approved_close_should_destroy;
+
+    #[test]
+    fn main_window_close_keeps_the_lifecycle_guard() {
+        assert!(!renderer_approved_close_should_destroy("main"));
+        assert!(renderer_approved_close_should_destroy("file-editor-local-1"));
+        assert!(renderer_approved_close_should_destroy("connection-manager"));
+    }
+}
+
+#[cfg(test)]
+mod ui_state_tests {
+    use super::normalize_ui_state;
+
+    #[test]
+    fn reads_current_object_ui_state() {
+        let states = normalize_ui_state(serde_json::json!({ "main.tab-ui": "tabs" })).unwrap();
+        assert_eq!(states.get("main.tab-ui").and_then(|value| value.as_str()), Some("tabs"));
+    }
+
+    #[test]
+    fn migrates_electron_and_legacy_array_ui_state() {
+        let electron = normalize_ui_state(serde_json::json!({
+            "version": 1,
+            "values": { "ssh-key-manager-ui": "folders" }
+        }))
+        .unwrap();
+        assert_eq!(
+            electron.get("ssh-key-manager-ui").and_then(|value| value.as_str()),
+            Some("folders")
+        );
+
+        let legacy = normalize_ui_state(serde_json::json!([
+            { "key": "ssh-key-manager-ui", "value": "legacy-folders" }
+        ]))
+        .unwrap();
+        assert_eq!(
+            legacy.get("ssh-key-manager-ui").and_then(|value| value.as_str()),
+            Some("legacy-folders")
         );
     }
 }

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -3,8 +3,11 @@ pub mod services;
 pub mod sessions;
 pub mod storage;
 
+#[cfg(target_os = "macos")]
+use tauri::image::Image;
 use tauri::{
     menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     window::Color, AppHandle, Emitter, LogicalPosition, Manager, WebviewUrl, WebviewWindow,
     WebviewWindowBuilder, WindowEvent, Wry,
 };
@@ -45,6 +48,14 @@ impl serde::Serialize for AppError {
 #[derive(Default)]
 pub(crate) struct FileEditorCloseRegistry {
     pending_labels: Mutex<HashSet<String>>,
+}
+
+/// Windows hidden together with the main window must be restored together as
+/// well. This mirrors Electron's `childWindowsHiddenWithMain` lifecycle and
+/// avoids losing standalone managers/editors after a tray hide/show cycle.
+#[derive(Default)]
+struct HiddenWithMainRegistry {
+    labels: Mutex<HashSet<String>>,
 }
 
 impl FileEditorCloseRegistry {
@@ -113,6 +124,10 @@ fn application_menu_accelerators(platform: &str) -> (&'static str, &'static str)
     } else {
         ("Alt+F4", "Ctrl+W")
     }
+}
+
+fn tray_icon_should_be_template(platform: &str) -> bool {
+    platform == "macos"
 }
 
 fn focused_webview_window(app: &AppHandle<Wry>) -> Option<WebviewWindow<Wry>> {
@@ -370,6 +385,10 @@ fn window_url(input: &OpenWindowInput) -> WebviewUrl {
     WebviewUrl::App(format!("index.html?{}", window_query(input)).into())
 }
 
+fn child_window_should_be_transparent(platform: &str, decorations: bool) -> bool {
+    platform == "macos" && !decorations
+}
+
 pub fn open_child_window(app: &AppHandle, input: OpenWindowInput) -> Result<(), AppError> {
     let label = window_label(&input);
     if let Some(window) = app.get_webview_window(&label) {
@@ -382,6 +401,11 @@ pub fn open_child_window(app: &AppHandle, input: OpenWindowInput) -> Result<(), 
                 .destroy()
                 .map_err(|error| AppError::Window(error.to_string()))?;
         } else {
+            crate::services::logging::debug(
+                app,
+                "window",
+                format!("focus existing label={label} kind={}", input.kind),
+            );
             window
                 .show()
                 .map_err(|error| AppError::Window(error.to_string()))?;
@@ -403,6 +427,17 @@ pub fn open_child_window(app: &AppHandle, input: OpenWindowInput) -> Result<(), 
         _ => return Ok(()),
     };
 
+    // Frameless macOS windows need a transparent native surface so the
+    // renderer's rounded standalone frame can clip the four corners. Keep
+    // Windows/Linux opaque: transparent Wry windows there can flash during
+    // startup and have different shadow/compositor behaviour.
+    let transparent = child_window_should_be_transparent(std::env::consts::OS, decorations);
+    let background_color = if transparent {
+        Color(0, 0, 0, 0)
+    } else {
+        Color(21, 21, 21, 255)
+    };
+
     let window = WebviewWindowBuilder::new(app, &label, window_url(&input))
         .title(title)
         .inner_size(width, height)
@@ -412,11 +447,24 @@ pub fn open_child_window(app: &AppHandle, input: OpenWindowInput) -> Result<(), 
         // Match Electron's `show: false` + `ready-to-show` lifecycle. Wry
         // otherwise shows a transparent native frame before React and the
         // theme bootstrap have painted, which flashes twice on Windows.
-        .transparent(false)
-        .background_color(Color(21, 21, 21, 255))
+        .transparent(transparent)
+        .background_color(background_color)
+        .shadow(true)
         .visible(false)
         .build()
-        .map_err(|error| AppError::Window(error.to_string()))?;
+        .map_err(|error| {
+            crate::services::logging::error(
+                app,
+                "window",
+                format!("create failed label={label} kind={} error={error}", input.kind),
+            );
+            AppError::Window(error.to_string())
+        })?;
+    crate::services::logging::info(
+        app,
+        "window",
+        format!("created label={label} kind={}", input.kind),
+    );
     if input.kind == "file-editor" {
         let editor_window = window.clone();
         window.on_window_event(move |event| {
@@ -432,17 +480,63 @@ pub fn open_child_window(app: &AppHandle, input: OpenWindowInput) -> Result<(), 
 }
 
 fn show_main_window(app: &AppHandle<Wry>) {
+    let hidden_labels = {
+        let state = app.state::<HiddenWithMainRegistry>();
+        let mut labels = state
+            .labels
+            .lock()
+            .expect("hidden window registry lock poisoned");
+        labels.drain().collect::<Vec<_>>()
+    };
+
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.show();
         let _ = window.set_focus();
     }
+
+    for label in hidden_labels {
+        if label != "main" {
+            if let Some(window) = app.get_webview_window(&label) {
+                let _ = window.show();
+            }
+        }
+    }
 }
 
-fn request_main_close(app: &AppHandle<Wry>) {
+pub(crate) fn hide_main_window_and_children(app: &AppHandle<Wry>) {
+    let mut hidden_labels = HashSet::new();
+    for (label, window) in app.webview_windows() {
+        if window.is_visible().unwrap_or(false) {
+            let _ = window.hide();
+            hidden_labels.insert(label);
+        }
+    }
+
+    let state = app.state::<HiddenWithMainRegistry>();
+    *state
+        .labels
+        .lock()
+        .expect("hidden window registry lock poisoned") = hidden_labels;
+}
+
+fn toggle_main_window_visibility(app: &AppHandle<Wry>) {
+    let should_hide = app
+        .get_webview_window("main")
+        .is_some_and(|window| {
+            window.is_visible().unwrap_or(false) && window.is_focused().unwrap_or(false)
+        });
+    if should_hide {
+        hide_main_window_and_children(app);
+    } else {
+        show_main_window(app);
+    }
+}
+
+pub(crate) fn request_main_window_close(app: &AppHandle<Wry>, is_quit: bool) {
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.emit(
             "app:window-close-request",
-            serde_json::json!({ "isQuit": true }),
+            serde_json::json!({ "isQuit": is_quit }),
         );
     }
 }
@@ -451,8 +545,20 @@ fn request_main_close(app: &AppHandle<Wry>) {
 pub fn run() {
     tauri::Builder::default()
         .setup(|app| {
+            crate::services::logging::init(app.handle());
+            crate::services::logging::info(
+                app.handle(),
+                "app",
+                format!(
+                    "startup version={} platform={} arch={}",
+                    app.package_info().version,
+                    std::env::consts::OS,
+                    std::env::consts::ARCH
+                ),
+            );
             app.manage(crate::services::WorkspaceState::default());
             app.manage(FileEditorCloseRegistry::default());
+            app.manage(HiddenWithMainRegistry::default());
             app.manage(WindowMenuState::default());
 
             let main_window = app.get_webview_window("main")
@@ -474,8 +580,13 @@ pub fn run() {
             main_window.on_window_event(move |event| {
                 match event {
                     WindowEvent::CloseRequested { api, .. } => {
+                        crate::services::logging::info(
+                            &app_handle,
+                            "window",
+                            "main close requested",
+                        );
                         api.prevent_close();
-                        request_main_close(&app_handle);
+                        request_main_window_close(&app_handle, false);
                     }
                     WindowEvent::Resized(_) => {
                         if let Some(window) = app_handle.get_webview_window("main") {
@@ -589,9 +700,25 @@ pub fn run() {
                 .build()
                 .map_err(|error| error.to_string())?;
 
-            if let Some(tray) = app.tray_by_id("main") {
-                let _ = tray.set_menu(Some(tray_menu));
-                let _ = tray.on_menu_event(|app, event| match event.id().as_ref() {
+            #[cfg(target_os = "macos")]
+            // tray-icon renders the source at 18 logical points on macOS.
+            // Feed it the 36px Retina representation so the status item has
+            // one physical source pixel per output pixel on @2x displays.
+            let tray_icon = Image::from_bytes(include_bytes!("../../build/trayTemplate@2x.png"))
+                .map_err(|error| error.to_string())?;
+            #[cfg(not(target_os = "macos"))]
+            let tray_icon = app
+                .default_window_icon()
+                .cloned()
+                .ok_or_else(|| "Failed to load the default tray icon".to_string())?;
+
+            TrayIconBuilder::with_id("main")
+                .icon(tray_icon)
+                .icon_as_template(tray_icon_should_be_template(std::env::consts::OS))
+                .tooltip("FileTerm")
+                .menu(&tray_menu)
+                .show_menu_on_left_click(false)
+                .on_menu_event(|app, event| match event.id().as_ref() {
                     "tray-connection-manager" => {
                         let _ = open_child_window(
                             app,
@@ -627,10 +754,23 @@ pub fn run() {
                         );
                     }
                     "tray-show-main" => show_main_window(app),
-                    "tray-quit" => request_main_close(app),
+                    "tray-quit" => request_main_window_close(app, true),
                     _ => {}
-                });
-            }
+                })
+                .on_tray_icon_event(|tray, event| {
+                    if matches!(
+                        event,
+                        TrayIconEvent::Click {
+                            button: MouseButton::Left,
+                            button_state: MouseButtonState::Up,
+                            ..
+                        }
+                    ) {
+                        toggle_main_window_visibility(tray.app_handle());
+                    }
+                })
+                .build(app)
+                .map_err(|error| error.to_string())?;
 
             Ok(())
         })
@@ -727,12 +867,13 @@ pub fn run() {
             }
             "window-request-close" => request_close_focused_window(app),
             "show-main" => show_main_window(app),
-            "quit" => request_main_close(app),
+            "quit" => request_main_window_close(app, true),
             _ => {}
         })
         .invoke_handler(tauri::generate_handler![
             crate::commands::app_get_platform,
             crate::commands::app_get_arch,
+            crate::commands::app_get_runtime_version,
             crate::commands::app_read_clipboard_text,
             crate::commands::app_write_clipboard_text,
             crate::commands::app_open_external_url,
@@ -853,13 +994,31 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::{application_menu_accelerators, FileEditorCloseRegistry, WindowMenuKind};
+    use super::{
+        application_menu_accelerators, child_window_should_be_transparent, FileEditorCloseRegistry,
+        tray_icon_should_be_template, WindowMenuKind,
+    };
 
     #[test]
     fn keeps_mac_and_non_mac_window_shortcuts_distinct() {
         assert_eq!(application_menu_accelerators("macos"), ("Cmd+Q", "Cmd+W"));
         assert_eq!(application_menu_accelerators("windows"), ("Alt+F4", "Ctrl+W"));
         assert_eq!(application_menu_accelerators("linux"), ("Alt+F4", "Ctrl+W"));
+    }
+
+    #[test]
+    fn uses_template_tray_icons_on_macos_only() {
+        assert!(tray_icon_should_be_template("macos"));
+        assert!(!tray_icon_should_be_template("windows"));
+        assert!(!tray_icon_should_be_template("linux"));
+    }
+
+    #[test]
+    fn only_frameless_macos_child_windows_use_transparency() {
+        assert!(child_window_should_be_transparent("macos", false));
+        assert!(!child_window_should_be_transparent("macos", true));
+        assert!(!child_window_should_be_transparent("windows", false));
+        assert!(!child_window_should_be_transparent("linux", false));
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/services/logging.rs
+++ b/apps/tauri/src-tauri/src/services/logging.rs
@@ -6,6 +6,8 @@
 
 use std::fs::{self, OpenOptions};
 use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use tauri::AppHandle;
@@ -13,24 +15,43 @@ use tauri::AppHandle;
 use crate::storage::state_path;
 
 const MAX_LOG_BYTES: u64 = 2 * 1024 * 1024;
+static LOG_LOCK: Mutex<()> = Mutex::new(());
+static LOG_DIRECTORY: OnceLock<PathBuf> = OnceLock::new();
+static AUTHORIZATION_PATTERN: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r#"(?i)(authorization["']?\s*[:=]\s*["']?(?:bearer|basic)\s+)[^\s,;"'}]+"#,
+    )
+    .expect("static authorization redaction regex")
+});
+static SECRET_PATTERN: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r#"(?i)(password|passphrase|authorization|proxy[_-]?password|token)["']?\s*([:=])\s*["']?([^\s,;"'}]+)"#,
+    )
+    .expect("static redaction regex")
+});
 
 fn log_directory(app: &AppHandle) -> Option<std::path::PathBuf> {
     state_path(app).ok().map(|path| path.with_file_name("logs"))
 }
 
-fn redact(message: &str) -> String {
-    let pattern = regex::Regex::new(
-        r"(?i)(password|passphrase|authorization|proxy[_-]?password|token)\s*([:=])\s*([^\s,;]+)",
-    )
-    .expect("static redaction regex");
-    pattern.replace_all(message, "$1$2[REDACTED]").into_owned()
+pub fn init(app: &AppHandle) {
+    if let Some(directory) = log_directory(app) {
+        let _ = LOG_DIRECTORY.set(directory);
+    }
 }
 
-pub fn write(app: &AppHandle, level: &str, scope: &str, message: impl AsRef<str>) {
-    let Some(directory) = log_directory(app) else {
+fn redact(message: &str) -> String {
+    let message = AUTHORIZATION_PATTERN.replace_all(message, "$1[REDACTED]");
+    SECRET_PATTERN
+        .replace_all(&message, "$1$2[REDACTED]")
+        .into_owned()
+}
+
+fn append(directory: &Path, level: &str, scope: &str, message: &str) {
+    let Ok(_guard) = LOG_LOCK.lock() else {
         return;
     };
-    if fs::create_dir_all(&directory).is_err() {
+    if fs::create_dir_all(directory).is_err() {
         return;
     }
     let path = directory.join("app.log");
@@ -48,11 +69,77 @@ pub fn write(app: &AppHandle, level: &str, scope: &str, message: impl AsRef<str>
         .as_millis();
     let line = format!(
         "{timestamp} [{level}] [{scope}] {}\n",
-        redact(message.as_ref())
+        redact(message)
     );
     if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
         let _ = file.write_all(line.as_bytes());
     }
+}
+
+pub fn write(app: &AppHandle, level: &str, scope: &str, message: impl AsRef<str>) {
+    let Some(directory) = log_directory(app) else {
+        return;
+    };
+    append(&directory, level, scope, message.as_ref());
+}
+
+pub fn write_global(level: &str, scope: &str, message: impl AsRef<str>) {
+    let Some(directory) = LOG_DIRECTORY.get() else {
+        return;
+    };
+    append(directory, level, scope, message.as_ref());
+}
+
+pub fn debug(app: &AppHandle, scope: &str, message: impl AsRef<str>) {
+    write(app, "DEBUG", scope, message);
+}
+
+pub fn info(app: &AppHandle, scope: &str, message: impl AsRef<str>) {
+    write(app, "INFO", scope, message);
+}
+
+pub fn warn(app: &AppHandle, scope: &str, message: impl AsRef<str>) {
+    write(app, "WARN", scope, message);
+}
+
+pub fn error(app: &AppHandle, scope: &str, message: impl AsRef<str>) {
+    write(app, "ERROR", scope, message);
+}
+
+pub fn debug_global(scope: &str, message: impl AsRef<str>) {
+    write_global("DEBUG", scope, message);
+}
+
+pub fn info_global(scope: &str, message: impl AsRef<str>) {
+    write_global("INFO", scope, message);
+}
+
+pub fn warn_global(scope: &str, message: impl AsRef<str>) {
+    write_global("WARN", scope, message);
+}
+
+pub fn error_global(scope: &str, message: impl AsRef<str>) {
+    write_global("ERROR", scope, message);
+}
+
+pub fn error_chain(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut messages = vec![error.to_string()];
+    let mut source = error.source();
+    while let Some(cause) = source {
+        messages.push(cause.to_string());
+        source = cause.source();
+    }
+    messages.join(" <- ")
+}
+
+pub fn session(
+    app: &AppHandle,
+    level: &str,
+    protocol: &str,
+    tab_id: &str,
+    message: impl AsRef<str>,
+) {
+    write(app, level, &format!("{protocol}:{tab_id}"), message);
 }
 
 pub fn ssh_debug(app: &AppHandle, tab_id: &str, message: impl AsRef<str>) {
@@ -65,9 +152,21 @@ mod tests {
 
     #[test]
     fn strips_common_secret_labels() {
-        let line = redact("password=hunter2 Authorization: BearerSecret proxyPassword:abc");
+        let line = redact(
+            r##"password=hunter2 Authorization: Bearer very-secret Authorization=Basic encoded-secret proxyPassword:abc "passphrase":"private" token='opaque'"##,
+        );
         assert!(!line.contains("hunter2"));
         assert!(!line.contains("BearerSecret"));
+        assert!(!line.contains("very-secret"));
+        assert!(!line.contains("encoded-secret"));
         assert!(!line.contains("abc"));
+        assert!(!line.contains("private"));
+        assert!(!line.contains("opaque"));
+    }
+
+    #[test]
+    fn preserves_non_secret_diagnostics() {
+        let line = redact("session=tab-1 platform=windows cpu=12%");
+        assert_eq!(line, "session=tab-1 platform=windows cpu=12%");
     }
 }

--- a/apps/tauri/src-tauri/src/services/profile_ops.rs
+++ b/apps/tauri/src-tauri/src/services/profile_ops.rs
@@ -266,10 +266,7 @@ pub async fn update_trusted_host_fingerprint(
     profile_id: &str,
     fingerprint: &str,
 ) -> Result<(), AppError> {
-    eprintln!(
-        "[profile-ops] update_trusted_host_fingerprint profile_id='{}' fingerprint='{}'",
-        profile_id, fingerprint
-    );
+    crate::services::logging::info(app, "profile", "saving trusted host fingerprint");
     let app = app.clone();
     let profile_id = profile_id.to_string();
     let fingerprint = fingerprint.to_string();
@@ -288,9 +285,10 @@ pub async fn update_trusted_host_fingerprint(
                 found = true;
             }
         }
-        eprintln!(
-            "[profile-ops] update_trusted_host_fingerprint found_profile={} — writing profiles.json",
-            found
+        crate::services::logging::debug(
+            &app,
+            "profile",
+            format!("trusted host fingerprint profile_found={found}"),
         );
         let stripped: Vec<Value> = profiles.iter().map(strip_secret_fields).collect();
         write_json_array(&app, "profiles.json", &stripped)?;

--- a/apps/tauri/src-tauri/src/services/transfers.rs
+++ b/apps/tauri/src-tauri/src/services/transfers.rs
@@ -910,6 +910,17 @@ async fn run(app: AppHandle, transfer_id: String) -> Result<(), AppError> {
     if task.terminal() || task.status == "paused" {
         return Ok(());
     }
+    crate::services::logging::info(
+        &app,
+        &format!("transfer:{transfer_id}"),
+        format!(
+            "starting direction={} target_type={} name={} total_bytes={}",
+            task.direction,
+            task.target_type.as_deref().unwrap_or("file"),
+            task.name,
+            task.total_bytes.unwrap_or(0)
+        ),
+    );
     let resume_requested = task.message.as_deref() == Some("等待继续传输");
     let profile_id = task
         .profile_id
@@ -1174,6 +1185,20 @@ async fn run(app: AppHandle, transfer_id: String) -> Result<(), AppError> {
         .await
     };
     state.transfer_controls.write().await.remove(&transfer_id);
+    if result.is_ok() {
+        if let Ok(current) = task_for(&app, &transfer_id).await {
+            crate::services::logging::info(
+                &app,
+                &format!("transfer:{transfer_id}"),
+                format!(
+                    "stopped status={} transferred_bytes={} total_bytes={}",
+                    current.status,
+                    current.transferred_bytes.unwrap_or(0),
+                    current.total_bytes.unwrap_or(0)
+                ),
+            );
+        }
+    }
     result
 }
 
@@ -1541,6 +1566,11 @@ async fn fail_if_running(
     transfer_id: &str,
     error: String,
 ) -> Result<(), AppError> {
+    crate::services::logging::error(
+        app,
+        &format!("transfer:{transfer_id}"),
+        format!("failed error={error}"),
+    );
     let task = task_for(app, transfer_id).await?;
     if matches!(task.status.as_str(), "paused" | "canceled") {
         return Ok(());
@@ -1684,6 +1714,11 @@ pub async fn pause(app: &AppHandle, transfer_id: String) -> Result<(), AppError>
         true,
     )
     .await?;
+    crate::services::logging::warn(
+        app,
+        &format!("transfer:{transfer_id}"),
+        "paused by user",
+    );
     Ok(())
 }
 
@@ -1747,6 +1782,11 @@ pub async fn discard(app: &AppHandle, transfer_id: String) -> Result<(), AppErro
         true,
     )
     .await?;
+    crate::services::logging::warn(
+        app,
+        &format!("transfer:{transfer_id}"),
+        "canceled by user; cleaning partial data",
+    );
     let app_handle = app.clone();
     tauri::async_runtime::spawn(async move {
         let cleanup = if let Some(manifest) = task.manifest {
@@ -1859,6 +1899,11 @@ pub async fn resume(app: &AppHandle, transfer_id: String) -> Result<(), AppError
         true,
     )
     .await?;
+    crate::services::logging::info(
+        app,
+        &format!("transfer:{transfer_id}"),
+        "resume queued",
+    );
     start(app.clone(), transfer_id);
     Ok(())
 }
@@ -1891,6 +1936,7 @@ pub async fn shutdown(app: &AppHandle) -> Result<(), AppError> {
         token.cancel();
     }
     let mut tasks = state.transfers.write().await;
+    let active_count = tasks.iter().filter(|task| task.active()).count();
     for task in tasks.iter_mut().filter(|task| task.active()) {
         task.status = if task.resumable { "paused" } else { "canceled" }.to_string();
         task.message = Some("应用退出时已暂停，可手动继续".to_string());
@@ -1898,6 +1944,11 @@ pub async fn shutdown(app: &AppHandle) -> Result<(), AppError> {
         task.updated_at = Some(now_ms());
     }
     drop(tasks);
+    crate::services::logging::info(
+        app,
+        "transfer",
+        format!("shutdown active_tasks={active_count}"),
+    );
     persist(app).await
 }
 

--- a/apps/tauri/src-tauri/src/services/updates.rs
+++ b/apps/tauri/src-tauri/src/services/updates.rs
@@ -61,6 +61,7 @@ fn is_newer(candidate: &str, current: &str) -> bool {
 }
 
 pub async fn check(app: &AppHandle) -> Result<serde_json::Value, AppError> {
+    crate::services::logging::info(app, "update", "check started");
     set_status(
         app,
         serde_json::json!({ "state": "checking", "currentVersion": current_version(app), "updateMode": "release-page" }),
@@ -106,6 +107,15 @@ pub async fn check(app: &AppHandle) -> Result<serde_json::Value, AppError> {
             "message": format!("更新检查失败: {error}"),
         }),
     };
+    let state = status
+        .get("state")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    if state == "error" {
+        crate::services::logging::warn(app, "update", "check completed state=error");
+    } else {
+        crate::services::logging::info(app, "update", format!("check completed state={state}"));
+    }
     set_status(app, status.clone()).await;
     Ok(status)
 }
@@ -116,7 +126,12 @@ pub async fn open_release_page(app: &AppHandle) -> Result<(), AppError> {
         .get("releaseUrl")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("https://github.com/St0ff3l/fileterm/releases/latest");
-    open::that(url).map_err(|error| AppError::Command(error.to_string()))
+    let result = open::that(url).map_err(|error| AppError::Command(error.to_string()));
+    match &result {
+        Ok(()) => crate::services::logging::info(app, "update", "release page opened"),
+        Err(error) => crate::services::logging::error(app, "update", format!("open release page failed: {error}")),
+    }
+    result
 }
 
 #[cfg(test)]

--- a/apps/tauri/src-tauri/src/services/webdav.rs
+++ b/apps/tauri/src-tauri/src/services/webdav.rs
@@ -395,10 +395,29 @@ pub fn save_config(app: &AppHandle, input: Value) -> Result<Value, AppError> {
         content_hash: previous.content_hash,
     };
     write_config(app, &next)?;
+    crate::services::logging::info(
+        app,
+        "webdav",
+        format!(
+            "configuration saved enabled={} insecure_tls={}",
+            next.enabled,
+            next.allow_insecure_tls == Some(true)
+        ),
+    );
     Ok(public_config(&next))
 }
 
 pub async fn upload(app: &AppHandle) -> Result<Value, AppError> {
+    crate::services::logging::info(app, "webdav", "upload started");
+    let result = upload_inner(app).await;
+    match &result {
+        Ok(_) => crate::services::logging::info(app, "webdav", "upload completed"),
+        Err(error) => crate::services::logging::error(app, "webdav", format!("upload failed: {error}")),
+    }
+    result
+}
+
+async fn upload_inner(app: &AppHandle) -> Result<Value, AppError> {
     let mut config = configured(app)?;
     let client = client()?;
     let (payload, content_hash) = export_bundle(app)?;
@@ -468,6 +487,24 @@ async fn upload_payload(
 }
 
 pub async fn download(app: &AppHandle) -> Result<Value, AppError> {
+    crate::services::logging::info(app, "webdav", "download started");
+    let result = download_inner(app).await;
+    match &result {
+        Ok(value) => crate::services::logging::info(
+            app,
+            "webdav",
+            format!(
+                "download completed imported={} skipped={}",
+                value.get("imported").and_then(Value::as_u64).unwrap_or(0),
+                value.get("skipped").and_then(Value::as_u64).unwrap_or(0)
+            ),
+        ),
+        Err(error) => crate::services::logging::error(app, "webdav", format!("download failed: {error}")),
+    }
+    result
+}
+
+async fn download_inner(app: &AppHandle) -> Result<Value, AppError> {
     let mut config = configured(app)?;
     let client = client()?;
     let (bytes, remote_etag) = download_payload(&client, &config).await?;

--- a/apps/tauri/src-tauri/src/services/workspace.rs
+++ b/apps/tauri/src-tauri/src/services/workspace.rs
@@ -19,6 +19,48 @@ pub struct WorkspaceTab {
     pub status: String, // "connecting" | "connected" | "disconnected"
 }
 
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionCapabilities {
+    pub terminal: bool,
+    pub files: bool,
+    pub resource_monitoring: bool,
+    pub shell_integration: bool,
+    pub file_access: bool,
+    pub tunnels: bool,
+}
+
+impl ConnectionCapabilities {
+    pub fn for_session_type(session_type: &str) -> Self {
+        match session_type {
+            "ssh" => Self {
+                terminal: true,
+                files: true,
+                resource_monitoring: true,
+                shell_integration: true,
+                file_access: true,
+                tunnels: true,
+            },
+            "ftp" => Self {
+                terminal: false,
+                files: true,
+                resource_monitoring: false,
+                shell_integration: false,
+                file_access: false,
+                tunnels: false,
+            },
+            _ => Self {
+                terminal: true,
+                files: false,
+                resource_monitoring: false,
+                shell_integration: false,
+                file_access: false,
+                tunnels: false,
+            },
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionSnapshot {
@@ -43,6 +85,7 @@ pub struct SessionSnapshot {
     pub shell_user: Option<String>,
     pub connected: bool,
     pub system_metrics: Option<serde_json::Value>,
+    pub capabilities: ConnectionCapabilities,
 }
 
 /// The local endpoint to connect when an SSH server opens a `forwarded-tcpip`
@@ -137,9 +180,27 @@ impl WorkspaceState {
 
 #[cfg(test)]
 mod tests {
-    use super::WorkspaceState;
+    use super::{ConnectionCapabilities, WorkspaceState};
     use std::sync::{Arc, Mutex};
     use tauri::ipc::Channel;
+
+    #[test]
+    fn ssh_is_the_only_session_type_with_tunnel_capability() {
+        assert!(ConnectionCapabilities::for_session_type("ssh").tunnels);
+        assert!(!ConnectionCapabilities::for_session_type("ftp").tunnels);
+        assert!(!ConnectionCapabilities::for_session_type("telnet").tunnels);
+        assert!(!ConnectionCapabilities::for_session_type("serial").tunnels);
+    }
+
+    #[test]
+    fn capabilities_serialize_with_the_core_camel_case_shape() {
+        let value = serde_json::to_value(ConnectionCapabilities::for_session_type("ssh")).unwrap();
+
+        assert_eq!(value["resourceMonitoring"], true);
+        assert_eq!(value["shellIntegration"], true);
+        assert_eq!(value["fileAccess"], true);
+        assert_eq!(value["tunnels"], true);
+    }
 
     #[test]
     fn terminal_output_channel_preserves_stream_order_under_load() {

--- a/apps/tauri/src-tauri/src/sessions/ftp.rs
+++ b/apps/tauri/src-tauri/src/sessions/ftp.rs
@@ -42,9 +42,10 @@ pub fn start_ftp_worker(
     command_rx: mpsc::Receiver<WorkerCmd>,
     app: AppHandle,
 ) {
+    crate::services::logging::session(&app, "INFO", "ftp", &tab_id, "worker starting");
     tauri::async_runtime::spawn(async move {
         if let Err(error) = run_ftp_worker(&tab_id, &profile, command_rx, &app).await {
-            crate::services::logging::write(&app, "ERROR", "ftp", format!("tab={tab_id} {error}"));
+            crate::services::logging::session(&app, "ERROR", "ftp", &tab_id, &error);
             set_ftp_state(
                 &app,
                 &tab_id,
@@ -79,6 +80,13 @@ async fn run_ftp_worker(
     let mut client = connect_ftp(profile, host, port).await?;
     let mut listing_state = FtpListingState::default();
     let initial_files = client_list(&mut client, &remote_path, &mut listing_state).await?;
+    crate::services::logging::session(
+        app,
+        "INFO",
+        "ftp",
+        tab_id,
+        format!("connected host={host} port={port} entries={}", initial_files.len()),
+    );
     set_ftp_state(
         app,
         tab_id,
@@ -244,6 +252,7 @@ async fn run_ftp_worker(
             }
             Some(WorkerCmd::WriteTerminal(_)) | Some(WorkerCmd::ResizeTerminal { .. }) => {}
             Some(WorkerCmd::Disconnect) | None => {
+                crate::services::logging::session(app, "INFO", "ftp", tab_id, "disconnecting");
                 let _ = client_quit(&mut client).await;
                 set_ftp_state(
                     app,

--- a/apps/tauri/src-tauri/src/sessions/local_files.rs
+++ b/apps/tauri/src-tauri/src/sessions/local_files.rs
@@ -153,6 +153,10 @@ pub fn app_list_local_directory(dir_path: Option<String>) -> Result<DirectorySna
     let entries = match fs::read_dir(&root) {
         Ok(e) => e,
         Err(error) => {
+            crate::services::logging::error_global(
+                "local",
+                format!("list failed error={error}"),
+            );
             return Err(AppError::Storage(format!(
                 "Failed to read directory {}: {}",
                 root.display(),
@@ -188,6 +192,11 @@ pub fn app_list_local_directory(dir_path: Option<String>) -> Result<DirectorySna
         bf.cmp(&af).then_with(|| a.name.cmp(&b.name))
     });
 
+    crate::services::logging::debug_global(
+        "local",
+        format!("listed directory entries={}", items.len()),
+    );
+
     Ok(DirectorySnapshot {
         path: root.to_string_lossy().to_string(),
         items,
@@ -200,7 +209,14 @@ pub fn app_read_local_file(
     encoding: Option<String>,
 ) -> Result<String, AppError> {
     let enc = encoding.unwrap_or_else(|| "utf-8".to_string());
-    let bytes = fs::read(&file_path).map_err(|e| AppError::Storage(e.to_string()))?;
+    let bytes = fs::read(&file_path).map_err(|error| {
+        crate::services::logging::error_global("local", format!("read failed error={error}"));
+        AppError::Storage(error.to_string())
+    })?;
+    crate::services::logging::debug_global(
+        "local",
+        format!("read file bytes={} encoding={enc}", bytes.len()),
+    );
     Ok(decode_bytes(&bytes, &enc))
 }
 
@@ -215,13 +231,18 @@ pub fn app_write_local_file(
     if let Some(parent) = Path::new(&file_path).parent() {
         fs::create_dir_all(parent).map_err(|e| AppError::Storage(e.to_string()))?;
     }
-    fs::write(&file_path, bytes).map_err(|e| AppError::Storage(e.to_string()))
+    let byte_count = bytes.len();
+    let result = fs::write(&file_path, bytes).map_err(|e| AppError::Storage(e.to_string()));
+    log_local_result("write file", &result, Some(byte_count));
+    result
 }
 
 #[tauri::command]
 pub fn app_create_local_directory(dir_path: String, name: String) -> Result<(), AppError> {
     let target = Path::new(&dir_path).join(&name);
-    fs::create_dir_all(&target).map_err(|e| AppError::Storage(e.to_string()))
+    let result = fs::create_dir_all(&target).map_err(|e| AppError::Storage(e.to_string()));
+    log_local_result("create directory", &result, None);
+    result
 }
 
 #[tauri::command]
@@ -230,7 +251,9 @@ pub fn app_create_local_file(dir_path: String, name: String) -> Result<(), AppEr
     if let Some(parent) = target.parent() {
         fs::create_dir_all(parent).map_err(|e| AppError::Storage(e.to_string()))?;
     }
-    fs::write(&target, b"").map_err(|e| AppError::Storage(e.to_string()))
+    let result = fs::write(&target, b"").map_err(|e| AppError::Storage(e.to_string()));
+    log_local_result("create file", &result, Some(0));
+    result
 }
 
 #[tauri::command]
@@ -241,7 +264,9 @@ pub fn app_copy_local_path(source_path: String, destination_path: String) -> Res
     if let Some(parent) = Path::new(&destination_path).parent() {
         fs::create_dir_all(parent).map_err(|e| AppError::Storage(e.to_string()))?;
     }
-    copy_recursive(Path::new(&source_path), Path::new(&destination_path))
+    let result = copy_recursive(Path::new(&source_path), Path::new(&destination_path));
+    log_local_result("copy path", &result, None);
+    result
 }
 
 fn copy_recursive(src: &Path, dst: &Path) -> Result<(), AppError> {
@@ -279,7 +304,7 @@ pub fn app_move_local_path(source_path: String, destination_path: String) -> Res
     if let Some(parent) = Path::new(&destination_path).parent() {
         fs::create_dir_all(parent).map_err(|e| AppError::Storage(e.to_string()))?;
     }
-    match fs::rename(&source_path, &destination_path) {
+    let result = match fs::rename(&source_path, &destination_path) {
         Ok(()) => Ok(()),
         Err(error) => {
             if error.raw_os_error() == Some(18) {
@@ -290,7 +315,9 @@ pub fn app_move_local_path(source_path: String, destination_path: String) -> Res
                 Err(AppError::Storage(error.to_string()))
             }
         }
-    }
+    };
+    log_local_result("move path", &result, None);
+    result
 }
 
 #[tauri::command]
@@ -299,12 +326,32 @@ pub fn app_rename_local_path(target_path: String, new_name: String) -> Result<()
         .parent()
         .ok_or_else(|| AppError::Storage("Cannot rename root".to_string()))?;
     let dest = parent.join(&new_name);
-    fs::rename(&target_path, &dest).map_err(|e| AppError::Storage(e.to_string()))
+    let result = fs::rename(&target_path, &dest).map_err(|e| AppError::Storage(e.to_string()));
+    log_local_result("rename path", &result, None);
+    result
 }
 
 #[tauri::command]
 pub fn app_delete_local_path(target_path: String) -> Result<(), AppError> {
-    remove_path(Path::new(&target_path))
+    let result = remove_path(Path::new(&target_path));
+    log_local_result("delete path", &result, None);
+    result
+}
+
+fn log_local_result(operation: &str, result: &Result<(), AppError>, bytes: Option<usize>) {
+    match result {
+        Ok(()) => crate::services::logging::info_global(
+            "local",
+            bytes.map_or_else(
+                || format!("{operation} completed"),
+                |count| format!("{operation} completed bytes={count}"),
+            ),
+        ),
+        Err(error) => crate::services::logging::error_global(
+            "local",
+            format!("{operation} failed error={error}"),
+        ),
+    }
 }
 
 fn remove_path(p: &Path) -> Result<(), AppError> {

--- a/apps/tauri/src-tauri/src/sessions/serial.rs
+++ b/apps/tauri/src-tauri/src/sessions/serial.rs
@@ -14,14 +14,10 @@ pub fn start_serial_worker(
     command_rx: mpsc::Receiver<WorkerCmd>,
     app: AppHandle,
 ) {
+    crate::services::logging::session(&app, "INFO", "serial", &tab_id, "worker starting");
     tauri::async_runtime::spawn(async move {
         if let Err(error) = run_serial_worker(&tab_id, &profile, command_rx, &app).await {
-            crate::services::logging::write(
-                &app,
-                "ERROR",
-                "serial",
-                format!("tab={tab_id} {error}"),
-            );
+            crate::services::logging::session(&app, "ERROR", "serial", &tab_id, &error);
             emit_terminal_data(&app, &tab_id, &format!("\r\n[Serial] {error}\r\n")).await;
             set_terminal_state(&app, &tab_id, format!("Serial error: {error}"), false).await;
         }
@@ -70,6 +66,13 @@ async fn run_serial_worker(
         .open_native_async()
         .map_err(|error| serial_error(device_path, error))?;
     let (mut reader, mut writer) = tokio::io::split(stream);
+    crate::services::logging::session(
+        app,
+        "INFO",
+        "serial",
+        tab_id,
+        format!("connected baud_rate={baud_rate}"),
+    );
     set_terminal_state(
         app,
         tab_id,
@@ -92,6 +95,7 @@ async fn run_serial_worker(
                         // Raw serial links have no terminal-size negotiation.
                     }
                     Some(WorkerCmd::Disconnect) | None => {
+                        crate::services::logging::session(app, "INFO", "serial", tab_id, "disconnecting");
                         let _ = writer.shutdown().await;
                         set_terminal_state(app, tab_id, "Serial disconnected".to_string(), false).await;
                         return Ok(());
@@ -102,6 +106,7 @@ async fn run_serial_worker(
             read = reader.read(&mut buffer) => {
                 let count = read.map_err(|error| serial_error(device_path, error))?;
                 if count == 0 {
+                    crate::services::logging::session(app, "WARN", "serial", tab_id, "device disconnected");
                     set_terminal_state(app, tab_id, "Serial device disconnected".to_string(), false).await;
                     return Ok(());
                 }

--- a/apps/tauri/src-tauri/src/sessions/ssh.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh.rs
@@ -32,6 +32,13 @@ use tokio_socks::tcp::Socks5Stream;
 
 use super::{TransferFileStat, WorkerCmd};
 
+fn resource_monitoring_enabled(profile: &Value) -> bool {
+    profile
+        .get("enableResourceMonitoring")
+        .and_then(Value::as_bool)
+        != Some(false)
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Public entry point
 // ─────────────────────────────────────────────────────────────────────────────
@@ -113,7 +120,7 @@ pub fn start_ssh_worker(
 ) {
     tokio::spawn(async move {
         let tid = tab_id.clone();
-        crate::services::logging::ssh_debug(&app, &tid, "SSH worker started");
+        crate::services::logging::session(&app, "INFO", "ssh", &tid, "worker started");
         // The initial "连接主机...\r\n" notice is already in the session
         // snapshot's `terminal_transcript` (set by `app_open_profile`), so
         // the renderer hydrates it via `bootText` — no need to emit it here.
@@ -128,7 +135,7 @@ pub fn start_ssh_worker(
         )
         .await;
         if cancellation.is_cancelled() {
-            crate::services::logging::ssh_debug(&app, &tid, "SSH worker cancelled");
+            crate::services::logging::session(&app, "INFO", "ssh", &tid, "worker cancelled");
             return;
         }
         match run_result {
@@ -136,8 +143,7 @@ pub fn start_ssh_worker(
                 emit_terminal_data(&app, &tid, "连接已断开\r\n").await;
             }
             Err(e) => {
-                eprintln!("[SSH Worker] error for tab {}: {}", tid, e);
-                crate::services::logging::ssh_debug(&app, &tid, format!("SSH worker failed: {e}"));
+                crate::services::logging::session(&app, "ERROR", "ssh", &tid, format!("worker failed: {e}"));
                 emit_terminal_data(&app, &tid, &format!("连接失败: {}\r\n", e)).await;
             }
         }
@@ -153,10 +159,7 @@ pub fn start_ssh_worker(
             .and_then(|v| v.as_str())
             .unwrap_or("manual");
         if reconnect_mode == "auto" {
-            eprintln!(
-                "[SSH Worker] tab={} auto-reconnect scheduled (2000ms delay)",
-                tid
-            );
+            crate::services::logging::session(&app, "INFO", "ssh", &tid, "auto-reconnect scheduled delay_ms=2000");
             tokio::time::sleep(Duration::from_secs(2)).await;
 
             // Re-check: tab may have been closed or already reconnected by
@@ -174,14 +177,11 @@ pub fn start_ssh_worker(
             };
 
             if should_reconnect {
-                eprintln!("[SSH Worker] tab={} auto-reconnect firing", tid);
+                crate::services::logging::session(&app, "INFO", "ssh", &tid, "auto-reconnect firing");
                 // Trigger reconnect via the same path the renderer uses.
                 let _ = crate::commands::app_reconnect_tab(app.clone(), tid.clone()).await;
             } else {
-                eprintln!(
-                    "[SSH Worker] tab={} auto-reconnect cancelled (tab closed or already connected)",
-                    tid
-                );
+                crate::services::logging::session(&app, "DEBUG", "ssh", &tid, "auto-reconnect canceled");
             }
         }
     });
@@ -210,30 +210,22 @@ impl Handler for ClientHandler {
         server_public_key: &russh::keys::PublicKey,
     ) -> Result<bool, Self::Error> {
         let fp = fingerprint_sha256_base64(server_public_key);
-        eprintln!(
-            "[SSH host-key] tab={} profile={} host={} fp='{}' trusted={:?}",
-            self.tab_id, self.profile_id, self.host, fp, self.trusted_fingerprint
+        crate::services::logging::session(
+            &self.app,
+            "DEBUG",
+            "ssh",
+            &self.tab_id,
+            format!("host-key verification host={} port={}", self.host, self.port),
         );
         // Short-circuit: if the profile already trusts this exact
         // fingerprint, accept without prompting. This is the common path
         // after the user previously chose "accept-and-save".
         if let Some(known) = &self.trusted_fingerprint {
-            eprintln!(
-                "[SSH host-key] comparing known='{}' (len={}) vs fp='{}' (len={}) equal={}",
-                known,
-                known.len(),
-                fp,
-                fp.len(),
-                known == &fp
-            );
             if known == &fp {
+                crate::services::logging::session(&self.app, "INFO", "ssh", &self.tab_id, "host-key matched saved fingerprint");
                 return Ok(true);
             }
-            eprintln!(
-                "[SSH host-key] mismatch — byte diff: known_bytes={:?} fp_bytes={:?}",
-                known.as_bytes(),
-                fp.as_bytes()
-            );
+            crate::services::logging::session(&self.app, "WARN", "ssh", &self.tab_id, "host-key mismatch; requesting user verification");
         }
         let known = self.trusted_fingerprint.clone();
         let request_id = uuid::Uuid::new_v4().to_string();
@@ -320,6 +312,7 @@ impl Handler for ClientHandler {
 
         reply.accept().await;
         let tab_id = self.tab_id.clone();
+        let app = self.app.clone();
         tokio::spawn(async move {
             let result = async {
                 let mut local = TcpStream::connect((&*target.target_host, target.target_port)).await?;
@@ -329,7 +322,7 @@ impl Handler for ClientHandler {
             }
             .await;
             if let Err(error) = result {
-                eprintln!("[SSH tunnel] remote forward tab={tab_id} connection failed: {error}");
+                crate::services::logging::session(&app, "WARN", "tunnel", &tab_id, format!("remote forward connection failed: {error}"));
             }
         });
         Ok(())
@@ -455,10 +448,24 @@ impl TunnelManager {
         match start_result {
             Ok(()) => {
                 self.set_status(rule_id, "running", None);
+                crate::services::logging::session(
+                    &self.app,
+                    "INFO",
+                    "tunnel",
+                    &self.tab_id,
+                    format!("started id={rule_id} kind={}", rule.kind),
+                );
                 self.list()
             }
             Err(error) => {
                 self.set_status(rule_id, "error", Some(error.clone()));
+                crate::services::logging::session(
+                    &self.app,
+                    "ERROR",
+                    "tunnel",
+                    &self.tab_id,
+                    format!("start failed id={rule_id} error={error}"),
+                );
                 Err(error)
             }
         }
@@ -473,6 +480,7 @@ impl TunnelManager {
         let rule = rule.clone();
         let rule_id = rule.id.clone();
         let tab_id = self.tab_id.clone();
+        let app = self.app.clone();
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -482,6 +490,7 @@ impl TunnelManager {
                             let handle = Arc::clone(&handle);
                             let rule = rule.clone();
                             let connection_tab_id = tab_id.clone();
+                            let connection_app = app.clone();
                             tokio::spawn(async move {
                                 let result = if rule.kind == "dynamic" {
                                     forward_socks5_connection(socket, handle).await
@@ -489,12 +498,12 @@ impl TunnelManager {
                                     forward_local_connection(socket, handle, &rule).await
                                 };
                                 if let Err(error) = result {
-                                    eprintln!("[SSH tunnel] tab={connection_tab_id} {} connection failed: {error}", rule.id);
+                                    crate::services::logging::session(&connection_app, "WARN", "tunnel", &connection_tab_id, format!("connection failed id={} error={error}", rule.id));
                                 }
                             });
                         }
                         Err(error) => {
-                            eprintln!("[SSH tunnel] tab={tab_id} {} listener failed: {error}", rule.id);
+                            crate::services::logging::session(&app, "ERROR", "tunnel", &tab_id, format!("listener failed id={} error={error}", rule.id));
                             break;
                         }
                     }
@@ -554,12 +563,26 @@ impl TunnelManager {
             }
         }
         self.set_status(rule_id, "stopped", None);
+        crate::services::logging::session(
+            &self.app,
+            "INFO",
+            "tunnel",
+            &self.tab_id,
+            format!("stopped id={rule_id}"),
+        );
         self.list()
     }
 
     async fn delete(&mut self, rule_id: &str) -> Result<Vec<Value>, String> {
         self.stop(rule_id).await?;
         self.tunnels.remove(rule_id);
+        crate::services::logging::session(
+            &self.app,
+            "INFO",
+            "tunnel",
+            &self.tab_id,
+            format!("deleted id={rule_id}"),
+        );
         self.list()
     }
 
@@ -1459,11 +1482,15 @@ async fn open_session(
         .get("trustedHostFingerprint")
         .and_then(|f| f.as_str())
         .map(|s| s.to_string());
-    eprintln!(
-        "[SSH host-key] open_session tab={} profile_id='{}' trustedHostFingerprint_from_profile={:?}",
+    crate::services::logging::session(
+        app,
+        "INFO",
+        "ssh",
         tab_id,
-        profile.get("id").and_then(|v| v.as_str()).unwrap_or(""),
-        trusted
+        format!(
+            "opening session host={host} port={port} auth_type={auth_type} saved_host_key={}",
+            trusted.is_some()
+        ),
     );
 
     let profile_id = profile
@@ -1487,10 +1514,7 @@ async fn open_session(
         .map(|s| s.to_string());
 
     if let Some(jpid) = jump_profile_id {
-        eprintln!(
-            "[SSH jump] tab={} — resolving jump profile '{}'",
-            tab_id, jpid
-        );
+        crate::services::logging::session(app, "INFO", "ssh", tab_id, "resolving jump host");
         // Load the jump profile from disk (same directory as profiles.json)
         let jump_profile = load_jump_profile(app, &jpid)?;
 
@@ -1504,13 +1528,7 @@ async fn open_session(
             return Err("Jump Host cannot itself reference another Jump Host".to_string());
         }
 
-        eprintln!(
-            "[SSH jump] tab={} — connecting to jump host '{}@{}:{}'",
-            tab_id,
-            jump_profile.get("username").and_then(|v| v.as_str()).unwrap_or(""),
-            jump_profile.get("host").and_then(|v| v.as_str()).unwrap_or(""),
-            jump_profile.get("port").and_then(|v| v.as_i64()).unwrap_or(22)
-        );
+        crate::services::logging::session(app, "INFO", "ssh", tab_id, "connecting through jump host");
 
         // Connect + authenticate to the jump host.
         // Box::pin is required because `open_session` is recursive (the jump
@@ -1518,7 +1536,7 @@ async fn open_session(
         // Rust requires indirection for recursive async fns to avoid
         // infinitely-sized futures.
         let jump_handle = Box::pin(open_session(&jump_profile, app, tab_id)).await?;
-        eprintln!("[SSH jump] tab={} — jump host connected, opening direct-tcpip to target", tab_id);
+        crate::services::logging::session(app, "INFO", "ssh", tab_id, "jump host connected; opening target channel");
 
         let mut target_handle = connect_target_through_jump(
             &jump_handle,
@@ -2170,9 +2188,12 @@ async fn run_worker_loop(
 
     // ── Probe platform ─────────────────────────────────────────────────────
     let platform = super::system_metrics::probe_remote_platform(&handle).await;
-    eprintln!(
-        "[SSH metrics] tab={} platform='{}' — probe completed",
-        tab_id, platform
+    crate::services::logging::session(
+        app,
+        "INFO",
+        "metrics",
+        tab_id,
+        format!("platform probe completed platform={platform}"),
     );
 
     // ── Inject shell CWD setup (POSIX only, fail-closed) ───────────────────
@@ -2184,17 +2205,9 @@ async fn run_worker_loop(
     let mut shell_setup_waiting_for_prompt = shell_cwd_setup_for_platform(&platform).is_some();
     let mut shell_prompt_buffer = String::new();
     if let Some(setup) = shell_cwd_setup_for_platform(&platform) {
-        eprintln!(
-            "[SSH shell-setup] tab={} platform='{}' — waiting for first prompt before CWD hook injection ({} bytes)",
-            tab_id,
-            platform,
-            setup.len()
-        );
+        crate::services::logging::session(app, "DEBUG", "ssh", tab_id, format!("shell setup waiting for prompt platform={platform} bytes={}", setup.len()));
     } else {
-        eprintln!(
-            "[SSH shell-setup] tab={} platform='{}' — skipping setup (unsupported platform)",
-            tab_id, platform
-        );
+        crate::services::logging::session(app, "DEBUG", "ssh", tab_id, format!("shell setup skipped platform={platform}"));
     }
 
     update_tab_status_and_emit(app, tab_id, "connected").await;
@@ -2238,6 +2251,9 @@ async fn run_worker_loop(
                 shell_user: None,
                 connected: true,
                 system_metrics: None,
+                capabilities: crate::services::workspace::ConnectionCapabilities::for_session_type(
+                    "ssh",
+                ),
             },
         );
     }
@@ -2275,8 +2291,7 @@ async fn run_worker_loop(
         }
         Err(error) => {
             let reason = format_sftp_unavailable_reason(&error);
-            eprintln!("[SSH SFTP] tab={tab_id} unavailable: {reason}");
-            crate::services::logging::ssh_debug(app, tab_id, format!("SFTP unavailable: {reason}"));
+            crate::services::logging::session(app, "WARN", "sftp", tab_id, format!("unavailable: {reason}"));
             {
                 let mut sessions = state.sessions.write().await;
                 if let Some(session) = sessions.get_mut(tab_id) {
@@ -2300,17 +2315,20 @@ async fn run_worker_loop(
     // The remote side controls the 1s cadence via `sleep 1`, so data arrives
     // at a rock-steady interval regardless of SSH RTT.
     let metrics_shutdown = Arc::new(tokio::sync::Notify::new());
-    let metrics_shutdown_clone = metrics_shutdown.clone();
-    {
+    if resource_monitoring_enabled(profile) {
+        let metrics_shutdown_clone = metrics_shutdown.clone();
         let metrics_handle = Arc::clone(&handle);
         let metrics_app = app.clone();
         let metrics_tid = tab_id.to_string();
         let metrics_plat = platform.clone();
         let metrics_cancellation = cancellation.clone();
         tokio::spawn(async move {
-            eprintln!(
-                "[SSH metrics] task spawned tab={} plat='{}' — starting streaming collector",
-                metrics_tid, metrics_plat
+            crate::services::logging::session(
+                &metrics_app,
+                "INFO",
+                "metrics",
+                &metrics_tid,
+                format!("collector starting platform={metrics_plat}"),
             );
 
             // Build the infinite-loop script. Each iteration emits a
@@ -2349,10 +2367,7 @@ async fn run_worker_loop(
             let mut channel = match metrics_handle.channel_open_session().await {
                 Ok(c) => c,
                 Err(e) => {
-                    eprintln!(
-                        "[SSH metrics] tab={} failed to open channel: {}",
-                        metrics_tid, e
-                    );
+                    crate::services::logging::session(&metrics_app, "ERROR", "metrics", &metrics_tid, format!("open channel failed: {e}"));
                     return;
                 }
             };
@@ -2367,32 +2382,24 @@ async fn run_worker_loop(
                 channel.request_shell(true).await
             };
             if let Err(e) = collector_start {
-                eprintln!(
-                    "[SSH metrics] tab={} failed to start collector shell: {}",
-                    metrics_tid, e
-                );
+                crate::services::logging::session(&metrics_app, "ERROR", "metrics", &metrics_tid, format!("start collector failed: {e}"));
                 return;
             }
 
             if let Some(script) = script_body.as_deref() {
                 if let Err(e) = channel.data(script.as_bytes()).await {
-                    eprintln!(
-                        "[SSH metrics] tab={} failed to write script: {}",
-                        metrics_tid, e
-                    );
+                    crate::services::logging::session(&metrics_app, "ERROR", "metrics", &metrics_tid, format!("write collector script failed: {e}"));
                     return;
                 }
             }
 
-            eprintln!(
-                "[SSH metrics] tab={} streaming collector started — waiting for first block",
-                metrics_tid
-            );
+            crate::services::logging::session(&metrics_app, "INFO", "metrics", &metrics_tid, "collector started; waiting for first sample");
 
             // Stream reader: accumulate data, split on the marker, parse
             // each complete block and emit it to the renderer.
             let mut buffer: Vec<u8> = Vec::new();
             let marker_bytes = marker.as_bytes();
+            let mut sample_count = 0_u64;
 
             loop {
                 tokio::select! {
@@ -2432,6 +2439,16 @@ async fn run_worker_loop(
                                         // Probably garbage / incomplete block
                                         continue;
                                     }
+                                    sample_count += 1;
+                                    if sample_count == 1 {
+                                        crate::services::logging::session(
+                                            &metrics_app,
+                                            "INFO",
+                                            "metrics",
+                                            &metrics_tid,
+                                            format!("first sample cpu_percent={cpu_pct:.1} memory_percent={mem_pct:.1}"),
+                                        );
+                                    }
                                     {
                                         let state = metrics_app
                                             .state::<crate::services::workspace::WorkspaceState>();
@@ -2460,10 +2477,7 @@ async fn run_worker_loop(
                                 buffer.extend_from_slice(data.as_ref());
                             }
                             Some(ChannelMsg::ExitStatus { .. }) | None => {
-                                eprintln!(
-                                    "[SSH metrics] tab={} channel closed",
-                                    metrics_tid
-                                );
+                                crate::services::logging::session(&metrics_app, "WARN", "metrics", &metrics_tid, "collector channel closed");
                                 break;
                             }
                             _ => {}
@@ -2473,11 +2487,14 @@ async fn run_worker_loop(
             }
 
             let _ = channel.close().await;
-            eprintln!(
-                "[SSH metrics] tab={} task ended",
-                metrics_tid
-            );
+            crate::services::logging::session(&metrics_app, "INFO", "metrics", &metrics_tid, "collector stopped");
         });
+    } else {
+        let mut sessions = state.sessions.write().await;
+        if let Some(session) = sessions.get_mut(tab_id) {
+            session.system_metrics = None;
+        }
+        crate::services::logging::session(app, "INFO", "metrics", tab_id, "collection disabled by profile");
     }
 
     // ── Main event loop: terminal reads + command dispatch ─────────────────
@@ -2617,7 +2634,7 @@ async fn run_worker_loop(
                             }
                             Ok(false) => {}
                             Err(e) => {
-                                eprintln!("[SSH Worker] cmd error for tab {}: {}", tab_id, e);
+                                crate::services::logging::session(app, "WARN", "ssh", tab_id, format!("command failed: {e}"));
                             }
                         }
                     }
@@ -2776,10 +2793,7 @@ async fn run_worker_loop(
                                             Some(ShellSetupEchoSuppression::new(false));
                                     }
                                     Err(error) => {
-                                        eprintln!(
-                                            "[SSH shell-setup] tab={} failed to write setup after first prompt: {}",
-                                            tab_id, error
-                                        );
+                                        crate::services::logging::session(app, "WARN", "ssh", tab_id, format!("shell setup write failed: {error}"));
                                     }
                                 }
                             }
@@ -4282,15 +4296,14 @@ fn format_perm(perm: u32, is_dir: bool, is_link: bool) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_http_connect_request, format_sftp_unavailable_reason, is_password_prompt,
-        looks_like_mfa_prompt, parent_remote_path, forward_local_connection, forward_socks5_connection,
-        capture_sudo_password_input, looks_like_root_prompt, looks_like_shell_prompt,
-        remote_bind_host_matches, track_cwd_and_user,
-        coalesce_terminal_input,
-        suppress_shell_setup_echo, track_sudo_prompt_from_terminal, ShellSetupEchoSuppression,
-        SHELL_SETUP_SETTLE_DELAY,
+        build_http_connect_request, capture_sudo_password_input, coalesce_terminal_input,
+        format_sftp_unavailable_reason, forward_local_connection, forward_socks5_connection,
+        is_password_prompt, looks_like_mfa_prompt, looks_like_root_prompt, looks_like_shell_prompt,
+        parent_remote_path, remote_bind_host_matches, resource_monitoring_enabled,
+        suppress_shell_setup_echo, track_cwd_and_user, track_sudo_prompt_from_terminal,
         try_keyboard_interactive_with_responder, tunnel_bind_address, validate_tunnel_rule,
-        KeyboardInteractiveRequest, SshTunnelRule,
+        KeyboardInteractiveRequest, ShellSetupEchoSuppression, SshTunnelRule,
+        SHELL_SETUP_SETTLE_DELAY,
     };
     use std::borrow::Cow;
     use std::sync::{Arc, Mutex};
@@ -4301,6 +4314,17 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio::time::{timeout, Duration};
+
+    #[test]
+    fn resource_monitoring_respects_explicit_profile_disable() {
+        assert!(resource_monitoring_enabled(&serde_json::json!({})));
+        assert!(resource_monitoring_enabled(&serde_json::json!({
+            "enableResourceMonitoring": true
+        })));
+        assert!(!resource_monitoring_enabled(&serde_json::json!({
+            "enableResourceMonitoring": false
+        })));
+    }
 
     #[cfg(unix)]
     struct OpenSshFixture {

--- a/apps/tauri/src-tauri/src/sessions/telnet.rs
+++ b/apps/tauri/src-tauri/src/sessions/telnet.rs
@@ -141,14 +141,10 @@ pub fn start_telnet_worker(
     command_rx: mpsc::Receiver<WorkerCmd>,
     app: AppHandle,
 ) {
+    crate::services::logging::session(&app, "INFO", "telnet", &tab_id, "worker starting");
     tauri::async_runtime::spawn(async move {
         if let Err(error) = run_telnet_worker(&tab_id, &profile, command_rx, &app).await {
-            crate::services::logging::write(
-                &app,
-                "ERROR",
-                "telnet",
-                format!("tab={tab_id} {error}"),
-            );
+            crate::services::logging::session(&app, "ERROR", "telnet", &tab_id, &error);
             emit_terminal_data(&app, &tab_id, &format!("\r\n[Telnet] {error}\r\n")).await;
             set_terminal_state(&app, &tab_id, format!("Telnet error: {error}"), false).await;
         }
@@ -172,6 +168,13 @@ async fn run_telnet_worker(
         .unwrap_or("utf-8")
         .to_string();
     let stream = connect_transport(profile, host, port).await?;
+    crate::services::logging::session(
+        app,
+        "INFO",
+        "telnet",
+        tab_id,
+        format!("connected host={host} port={port}"),
+    );
     let (mut reader, mut writer) = tokio::io::split(stream);
     let mut parser = TelnetParser::new();
     set_terminal_state(app, tab_id, format!("Telnet {host}:{port}"), true).await;
@@ -195,6 +198,7 @@ async fn run_telnet_worker(
                         writer.write_all(&parser.set_size(cols, rows)).await.map_err(|error| error.to_string())?;
                     }
                     Some(WorkerCmd::Disconnect) | None => {
+                        crate::services::logging::session(app, "INFO", "telnet", tab_id, "disconnecting");
                         let _ = writer.shutdown().await;
                         set_terminal_state(app, tab_id, "Telnet disconnected".to_string(), false).await;
                         return Ok(());
@@ -205,6 +209,7 @@ async fn run_telnet_worker(
             read = reader.read(&mut buffer) => {
                 let count = read.map_err(|error| error.to_string())?;
                 if count == 0 {
+                    crate::services::logging::session(app, "WARN", "telnet", tab_id, "remote closed connection");
                     set_terminal_state(app, tab_id, "Telnet disconnected".to_string(), false).await;
                     return Ok(());
                 }

--- a/apps/tauri/src/bridge/tauri-api.ts
+++ b/apps/tauri/src/bridge/tauri-api.ts
@@ -219,6 +219,8 @@ export function createTauriApi(): FileTermDesktopApi {
     arch,
     appVersion: '0.0.0',
     appName: 'FileTerm',
+    runtimeName: 'Tauri',
+    runtimeVersion: '0.0.0',
     isDesktop: true,
     getUpdateStatus: () => invoke<AppUpdateStatus>('app_get_update_status'),
     checkForUpdates: () => invoke<AppUpdateStatus>('app_check_for_updates'),
@@ -274,7 +276,7 @@ export function createTauriApi(): FileTermDesktopApi {
     cancelCloseCurrentFileEditor: () => invoke<void>('app_cancel_file_editor_close'),
     showWindowMenu: (menuType: 'app' | 'file' | 'view' | 'window', x: number, y: number) =>
       invoke<void>('app_show_window_menu', { menuType, x, y }),
-    requestQuitApp: () => invoke<void>('app_window_action', { action: 'quit' }),
+    requestQuitApp: () => invoke<void>('app_window_action', { action: 'request-quit' }),
     listLocalDirectory: (dirPath?: string) =>
       invoke<{ path: string; items: LocalFileItem[] }>('app_list_local_directory', {
         dirPath: dirPath ?? null
@@ -469,18 +471,25 @@ export function createTauriApi(): FileTermDesktopApi {
         // the app instead of looping back through the confirmation dialog.
         return invoke<void>('app_window_action', { action: 'quit' })
       }
-      return invoke<void>('app_window_action', { action: 'minimize' })
+      return invoke<void>('app_window_action', { action: 'hide' })
     }
   } as unknown as FileTermDesktopApi
 
   // The core API exposes these as synchronous fields for Electron parity.
   // Tauri resolves app metadata asynchronously, so start with safe values and
   // hydrate them from the Rust runtime as soon as IPC is available.
-  void Promise.all([invoke<string>('app_get_platform'), invoke<string>('app_get_arch'), getVersion(), getName()])
-    .then(([nativePlatform, nativeArch, appVersion, appName]) => {
+  void Promise.all([
+    invoke<string>('app_get_platform'),
+    invoke<string>('app_get_arch'),
+    invoke<string>('app_get_runtime_version'),
+    getVersion(),
+    getName()
+  ])
+    .then(([nativePlatform, nativeArch, runtimeVersion, appVersion, appName]) => {
       Object.assign(api, {
         platform: normalizePlatform(nativePlatform),
         arch: nativeArch,
+        runtimeVersion,
         appVersion,
         appName
       })

--- a/apps/tauri/src/renderer/App.tsx
+++ b/apps/tauri/src/renderer/App.tsx
@@ -260,6 +260,8 @@ export function App() {
     : false
   const activeWorkspaceFocusKey = activeTab?.id ?? effectiveActiveLocalTabId
   const isWorkspaceFocusMode = activeWorkspaceFocusKey ? (workspaceFocusModes[activeWorkspaceFocusKey] ?? false) : false
+  const isResourceMonitoringAvailable =
+    activeProfile?.type === 'ssh' && activeProfile.enableResourceMonitoring !== false
   const activeTabId = activeTab?.id ?? null
   const setActiveFilePanelHeight = useCallback(
     (next: SetStateAction<number>) => {
@@ -300,11 +302,17 @@ export function App() {
       return
     }
 
-    setIsSystemSidebarCollapsed(isWorkspaceFocusMode)
+    setIsSystemSidebarCollapsed(isWorkspaceFocusMode || !isResourceMonitoringAvailable)
     if (!isWorkspaceFocusMode) {
       setSidebarWidth(214)
     }
-  }, [activeWorkspaceFocusKey, isHomeWorkspaceVisible, isWorkspaceFocusMode, setIsSystemSidebarCollapsed])
+  }, [
+    activeWorkspaceFocusKey,
+    isHomeWorkspaceVisible,
+    isResourceMonitoringAvailable,
+    isWorkspaceFocusMode,
+    setIsSystemSidebarCollapsed
+  ])
 
   // 3. Workspace Modals Hook
   const {
@@ -1146,12 +1154,8 @@ export function App() {
           <SystemSidebarShell
             activeProfile={activeProfile}
             activeSession={activeSession}
-            collapsed={
-              isSystemSidebarCollapsed ||
-              (activeProfile?.type === 'ssh' && activeProfile.enableResourceMonitoring === false)
-            }
-            showResourceMeters={activeProfile?.type !== 'ssh' || activeProfile.enableResourceMonitoring !== false}
-            showToggle={activeProfile?.type !== 'ssh' || activeProfile.enableResourceMonitoring !== false}
+            collapsed={isSystemSidebarCollapsed}
+            showResourceMeters={isResourceMonitoringAvailable}
             isResizing={isResizingSidebar}
             onOpenSystemInfo={openSystemInfo}
             onResizeStart={() => setIsResizingSidebar(true)}

--- a/apps/tauri/src/renderer/features/commands/CommandManagerModal.tsx
+++ b/apps/tauri/src/renderer/features/commands/CommandManagerModal.tsx
@@ -5,6 +5,8 @@ import { t } from '../../i18n'
 import { CommandEditorModal, emptyCommandForm, toCommandTemplateInput } from './CommandEditorModal'
 import { AppIcon } from '../common/AppIcon'
 import { CloseButton } from '../common/CloseButton'
+import { ManagerInlineFolderRow } from '../common/ManagerInlineFolderRow'
+import { managerDropClass, resolveManagerDropPosition } from '../common/manager-drag'
 import { usePointerSortFallback, type PointerSortTarget } from '../../hooks/usePointerSortFallback'
 
 type CommandTreeNode = (CommandFolder & { children: CommandTreeNode[] }) | (CommandTemplate & { children?: never })
@@ -215,14 +217,7 @@ export function CommandManagerModal({
     if (element.closest('.connection-manager-sidebar')) return 'inside' as const
     const targetNode = tree.map.get(targetId)
     if (!targetNode) return null
-    const rect = element.getBoundingClientRect()
-    const y = clientY - rect.top
-    if (targetNode.type === 'command-folder') {
-      if (y < rect.height * 0.25) return 'top' as const
-      if (y > rect.height * 0.75) return 'bottom' as const
-      return 'inside' as const
-    }
-    return y < rect.height * 0.5 ? ('top' as const) : ('bottom' as const)
+    return resolveManagerDropPosition(element, clientY, targetNode.type === 'command-folder')
   }
 
   const moveToRoot = (id: string) => {
@@ -382,10 +377,7 @@ export function CommandManagerModal({
     const isDragOver = dragOverId === node.id
     const isDragging = draggingId === node.id
 
-    let dropClass = ''
-    if (isDragOver && dragPosition) {
-      dropClass = `drop-${dragPosition}`
-    }
+    const dropClass = managerDropClass(isDragOver, dragPosition)
 
     return (
       <div key={node.id}>
@@ -612,36 +604,17 @@ export function CommandManagerModal({
             </div>
             <div className="manager-body connection-manager-body">
               {isCreatingFolder && resolvedActiveFolderId === 'all' && (
-                <div className="manager-row folder-row">
-                  <span className="manager-name-cell">
-                    <span className="folder-icon manager-folder-toggle">
-                      <AppIcon name="chevron-right" size={12} />
-                    </span>
-                    <input
-                      type="text"
-                      autoFocus
-                      value={newFolderName}
-                      onChange={(e) => setNewFolderName(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && newFolderName.trim()) {
-                          onCreateFolder(newFolderName.trim())
-                          setIsCreatingFolder(false)
-                        } else if (e.key === 'Escape') {
-                          setIsCreatingFolder(false)
-                        }
-                      }}
-                      onBlur={() => {
-                        if (newFolderName.trim()) onCreateFolder(newFolderName.trim())
-                        setIsCreatingFolder(false)
-                      }}
-                      className="manager-inline-input"
-                      placeholder={t.folderName}
-                    />
-                  </span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span></span>
-                </div>
+                <ManagerInlineFolderRow
+                  afterNameCells={['--', '--', null]}
+                  placeholder={t.folderName}
+                  value={newFolderName}
+                  onChange={setNewFolderName}
+                  onCommit={onCreateFolder}
+                  onDismiss={() => {
+                    setIsCreatingFolder(false)
+                    setNewFolderName('')
+                  }}
+                />
               )}
               {visibleNodes.map((node) => renderNode(node, 0, { includeChildren: !isSearching }))}
               {visibleNodes.length === 0 && !(isCreatingFolder && resolvedActiveFolderId === 'all') && (

--- a/apps/tauri/src/renderer/features/common/ManagerInlineFolderRow.tsx
+++ b/apps/tauri/src/renderer/features/common/ManagerInlineFolderRow.tsx
@@ -1,0 +1,71 @@
+import { useRef, type ReactNode } from 'react'
+import { AppIcon } from './AppIcon'
+
+export function ManagerInlineFolderRow({
+  value,
+  placeholder,
+  afterNameCells,
+  className = '',
+  onChange,
+  onCommit,
+  onDismiss
+}: {
+  value: string
+  placeholder: string
+  afterNameCells: ReactNode[]
+  className?: string
+  onChange(value: string): void
+  onCommit(name: string): boolean | void | Promise<boolean | void>
+  onDismiss(): void
+}) {
+  const isCommittingRef = useRef(false)
+
+  const commit = async () => {
+    if (isCommittingRef.current) return
+    const name = value.trim()
+    if (!name) {
+      onDismiss()
+      return
+    }
+
+    isCommittingRef.current = true
+    try {
+      const result = await onCommit(name)
+      if (result !== false) onDismiss()
+    } finally {
+      isCommittingRef.current = false
+    }
+  }
+
+  return (
+    <div className={`manager-row folder-row ${className}`.trim()}>
+      <span className="manager-name-cell">
+        <span className="folder-icon manager-folder-toggle">
+          <AppIcon name="chevron-right" size={12} />
+        </span>
+        <input
+          autoFocus
+          aria-label={placeholder}
+          className="manager-inline-input"
+          placeholder={placeholder}
+          type="text"
+          value={value}
+          onBlur={() => void commit()}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault()
+              void commit()
+            } else if (event.key === 'Escape') {
+              event.preventDefault()
+              onDismiss()
+            }
+          }}
+        />
+      </span>
+      {afterNameCells.map((cell, index) => (
+        <span key={index}>{cell}</span>
+      ))}
+    </div>
+  )
+}

--- a/apps/tauri/src/renderer/features/common/manager-drag.ts
+++ b/apps/tauri/src/renderer/features/common/manager-drag.ts
@@ -1,0 +1,20 @@
+export type ManagerDropPosition = 'top' | 'bottom' | 'inside'
+
+export function resolveManagerDropPosition(
+  element: HTMLElement,
+  clientY: number,
+  canDropInside: boolean
+): ManagerDropPosition {
+  const rect = element.getBoundingClientRect()
+  const y = clientY - rect.top
+  if (canDropInside) {
+    if (y < rect.height * 0.25) return 'top'
+    if (y > rect.height * 0.75) return 'bottom'
+    return 'inside'
+  }
+  return y < rect.height * 0.5 ? 'top' : 'bottom'
+}
+
+export function managerDropClass(isActiveTarget: boolean, position: ManagerDropPosition | null) {
+  return isActiveTarget && position ? `drop-${position}` : ''
+}

--- a/apps/tauri/src/renderer/features/connections/ConnectionManagerModal.tsx
+++ b/apps/tauri/src/renderer/features/connections/ConnectionManagerModal.tsx
@@ -4,6 +4,8 @@ import { ConfirmActionDialog } from '../common/ConfirmActionDialog'
 import { t } from '../../i18n'
 import { AppIcon } from '../common/AppIcon'
 import { CloseButton } from '../common/CloseButton'
+import { ManagerInlineFolderRow } from '../common/ManagerInlineFolderRow'
+import { managerDropClass, resolveManagerDropPosition } from '../common/manager-drag'
 import { usePointerSortFallback, type PointerSortTarget } from '../../hooks/usePointerSortFallback'
 
 type ConnectionTreeNode =
@@ -220,14 +222,7 @@ export function ConnectionManagerModal({
     if (element.closest('.connection-manager-sidebar')) return 'inside' as const
     const targetNode = tree.map.get(targetId)
     if (!targetNode) return null
-    const rect = element.getBoundingClientRect()
-    const y = clientY - rect.top
-    if (targetNode.type === 'folder') {
-      if (y < rect.height * 0.25) return 'top' as const
-      if (y > rect.height * 0.75) return 'bottom' as const
-      return 'inside' as const
-    }
-    return y < rect.height * 0.5 ? ('top' as const) : ('bottom' as const)
+    return resolveManagerDropPosition(element, clientY, targetNode.type === 'folder')
   }
 
   const moveToRoot = (id: string) => {
@@ -375,10 +370,7 @@ export function ConnectionManagerModal({
     const isDragOver = dragOverId === node.id
     const isDragging = draggingId === node.id
 
-    let dropClass = ''
-    if (isDragOver && dragPosition) {
-      dropClass = `drop-${dragPosition}`
-    }
+    const dropClass = managerDropClass(isDragOver, dragPosition)
 
     return (
       <div key={node.id}>
@@ -612,39 +604,26 @@ export function ConnectionManagerModal({
             </div>
             <div className="manager-body connection-manager-body">
               {isCreatingFolder && resolvedActiveFolderId === 'all' && (
-                <div className="manager-row folder-row">
-                  <span className="manager-name-cell">
-                    <span className="folder-icon manager-folder-toggle">
-                      <AppIcon name="chevron-right" size={12} />
-                    </span>
-                    <input
-                      type="text"
-                      autoFocus
-                      value={newFolderName}
-                      onChange={(e) => setNewFolderName(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && newFolderName.trim()) {
-                          onCreateFolder(newFolderName.trim())
-                          setIsCreatingFolder(false)
-                        } else if (e.key === 'Escape') {
-                          setIsCreatingFolder(false)
-                        }
-                      }}
-                      onBlur={() => {
-                        if (newFolderName.trim()) onCreateFolder(newFolderName.trim())
-                        setIsCreatingFolder(false)
-                      }}
-                      className="manager-inline-input"
-                      placeholder={t.folderName}
-                    />
-                  </span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span className="manager-type-badge is-folder">{t.homeFolderType}</span>
-                  <span>--</span>
-                  <span></span>
-                </div>
+                <ManagerInlineFolderRow
+                  afterNameCells={[
+                    '--',
+                    '--',
+                    '--',
+                    <span className="manager-type-badge is-folder" key="type">
+                      {t.homeFolderType}
+                    </span>,
+                    '--',
+                    null
+                  ]}
+                  placeholder={t.folderName}
+                  value={newFolderName}
+                  onChange={setNewFolderName}
+                  onCommit={onCreateFolder}
+                  onDismiss={() => {
+                    setIsCreatingFolder(false)
+                    setNewFolderName('')
+                  }}
+                />
               )}
               {visibleNodes.map((node) => renderNode(node, 0, { includeChildren: !isSearching }))}
               {visibleNodes.length === 0 && !(isCreatingFolder && resolvedActiveFolderId === 'all') && (

--- a/apps/tauri/src/renderer/features/settings/SettingsModal.tsx
+++ b/apps/tauri/src/renderer/features/settings/SettingsModal.tsx
@@ -67,7 +67,9 @@ export function SettingsModal({
     const platform = desktopApi?.platform ?? 'unknown'
     const arch = desktopApi?.arch ?? 'unknown'
     if (platform === 'darwin') {
-      return arch === 'arm64' ? 'macOS (Apple Silicon)' : 'macOS (Intel)'
+      if (arch === 'arm64') return 'macOS (Apple Silicon)'
+      if (arch === 'x64' || arch === 'x86_64') return 'macOS (Intel)'
+      return `macOS (${arch})`
     }
     if (platform === 'win32') {
       return arch === 'arm64' ? 'Windows (ARM)' : `Windows (${arch})`
@@ -429,8 +431,8 @@ export function SettingsModal({
                     <span className="info-value">v{desktopApi?.appVersion ?? '—'}</span>
                   </div>
                   <div className="about-info-item">
-                    <span className="info-label">Electron</span>
-                    <span className="info-value">v42.4.0</span>
+                    <span className="info-label">{desktopApi?.runtimeName ?? '—'}</span>
+                    <span className="info-value">v{desktopApi?.runtimeVersion ?? '—'}</span>
                   </div>
                   <div className="about-info-item">
                     <span className="info-label">{t.environmentInfo}</span>

--- a/apps/tauri/src/renderer/features/ssh-keys/SshKeyManagerPage.tsx
+++ b/apps/tauri/src/renderer/features/ssh-keys/SshKeyManagerPage.tsx
@@ -11,6 +11,8 @@ import {
 import type { SshKeyMetadata } from '@fileterm/core'
 import { AppIcon } from '../common/AppIcon'
 import { ConfirmActionDialog } from '../common/ConfirmActionDialog'
+import { ManagerInlineFolderRow } from '../common/ManagerInlineFolderRow'
+import { managerDropClass, resolveManagerDropPosition, type ManagerDropPosition } from '../common/manager-drag'
 import { useSshKeyLibrary } from '../../hooks/useSshKeyLibrary'
 import { SshKeyNoteDialog } from './SshKeyNoteDialog'
 import { t } from '../../i18n'
@@ -32,7 +34,7 @@ type SshKeyManagerUiState = {
 
 type DeleteTarget = { kind: 'folder' | 'key'; id: string; name: string }
 type DragItem = { kind: 'folder' | 'key'; id: string }
-type DragPosition = 'top' | 'bottom' | 'inside'
+type DragPosition = ManagerDropPosition
 type SortableItem = { kind: DragItem['kind']; id: string; fallbackOrder: number }
 
 const ROOT_DROP_TARGET_ID = '__ssh-key-root__'
@@ -53,6 +55,7 @@ export function SshKeyManagerPage({
   const { keys, loading, error, clearError, selectKeyFile, importKey, updateNote, deleteKey } = useSshKeyLibrary()
   const [query, setQuery] = useState('')
   const [busy, setBusy] = useState(false)
+  const [uiStateError, setUiStateError] = useState<string | null>(null)
   const [noteDialog, setNoteDialog] = useState<
     { mode: 'import' } | { mode: 'edit'; keyId: string; initialNote: string } | null
   >(null)
@@ -72,40 +75,52 @@ export function SshKeyManagerPage({
   const [isActionsExpanded, setIsActionsExpanded] = useState(false)
   const [isCreatingFolder, setIsCreatingFolder] = useState(false)
   const [newFolderName, setNewFolderName] = useState('')
+  const uiStateRevisionRef = useRef(0)
 
   useEffect(() => {
     let disposed = false
-    void desktopApi?.getUiStateItem(SSH_KEY_MANAGER_UI_STATE).then((raw) => {
-      if (disposed || !raw) return
-      try {
+    const revisionAtStart = uiStateRevisionRef.current
+    void desktopApi
+      ?.getUiStateItem(SSH_KEY_MANAGER_UI_STATE)
+      .then((raw) => {
+        if (disposed || !raw || revisionAtStart !== uiStateRevisionRef.current) return
         const parsed = JSON.parse(raw) as Partial<SshKeyManagerUiState>
         const nextFolders = Array.isArray(parsed.folders) ? parsed.folders.filter(isSshKeyFolder) : []
         const nextItemOrder = parsed.itemOrder ?? parsed.keyOrder ?? {}
         setFolders(nextFolders)
         setAssignments(parsed.assignments && typeof parsed.assignments === 'object' ? parsed.assignments : {})
         setItemOrder(nextItemOrder && typeof nextItemOrder === 'object' ? nextItemOrder : {})
-      } catch {
-        // Ignore an invalid UI state item and use the empty library layout.
-      }
-    })
+        setUiStateError(null)
+      })
+      .catch((cause: unknown) => {
+        if (!disposed) setUiStateError(cause instanceof Error ? cause.message : String(cause))
+      })
     return () => {
       disposed = true
     }
   }, [desktopApi])
 
   const persistUiState = useCallback(
-    (nextFolders: SshKeyFolder[], nextAssignments: Record<string, string>, nextItemOrder = itemOrder) => {
-      setFolders(nextFolders)
-      setAssignments(nextAssignments)
-      setItemOrder(nextItemOrder)
-      void desktopApi?.setUiStateItem(
-        SSH_KEY_MANAGER_UI_STATE,
-        JSON.stringify({
-          folders: nextFolders,
-          assignments: nextAssignments,
-          itemOrder: nextItemOrder
-        } satisfies SshKeyManagerUiState)
-      )
+    async (nextFolders: SshKeyFolder[], nextAssignments: Record<string, string>, nextItemOrder = itemOrder) => {
+      uiStateRevisionRef.current += 1
+      try {
+        await desktopApi?.setUiStateItem(
+          SSH_KEY_MANAGER_UI_STATE,
+          JSON.stringify({
+            folders: nextFolders,
+            assignments: nextAssignments,
+            itemOrder: nextItemOrder
+          } satisfies SshKeyManagerUiState)
+        )
+        setFolders(nextFolders)
+        setAssignments(nextAssignments)
+        setItemOrder(nextItemOrder)
+        setUiStateError(null)
+        return true
+      } catch (cause) {
+        setUiStateError(cause instanceof Error ? cause.message : String(cause))
+        return false
+      }
     },
     [desktopApi, itemOrder]
   )
@@ -185,11 +200,8 @@ export function SshKeyManagerPage({
     onStatsChange?.({ keyCount: keys.length, folderCount: folders.length })
   }, [folders.length, keys.length, onStatsChange])
 
-  const finishFolderCreation = () => {
-    const name = newFolderName.trim()
-    setIsCreatingFolder(false)
-    setNewFolderName('')
-    if (!name || folders.some((folder) => folder.name === name)) return
+  const finishFolderCreation = async (name: string) => {
+    if (folders.some((folder) => folder.name === name)) return false
 
     const folder = { id: createId('ssh-folder'), name }
     const rootOrders = [
@@ -198,7 +210,7 @@ export function SshKeyManagerPage({
         .filter((key) => !folders.some((item) => assignments[key.id] === item.id))
         .map((key) => orderOf(key.id, key.importedAt))
     ]
-    persistUiState([...folders, folder], assignments, {
+    return persistUiState([...folders, folder], assignments, {
       ...itemOrder,
       [folder.id]: Math.max(0, ...rootOrders) + 1000
     })
@@ -299,6 +311,12 @@ export function SshKeyManagerPage({
     dragStateRef.current = { dragging: null, dragOver: null }
     setDragging(null)
     setDragOver(null)
+    // Pointer-sort does not emit the native `dragend` event. Keep the click
+    // generated by this pointer-up suppressed, then restore normal folder
+    // expand/collapse clicks on the next event-loop turn.
+    window.setTimeout(() => {
+      suppressRowClickRef.current = false
+    }, 0)
   }
 
   const sortableItemsForParent = (parentId?: string): SortableItem[] => {
@@ -377,12 +395,7 @@ export function SshKeyManagerPage({
     clientY: number
   ): DragPosition => {
     if (element.closest('.connection-manager-sidebar')) return 'inside'
-    const rect = element.getBoundingClientRect()
-    const y = clientY - rect.top
-    if (target.kind === 'folder' && dragItem.kind === 'key' && y >= rect.height * 0.25 && y <= rect.height * 0.75) {
-      return 'inside'
-    }
-    return y < rect.height * 0.5 ? 'top' : 'bottom'
+    return resolveManagerDropPosition(element, clientY, target.kind === 'folder' && dragItem.kind === 'key')
   }
 
   const applyDrop = (activeDragging: DragItem, target: DragItem, position: DragPosition) => {
@@ -479,9 +492,6 @@ export function SshKeyManagerPage({
 
   const handleDragEnd = () => {
     clearDragState()
-    window.setTimeout(() => {
-      suppressRowClickRef.current = false
-    }, 0)
   }
 
   const handleImport = async (note: string, sourcePath?: string, folderId?: string) => {
@@ -526,13 +536,11 @@ export function SshKeyManagerPage({
   const folderForKey = (keyId: string) => assignments[keyId] ?? ''
 
   const isFolderDragOver = (folderId: string) => {
-    if (!dragOver || dragOver.id !== folderId) return ''
-    return `drop-${dragOver.position}`
+    return managerDropClass(dragOver?.id === folderId, dragOver?.position ?? null)
   }
 
   const isKeyDragOver = (keyId: string) => {
-    if (!dragOver || dragOver.id !== keyId) return ''
-    return `drop-${dragOver.position}`
+    return managerDropClass(dragOver?.id === keyId, dragOver?.position ?? null)
   }
 
   const openNewKeyDialog = () => {
@@ -635,37 +643,22 @@ export function SshKeyManagerPage({
               <span>操作</span>
             </div>
             <div className="manager-body connection-manager-body">
-              {error && !noteDialog ? <div className="ssh-key-manager-error">{error}</div> : null}
+              {(error || uiStateError) && !noteDialog ? (
+                <div className="ssh-key-manager-error">{error || uiStateError}</div>
+              ) : null}
               {isCreatingFolder && activeFolderId === 'all' ? (
-                <div className="manager-row folder-row ssh-key-folder-create-row">
-                  <span className="ssh-key-folder-name-cell">
-                    <span className="folder-icon manager-folder-toggle">
-                      <AppIcon name="chevron-right" size={12} />
-                    </span>
-                    <input
-                      autoFocus
-                      aria-label="文件夹名称"
-                      className="manager-inline-input"
-                      placeholder="文件夹名称"
-                      type="text"
-                      value={newFolderName}
-                      onChange={(event) => setNewFolderName(event.target.value)}
-                      onBlur={finishFolderCreation}
-                      onKeyDown={(event) => {
-                        if (event.key === 'Enter') finishFolderCreation()
-                        if (event.key === 'Escape') {
-                          setIsCreatingFolder(false)
-                          setNewFolderName('')
-                        }
-                      }}
-                    />
-                  </span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span>--</span>
-                  <span />
-                </div>
+                <ManagerInlineFolderRow
+                  afterNameCells={['--', '--', '--', '--', null]}
+                  className="ssh-key-folder-create-row"
+                  placeholder={t.folderName}
+                  value={newFolderName}
+                  onChange={setNewFolderName}
+                  onCommit={finishFolderCreation}
+                  onDismiss={() => {
+                    setIsCreatingFolder(false)
+                    setNewFolderName('')
+                  }}
+                />
               ) : null}
               {activeFolderId === 'all'
                 ? rootItems.map((rootItem) => {

--- a/apps/tauri/src/renderer/features/system/SystemSidebar.tsx
+++ b/apps/tauri/src/renderer/features/system/SystemSidebar.tsx
@@ -20,7 +20,6 @@ export function SystemSidebar({
   activeSession,
   collapsed,
   showResourceMeters,
-  showToggle,
   onOpenSystemInfo,
   onToggleCollapsed
 }: {
@@ -28,7 +27,6 @@ export function SystemSidebar({
   activeSession: SessionSnapshot | null
   collapsed: boolean
   showResourceMeters: boolean
-  showToggle: boolean
   onOpenSystemInfo(): void
   onToggleCollapsed(): void
 }) {
@@ -62,31 +60,29 @@ export function SystemSidebar({
 
   return (
     <div className={`system-sidebar-layout ${collapsed ? 'is-collapsed' : ''}`}>
-      {showToggle ? (
-        <button
-          aria-label={collapsed ? t.showSystemSidebar : t.hideSystemSidebar}
-          className={`system-sidebar-toggle ${collapsed ? 'is-collapsed' : ''}`}
-          onClick={onToggleCollapsed}
-          title={collapsed ? t.showSystemSidebar : t.hideSystemSidebar}
-          type="button"
+      <button
+        aria-label={collapsed ? t.showSystemSidebar : t.hideSystemSidebar}
+        className={`system-sidebar-toggle ${collapsed ? 'is-collapsed' : ''}`}
+        onClick={onToggleCollapsed}
+        title={collapsed ? t.showSystemSidebar : t.hideSystemSidebar}
+        type="button"
+      >
+        <svg
+          className="system-sidebar-toggle-icon"
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
         >
-          <svg
-            className="system-sidebar-toggle-icon"
-            width="14"
-            height="14"
-            viewBox="0 0 16 16"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <rect x="1.5" y="1.5" width="13" height="13" rx="2.5" />
-            <path d="M5.25 1.5V14.5" />
-          </svg>
-        </button>
-      ) : null}
+          <rect x="1.5" y="1.5" width="13" height="13" rx="2.5" />
+          <path d="M5.25 1.5V14.5" />
+        </svg>
+      </button>
       {!collapsed ? (
         <>
           <section className="sys-card">

--- a/apps/tauri/src/renderer/features/system/SystemSidebarShell.tsx
+++ b/apps/tauri/src/renderer/features/system/SystemSidebarShell.tsx
@@ -7,7 +7,6 @@ export function SystemSidebarShell({
   activeSession,
   collapsed,
   showResourceMeters,
-  showToggle,
   isResizing,
   onOpenSystemInfo,
   onResizeStart,
@@ -18,7 +17,6 @@ export function SystemSidebarShell({
   activeSession: SessionSnapshot | null
   collapsed: boolean
   showResourceMeters: boolean
-  showToggle: boolean
   isResizing: boolean
   onOpenSystemInfo(): void
   onResizeStart(): void
@@ -32,7 +30,6 @@ export function SystemSidebarShell({
         activeSession={activeSession}
         collapsed={collapsed}
         showResourceMeters={showResourceMeters}
-        showToggle={showToggle}
         onOpenSystemInfo={onOpenSystemInfo}
         onToggleCollapsed={() => {
           const nextCollapsed = !collapsed

--- a/apps/tauri/src/renderer/features/workspace/SshTunnelPanel.tsx
+++ b/apps/tauri/src/renderer/features/workspace/SshTunnelPanel.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import type { SshForwardRule, SshTunnelSnapshot } from '@fileterm/core'
 import { AppIcon } from '../common/AppIcon'
 import { CloseButton } from '../common/CloseButton'
+import { ConfirmActionDialog } from '../common/ConfirmActionDialog'
 
 const initialDraft = (): SshForwardRule => ({
   id: globalThis.crypto.randomUUID(),
@@ -215,9 +216,9 @@ function TunnelEditorDialog({ children, onClose }: { children: ReactNode; onClos
         role="dialog"
       >
         <header className="ssh-tunnel-dialog-header">
-          <div>
+          <div className="ssh-tunnel-dialog-title">
+            <AppIcon name="connections" size={16} />
             <span id="ssh-tunnel-dialog-title">新增运行时隧道</span>
-            <p>只在当前 SSH 工作区生效，关闭连接后自动停止。</p>
           </div>
           <CloseButton aria-label="关闭新增隧道窗口" onClick={onClose} size="compact" />
         </header>
@@ -242,6 +243,8 @@ function TunnelRow({
 }) {
   const running = tunnel.status === 'running' || tunnel.status === 'starting'
   const target = tunnel.kind === 'dynamic' ? 'SOCKS5' : `${tunnel.targetHost}:${tunnel.targetPort}`
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
   const update = async (action: () => Promise<SshTunnelSnapshot[]>) => {
     try {
       onChange(await action())
@@ -250,40 +253,64 @@ function TunnelRow({
       onError(cause instanceof Error ? cause.message : String(cause))
     }
   }
+
+  const deleteTunnel = async () => {
+    setIsDeleting(true)
+    try {
+      onChange(await window.fileterm!.deleteSshTunnel(tabId, tunnel.id))
+      onError(null)
+      setIsDeleteConfirmOpen(false)
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
   return (
-    <article className="ssh-tunnel-row">
-      <span className={`ssh-tunnel-status is-${tunnel.status}`} aria-label={tunnel.status} />
-      <div className="ssh-tunnel-description">
-        <strong>{tunnel.name || `${tunnel.kind.toUpperCase()} ${tunnel.bindPort}`}</strong>
-        <span>
-          {tunnel.kind.toUpperCase()} · {tunnel.bindHost}:{tunnel.bindPort} → {target}
-        </span>
-        {tunnel.error ? <em>{tunnel.error}</em> : null}
-      </div>
-      <span className="ssh-tunnel-state">{tunnel.status}</span>
-      <div className="ssh-tunnel-actions">
-        <button
-          type="button"
-          onClick={() =>
-            void update(() =>
-              running
-                ? window.fileterm!.stopSshTunnel(tabId, tunnel.id)
-                : window.fileterm!.startSshTunnel(tabId, tunnel.id)
-            )
-          }
-        >
-          {running ? '停止' : '启动'}
-        </button>
-        {tunnel.runtimeOnly ? (
+    <>
+      <article className="ssh-tunnel-row">
+        <span className={`ssh-tunnel-status is-${tunnel.status}`} aria-label={tunnel.status} />
+        <div className="ssh-tunnel-description">
+          <strong>{tunnel.name || `${tunnel.kind.toUpperCase()} ${tunnel.bindPort}`}</strong>
+          <span>
+            {tunnel.kind.toUpperCase()} · {tunnel.bindHost}:{tunnel.bindPort} → {target}
+          </span>
+          {tunnel.error ? <em>{tunnel.error}</em> : null}
+        </div>
+        <span className="ssh-tunnel-state">{tunnel.status}</span>
+        <div className="ssh-tunnel-actions">
           <button
             type="button"
-            className="danger"
-            onClick={() => void update(() => window.fileterm!.deleteSshTunnel(tabId, tunnel.id))}
+            onClick={() =>
+              void update(() =>
+                running
+                  ? window.fileterm!.stopSshTunnel(tabId, tunnel.id)
+                  : window.fileterm!.startSshTunnel(tabId, tunnel.id)
+              )
+            }
           >
-            删除
+            {running ? '停止' : '启动'}
           </button>
-        ) : null}
-      </div>
-    </article>
+          {tunnel.runtimeOnly ? (
+            <button type="button" className="danger" onClick={() => setIsDeleteConfirmOpen(true)}>
+              删除
+            </button>
+          ) : null}
+        </div>
+      </article>
+      {isDeleteConfirmOpen ? (
+        <ConfirmActionDialog
+          confirmLabel="删除"
+          description={`确定删除隧道“${tunnel.name || `${tunnel.kind.toUpperCase()} ${tunnel.bindPort}`}”吗？删除后 ${tunnel.bindHost}:${tunnel.bindPort} 的监听会立即停止，且无法恢复。`}
+          isSubmitting={isDeleting}
+          onClose={() => {
+            if (!isDeleting) setIsDeleteConfirmOpen(false)
+          }}
+          onConfirm={() => void deleteTunnel()}
+          title="删除隧道"
+        />
+      ) : null}
+    </>
   )
 }

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -2707,29 +2707,29 @@
   color: var(--text-main);
   font-family: var(--font-mono, monospace);
 }
-.ssh-tunnel-dialog {
+.modal-card.ssh-tunnel-dialog {
   width: min(560px, calc(100vw - 40px));
-  padding: 0;
+  padding: 0 !important;
+  overflow: hidden;
 }
 .ssh-tunnel-dialog-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 18px 20px 14px;
+  min-height: 48px;
+  padding: 0 16px;
   border-bottom: 1px solid var(--border-light);
 }
-.ssh-tunnel-dialog-header span {
-  display: block;
+.ssh-tunnel-dialog-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   color: var(--text-main);
-  font-size: 15px;
-  font-weight: 600;
 }
-.ssh-tunnel-dialog-header p {
-  margin: 4px 0 0;
-  color: var(--text-muted);
-  font-size: 12px;
-  line-height: 1.5;
+.ssh-tunnel-dialog-title > span {
+  font-size: 13px;
+  font-weight: 500;
 }
 .ssh-tunnel-form {
   display: grid;
@@ -2781,6 +2781,9 @@
   grid-column: 1 / -1;
   align-self: end;
   justify-content: end;
+  margin: 6px -20px -20px;
+  padding: 16px 20px;
+  border-top: 1px solid var(--border-light);
 }
 .ssh-tunnel-form-actions .flat-button {
   min-width: 76px;

--- a/apps/tauri/src/renderer/styles/features/ssh-keys.css
+++ b/apps/tauri/src/renderer/styles/features/ssh-keys.css
@@ -139,8 +139,8 @@
 }
 
 .ssh-key-folder-create-row {
-  min-height: 48px !important;
-  height: 48px !important;
+  min-height: 36px !important;
+  height: 36px !important;
   color: var(--text-main);
   box-sizing: border-box;
 }
@@ -149,7 +149,7 @@
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
 }
 
 .ssh-key-folder-row {
@@ -159,11 +159,6 @@
 
 .ssh-key-folder-row strong {
   font-weight: 500;
-}
-
-.ssh-key-folder-row.drop-inside {
-  background: var(--selection-bg) !important;
-  box-shadow: inset 3px 0 0 var(--accent-primary);
 }
 
 .ssh-key-nested-row {
@@ -182,25 +177,6 @@
 .ssh-key-empty-folder span {
   grid-column: 1 / -1;
   padding-left: 28px;
-}
-
-.ssh-key-folder-create-row input {
-  width: 100%;
-  min-width: 0;
-  max-width: 280px;
-  padding: 4px 8px;
-  border: 1px solid var(--accent-primary);
-  border-radius: 6px;
-  outline: 0;
-  background: var(--input-bg);
-  color: var(--text-main);
-  font: inherit;
-  font-size: 13px;
-  box-sizing: border-box;
-}
-
-.ssh-key-folder-create-row input:focus {
-  box-shadow: 0 0 0 2px var(--accent-focus-ring);
 }
 
 .ssh-private-key-field {

--- a/apps/tauri/src/renderer/styles/themes/default-dark.css
+++ b/apps/tauri/src/renderer/styles/themes/default-dark.css
@@ -1335,6 +1335,7 @@
 :root[data-theme='default-dark'] .manager-row.drop-inside,
 :root[data-theme='default'] .manager-row.drop-inside {
   background: var(--selection-bg);
+  box-shadow: inset 3px 0 0 var(--accent-primary);
 }
 
 :root:not([data-theme]) .folder-row,
@@ -3170,5 +3171,36 @@
 :root:not([data-theme]) .ssh-key-import-dialog .ssh-key-import-dialog__file-name,
 :root[data-theme='default-dark'] .ssh-key-import-dialog .ssh-key-import-dialog__file-name,
 :root[data-theme='default'] .ssh-key-import-dialog .ssh-key-import-dialog__file-name {
+  background: #1a1a1a !important;
+}
+
+/* Runtime tunnel editor follows the command editor's neutral dark surface hierarchy. */
+:root:not([data-theme]) .ssh-tunnel-dialog,
+:root[data-theme='default-dark'] .ssh-tunnel-dialog,
+:root[data-theme='default'] .ssh-tunnel-dialog,
+:root:not([data-theme]) .ssh-tunnel-form,
+:root[data-theme='default-dark'] .ssh-tunnel-form,
+:root[data-theme='default'] .ssh-tunnel-form {
+  background: #1b1b1b !important;
+}
+
+:root:not([data-theme]) .ssh-tunnel-form-actions,
+:root[data-theme='default-dark'] .ssh-tunnel-form-actions,
+:root[data-theme='default'] .ssh-tunnel-form-actions {
+  background: #1b1b1b !important;
+}
+
+:root:not([data-theme]) .ssh-tunnel-dialog-header,
+:root[data-theme='default-dark'] .ssh-tunnel-dialog-header,
+:root[data-theme='default'] .ssh-tunnel-dialog-header {
+  background: #242424 !important;
+}
+
+:root:not([data-theme]) .ssh-tunnel-form input,
+:root[data-theme='default-dark'] .ssh-tunnel-form input,
+:root[data-theme='default'] .ssh-tunnel-form input,
+:root:not([data-theme]) .ssh-tunnel-form select,
+:root[data-theme='default-dark'] .ssh-tunnel-form select,
+:root[data-theme='default'] .ssh-tunnel-form select {
   background: #1a1a1a !important;
 }

--- a/apps/tauri/src/renderer/styles/themes/default-light.css
+++ b/apps/tauri/src/renderer/styles/themes/default-light.css
@@ -941,7 +941,11 @@
   background: #eef2f7;
 }
 
-:root[data-theme='default-light'] .manager-row.drop-inside,
+:root[data-theme='default-light'] .manager-row.drop-inside {
+  background: var(--selection-bg);
+  box-shadow: inset 3px 0 0 var(--accent-primary);
+}
+
 :root[data-theme='default-light'] .folder-row {
   background: rgba(148, 163, 184, 0.08);
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,12 +181,17 @@ platform probe
 平台差异的原则：
 
 - renderer 从 `tauri-api.ts` 暴露的平台信息同步到 `document.documentElement.dataset.platform`。
+- 设置页展示的 runtime 名称与版本来自共享桌面 API；Electron preload 返回 Electron 版本，Tauri bridge 通过 Rust command 返回 Tauri 版本，renderer 不写死运行时信息。
+- Tauri 的 renderer UI 状态通过 Rust command 持久化为 `ui-state.json` 键值对象；读取时兼容 Electron 的 `{ version, values }` 包装格式和早期 `{ key, value }[]` 数组格式，业务组件不得自行假设另一种文件结构。
 - CSS 使用 `data-platform` 和稳定 class 做 macOS/Windows/Linux 差异化布局。
+- Tauri 无边框子窗口仅在 macOS 使用透明原生表面，由 renderer 的 `standalone-window-frame` 统一裁切圆角；Windows/Linux 保持不透明表面，避免透明窗口启动闪烁和合成器差异。
 - macOS 菜单栏托盘图标使用 `apps/tauri/build/trayTemplate*.png` template 资源，由 Rust/Tauri backend 设置 template 属性。
+- Tauri 托盘由 Rust backend 显式创建：macOS 使用独立 template 图标，Windows/Linux 使用应用图标。主窗口与可见子窗口隐藏到托盘后会成组恢复；普通关闭请求与真正退出请求保持分离。
 - 应用更新通过 Rust/Tauri update service 统一管理，renderer 仅经 `Rust commands/events -> tauri-api.ts -> renderer` 查询状态和触发检查；当前使用 GitHub Release 版本检查与安全发布页交接，签名静默 updater 仍待 Phase 5 发布资产。
-- 原生关闭快捷键由 Rust/Tauri backend 统一收口：macOS 使用 `Cmd+Q` 请求应用退出确认、`Cmd+W` 请求关闭当前工作区项/子窗口；Windows/Linux 分别保持 `Alt+F4` 退出与 `Ctrl+W` 关闭窗口语义。托盘退出和窗口关闭必须走同一确认与 transfer journal 清理链路。
+- 原生关闭快捷键由 Rust/Tauri backend 统一收口：macOS 使用 `Cmd+Q` 请求应用退出确认、`Cmd+W` 请求关闭当前工作区项/子窗口；Windows/Linux 分别保持 `Alt+F4` 退出与 `Ctrl+W` 关闭窗口语义。最后一个工作区项只触发普通窗口关闭/隐藏，不得直接销毁主窗口；托盘退出和应用退出快捷键必须走同一确认与 transfer journal 清理链路。
 - 主题和语言属于 Rust backend 持久化的 UI preferences；资源监控是 SSH 连接配置，关闭后该连接不采集资源数据，工作区仅保留窄侧栏。
 - 产品更名后，Rust backend 首次启动只迁移旧 Electron 用户目录中的应用自有 JSON 数据；Chromium session、缓存与日志不迁移。
+- Tauri backend 的持久化诊断统一进入 `services/logging.rs`：日志按 `app/window/protocol:tab/metrics/tunnel/transfer:id/local/update/webdav/profile` 分 scope，使用 `DEBUG/INFO/WARN/ERROR` 级别，并执行大小轮转与凭据标签脱敏。服务层不得只写 `stderr`；终端内容、文件内容、密码、token、私钥口令和完整主机指纹不得进入日志。
 
 ## 4.3 传输暂停与恢复边界
 

--- a/docs/plans/active/connection-protocol-expansion.md
+++ b/docs/plans/active/connection-protocol-expansion.md
@@ -2,7 +2,7 @@
 
 > 2026-07-13 实施更新：本计划的核心交付已落地。SSH MFA、SOCKS5/HTTP 代理、Telnet、Serial、SSH Config 导入、Jump Host、运行时 SSH 隧道、两阶段 JSON 导入/单文件兼容导出，以及 WebDAV 手动同步均已接通。当前文档保留为实现与验收记录；后续仅补真实设备和真实 WebDAV 服务的手工验收结果。
 
-> 范围说明（2026-07-14）：以上完成状态指 Electron 基线实现。Rust/Tauri 对齐进度以 `tauri-migration-progress.md` 为准；其中 SSH 隧道和代理尚未在 Tauri 中完成，FTP/FTPS、Telnet、Serial、Transfer 和 WebDAV 真实同步也仍待迁移。
+> 范围说明（2026-07-16）：Electron 是本计划的基线实现；Rust/Tauri 对齐进度以 `tauri-migration-progress.md` 为准。Tauri 已完成 SSH 代理、Jump Host 和运行时 `-L/-R/-D` 隧道，并补齐 workspace capability 快照，使 renderer 可显示并操作隧道面板；剩余工作以真实服务、实体设备和三平台发行验收为主。
 
 ## 实施完成摘要
 

--- a/docs/plans/active/tauri-migration-progress.md
+++ b/docs/plans/active/tauri-migration-progress.md
@@ -134,8 +134,8 @@
 | **Profile import/export**  | `services/connection-config-codec.ts`                          | ✅ SSH config/JSON preview + commit、fileterm/compatible 导出。                                                                                                          |
 | **Command history**        | `services/file-profile-repository.ts`                          | ✅ 每 profile 历史与命令发送偏好已持久化。                                                                                                                               |
 | **openLogsDirectory**      | `apps/electron/src/main/main.ts`                               | ✅ Rust command 打开应用日志目录。                                                                                                                                       |
-| **App logger**             | `services/app-logger.ts`                                       | ✅ 轮转本地 app/SSH/协议错误日志，秘密字段脱敏。                                                                                                                         |
-| **SSH debug logger**       | `services/sessions/ssh-debug-logger.ts`                        | ✅ SSH worker 生命周期/错误写入本地日志；不暴露凭据。                                                                                                                    |
+| **App logger**             | `services/app-logger.ts`                                       | ✅ 统一 `DEBUG/INFO/WARN/ERROR`、scope、并发写入、2 MB 轮转和秘密字段脱敏；覆盖应用/窗口、本地文件、更新、WebDAV、profile 与传输状态机。                                 |
+| **SSH debug logger**       | `services/sessions/ssh-debug-logger.ts`                        | ✅ 覆盖 SSH/SFTP、平台探测、资源采集启停与首样本、自动重连、Jump Host、隧道，以及 FTP/Telnet/Serial 生命周期；不记录终端内容、凭据或完整主机指纹。                       |
 | **真实 sshd/FTP 集成测试** | `test/protocol/sftp-resume.test.mjs` 等                        | ⚠️ Electron 的 7 项真实协议测试已通过。Tauri 本地 OpenSSH、FTPS、WebDAV、Telnet 夹具已覆盖 HTTP/SOCKS5、`-L/-D`、ETag 与 hash；Windows/Linux CI 仅已配置，尚未产生结果。 |
 
 ### 2.2 部分实现（需补齐）

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -844,6 +844,8 @@ export interface FileTermDesktopApi {
   arch: string
   appVersion: string
   appName: string
+  runtimeName: 'Electron' | 'Tauri'
+  runtimeVersion: string
   isDesktop: boolean
   getUpdateStatus(): Promise<AppUpdateStatus>
   checkForUpdates(): Promise<AppUpdateStatus>


### PR DESCRIPTION
## What changed

- align Tauri runtime tunnels, platform/runtime reporting, diagnostics, tray lifecycle, and main-window close behavior with the Electron baseline
- unify connection, command, and SSH-key manager inline-folder creation and drag/drop feedback across Electron and Tauri
- restore rounded macOS child-window surfaces and align tunnel modal styling, deletion confirmation, and title treatment
- persist Tauri UI state compatibly and document the resulting platform/runtime boundaries

## Why

The Tauri implementation had accumulated parity gaps: SSH tunnel capabilities were incomplete, the last Cmd+W path could behave like quitting, tray behavior was missing, runtime/architecture labels were inaccurate, child-window surfaces lost rounded corners, and manager folder interactions used divergent state and styling.

## Validation

- npm run typecheck
- npm run lint -- --max-warnings=0
- npm run format:check
- npm run test:electron
- npm run test:tauri
- npm run build:electron
- npm run test:transfers:protocol -w @fileterm/electron
