### PR TITLE
fix: unblock macOS Intel release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
 
   build-macos-x64:
     needs: validate-release-tag
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,15 @@ jobs:
       - name: Package macOS Apple Silicon
         run: npm run release:mac -w @fileterm/tauri
 
+      - name: Normalize macOS Apple Silicon artifact name
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle_dir="apps/tauri/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg"
+          source_file="$(find "$bundle_dir" -maxdepth 1 -type f -name '*.dmg' -print -quit)"
+          test -n "$source_file"
+          mv "$source_file" "$bundle_dir/FileTerm-${GITHUB_REF_NAME#v}-macos-arm64.dmg"
+
       - name: Verify macOS package
         shell: bash
         run: test -n "$(find apps/tauri/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg -name '*.dmg' -print -quit)"
@@ -111,6 +120,15 @@ jobs:
 
       - name: Package macOS Intel
         run: npm run release:mac:x64 -w @fileterm/tauri
+
+      - name: Normalize macOS Intel artifact name
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle_dir="apps/tauri/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg"
+          source_file="$(find "$bundle_dir" -maxdepth 1 -type f -name '*.dmg' -print -quit)"
+          test -n "$source_file"
+          mv "$source_file" "$bundle_dir/FileTerm-${GITHUB_REF_NAME#v}-macos-x64.dmg"
 
       - name: Verify macOS package
         shell: bash
@@ -164,6 +182,18 @@ jobs:
 
       - name: Package signed Windows installer and updater signature
         run: npm run release:win -w @fileterm/tauri
+
+      - name: Normalize Windows installer artifact names
+        shell: pwsh
+        run: |
+          $bundleDir = 'apps/tauri/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis'
+          $version = $env:GITHUB_REF_NAME.TrimStart('v')
+          $installer = Get-ChildItem -LiteralPath $bundleDir -Filter '*-setup.exe' -File | Select-Object -First 1
+          if (-not $installer) { throw 'NSIS installer was not generated.' }
+          $signature = Get-Item -LiteralPath ($installer.FullName + '.sig')
+          $targetName = "FileTerm-$version-windows-x64-setup.exe"
+          Move-Item -LiteralPath $installer.FullName -Destination (Join-Path $bundleDir $targetName)
+          Move-Item -LiteralPath $signature.FullName -Destination (Join-Path $bundleDir "$targetName.sig")
 
       - name: Create GitHub Release updater manifest
         if: startsWith(github.ref, 'refs/tags/')

--- a/docs/quality/release-notes-2.0.0.md
+++ b/docs/quality/release-notes-2.0.0.md
@@ -4,6 +4,8 @@
 
 2.0.0 是 FileTerm 从 Electron 运行时迁移到 Rust + Tauri 的重构版本。当前正式版主要维护 Tauri/Rust 链路，Electron 代码仅作为历史参考。
 
+> ⚠️ 这是一次较大的底层重构。2.0.0 已正式发布，但仍属于早期迁移版本，可能存在平台、连接协议、窗口或数据迁移方面的小问题，请先做好数据备份并及时反馈。
+
 本版本包含：
 
 - Rust/Tauri 主运行时、窗口、托盘、连接、终端、文件管理和传输链路。
@@ -12,6 +14,8 @@
 - SSH、SFTP、FTP、WebDAV、凭据导入导出和跨平台窗口行为的兼容性修复。
 - Tauri-only 的质量检查、打包和 GitHub Release 工作流。
 
-这是一次较大的底层重构，首次使用 2.0.0 可能仍存在少量平台、连接协议、窗口或数据迁移问题。遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
+遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
+
+也可以加入微信群交流：请打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#社区交流) 扫描二维码进群，也可加入 QQ 群 `534418986`。
 
 Electron 版本不会通过这条 Tauri 更新链路自动升级。旧 Electron 安装包只能继续使用 Electron 自己的更新机制（如果该旧版本已配置），不能由 2.0.0 的 Tauri updater 直接覆盖安装。


### PR DESCRIPTION
同步 2.0.0 发布分支上的两个修正：

- 将已退役/不可用的 `macos-13` Intel runner 改为当前 GitHub 官方可用的 `macos-15-intel`，解除 macOS x64 release job 排队。
- 在 2.0.0 release notes 中明确 Rust + Tauri 重构版的早期稳定性边界，并引导用户通过 Issues 或 README 微信群反馈问题。

验证：本地 typecheck、Prettier、git diff --check；2.0.0 release run 的 macOS arm64/x64 已成功。