### PR TITLE
fix(tauri): prevent duplicate reconnect attempts

### DIFF
--- a/apps/tauri/src-tauri/src/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/mod.rs
@@ -1168,6 +1168,18 @@ pub async fn app_reconnect_tab(
             .iter()
             .find(|p| p.get("id").and_then(|id| id.as_str()) == Some(&pid))
         {
+            // Claim the reconnect before awaiting worker shutdown. Tauri can
+            // dispatch Enter/button/auto-reconnect commands concurrently; a
+            // status check performed after an await lets each caller replace
+            // the worker and append another reconnect banner.
+            let should_start = {
+                let mut tabs = state.tabs.write().await;
+                claim_reconnect_tab(&mut tabs, &tab_id)
+            };
+            if !should_start {
+                return get_workspace_snapshot(app).await;
+            }
+
             // Terminate existing worker
             stop_session_worker(&state, &tab_id).await;
 
@@ -1177,10 +1189,6 @@ pub async fn app_reconnect_tab(
             // We only append a separator + "连接主机..." notice so the user
             // sees that a reconnect is in progress.
             {
-                let mut tabs = state.tabs.write().await;
-                if let Some(tab) = tabs.iter_mut().find(|t| t.id == tab_id) {
-                    tab.status = crate::services::WorkspaceTabStatus::Connecting;
-                }
                 let mut sessions = state.sessions.write().await;
                 if let Some(session) = sessions.get_mut(&tab_id) {
                     session.connected = false;
@@ -1259,6 +1267,17 @@ pub async fn app_reconnect_tab(
     }
 
     get_workspace_snapshot(app).await
+}
+
+fn claim_reconnect_tab(tabs: &mut [crate::services::WorkspaceTab], tab_id: &str) -> bool {
+    let Some(tab) = tabs.iter_mut().find(|tab| tab.id == tab_id) else {
+        return false;
+    };
+    if tab.status == crate::services::WorkspaceTabStatus::Connecting {
+        return false;
+    }
+    tab.status = crate::services::WorkspaceTabStatus::Connecting;
+    true
 }
 
 #[tauri::command]
@@ -2160,6 +2179,40 @@ mod command_template_tests {
             ),
             "deploy api --region cn-north --empty="
         );
+    }
+}
+
+#[cfg(test)]
+mod reconnect_tests {
+    use super::claim_reconnect_tab;
+    use crate::services::{WorkspaceTab, WorkspaceTabStatus};
+
+    fn tab(status: WorkspaceTabStatus) -> WorkspaceTab {
+        WorkspaceTab {
+            id: "tab-1".to_string(),
+            profile_id: "profile-1".to_string(),
+            session_type: "ssh".to_string(),
+            title: "Server".to_string(),
+            layout: "terminal-file".to_string(),
+            status,
+        }
+    }
+
+    #[test]
+    fn reconnect_can_only_be_claimed_once_while_connecting() {
+        let mut tabs = vec![tab(WorkspaceTabStatus::Closed)];
+
+        assert!(claim_reconnect_tab(&mut tabs, "tab-1"));
+        assert_eq!(tabs[0].status, WorkspaceTabStatus::Connecting);
+        assert!(!claim_reconnect_tab(&mut tabs, "tab-1"));
+    }
+
+    #[test]
+    fn reconnect_does_not_claim_an_unknown_tab() {
+        let mut tabs = vec![tab(WorkspaceTabStatus::Closed)];
+
+        assert!(!claim_reconnect_tab(&mut tabs, "missing"));
+        assert_eq!(tabs[0].status, WorkspaceTabStatus::Closed);
     }
 }
 

--- a/apps/tauri/src/renderer/components/TerminalView.tsx
+++ b/apps/tauri/src/renderer/components/TerminalView.tsx
@@ -111,12 +111,14 @@ export const TerminalView = memo(function TerminalView({
   tabId,
   bootText,
   connected = false,
+  connecting = false,
   onStatus,
   onReconnect
 }: {
   tabId: string
   bootText: string
   connected?: boolean
+  connecting?: boolean
   onStatus?(message: string | null): void
   onReconnect?(): void | Promise<void>
 }) {
@@ -141,6 +143,7 @@ export const TerminalView = memo(function TerminalView({
   // through a ref prevents a stale terminal-state event from a background
   // tab from swallowing keystrokes after this tab is brought back.
   const connectedRef = useRef(Boolean(connected))
+  const connectingRef = useRef(Boolean(connecting))
   const lastSyncedSizeRef = useRef<{ cols: number; rows: number; width: number; height: number } | null>(null)
   const lastObservedHostRectRef = useRef<{ width: number; height: number } | null>(null)
   const isHorizontalResizeActiveRef = useRef(false)
@@ -154,6 +157,7 @@ export const TerminalView = memo(function TerminalView({
   const activeTerminalTabIdRef = useRef<string | null>(null)
   tabIdRef.current = tabId
   connectedRef.current = Boolean(connected)
+  connectingRef.current = Boolean(connecting)
   onStatusRef.current = onStatus
   onReconnectRef.current = onReconnect
   const [hasSelection, setHasSelection] = useState(false)
@@ -573,7 +577,7 @@ export const TerminalView = memo(function TerminalView({
     terminal.unicode.activeVersion = '11'
     terminal.open(hostRef.current)
     const requestReconnect = () => {
-      if (wasConnectedRef.current || isReconnectingRef.current) {
+      if (wasConnectedRef.current || connectingRef.current || isReconnectingRef.current) {
         return false
       }
 

--- a/apps/tauri/src/renderer/features/terminal/TerminalDock.tsx
+++ b/apps/tauri/src/renderer/features/terminal/TerminalDock.tsx
@@ -124,11 +124,16 @@ export function TerminalDock({
   }, [panel])
 
   const handleToggleConnection = async () => {
-    if (!window.fileterm) return
+    if (!window.fileterm || activeTab.status === 'connecting' || isReconnectingRef.current) return
     if (connected) {
       await window.fileterm.disconnectTab(activeTab.id)
     } else {
-      await window.fileterm.reconnectTab(activeTab.id)
+      isReconnectingRef.current = true
+      try {
+        await window.fileterm.reconnectTab(activeTab.id)
+      } finally {
+        isReconnectingRef.current = false
+      }
     }
   }
 
@@ -379,7 +384,7 @@ export function TerminalDock({
         return
       }
       event.preventDefault()
-      if (!connected && onReconnect && !isReconnectingRef.current) {
+      if (!connected && activeTab.status !== 'connecting' && onReconnect && !isReconnectingRef.current) {
         isReconnectingRef.current = true
         setReconnectFeedbackVisible(true)
         if (reconnectFeedbackTimerRef.current !== null) {
@@ -571,8 +576,8 @@ export function TerminalDock({
 
   const isMac = window.fileterm?.platform === 'darwin'
   const placeholderText = isMac ? t.terminalDockPlaceholderMac : t.terminalDockPlaceholderWin
-  const connectionStateClass =
-    activeTab.status === 'connecting' ? 'is-connecting' : connected ? 'is-connected' : 'is-disconnected'
+  const isConnecting = activeTab.status === 'connecting'
+  const connectionStateClass = isConnecting ? 'is-connecting' : connected ? 'is-connected' : 'is-disconnected'
 
   return (
     <section ref={rootRef} className="terminal-dock">
@@ -583,8 +588,8 @@ export function TerminalDock({
         <label className="terminal-dock-input-shell">
           <textarea
             ref={inputRef}
-            disabled={activeTab.sessionType !== 'ssh'}
-            placeholder={reconnectFeedbackVisible ? t.terminalReconnecting : placeholderText}
+            disabled={activeTab.sessionType !== 'ssh' || isConnecting}
+            placeholder={reconnectFeedbackVisible || isConnecting ? t.terminalReconnecting : placeholderText}
             rows={1}
             wrap="off"
             value={command}
@@ -611,6 +616,7 @@ export function TerminalDock({
           </button>
           <button
             className={`terminal-dock-icon-btn terminal-dock-connection ${connectionStateClass}`}
+            disabled={isConnecting}
             type="button"
             title={connected ? t.terminalDockDisconnect : t.terminalDockReconnect}
             onClick={handleToggleConnection}

--- a/apps/tauri/src/renderer/features/workspace/SessionWorkspace.tsx
+++ b/apps/tauri/src/renderer/features/workspace/SessionWorkspace.tsx
@@ -379,6 +379,7 @@ export function SessionWorkspace({
             tabId={activeTab.id}
             bootText={activeSession.terminalTranscript ?? ''}
             connected={activeSession.connected === true}
+            connecting={activeTab.status === 'connecting'}
             onReconnect={reconnectOnEnter}
           />
           <TerminalDock


### PR DESCRIPTION
## 变更

- 连接进行中禁用终端命令输入和重连按钮，阻止重复回车触发
- 在 TerminalView 中识别 connecting 状态，忽略重连中的 Enter
- 在 Tauri `app_reconnect_tab` 命令中原子认领重连，拒绝同一标签的并发重连
- 增加单飞认领逻辑回归测试

## 根因

Renderer 侧重连 IPC 很快返回 connecting 快照，原有本地锁随之释放；同时后端没有在标签状态上做原子保护，连续按回车会重复停止/启动 worker 并追加多条重连提示。

## 验证

- `npm run typecheck -w @fileterm/tauri`
- `npm run lint -- --max-warnings=0`
- `npm run format:check`
- `npm run test:tauri`（111 Rust tests + 18 contract tests）