### PR TITLE
fix: stabilize packaged terminal and editor rendering

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/electron",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",
@@ -38,9 +38,9 @@
     "release:win": "npm run build && npm run package:win"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.0",
-    "@fileterm/shared": "2.0.0",
-    "@fileterm/storage": "2.0.0",
+    "@fileterm/core": "2.0.1",
+    "@fileterm/shared": "2.0.1",
+    "@fileterm/storage": "2.0.1",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -24,8 +24,8 @@
     "release:win": "node ./scripts/run-tauri.mjs build --target x86_64-pc-windows-msvc --config src-tauri/tauri.release.windows.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.0",
-    "@fileterm/shared": "2.0.0",
+    "@fileterm/core": "2.0.1",
+    "@fileterm/shared": "2.0.1",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.0.0"
+version = "2.0.1"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/apps/tauri/src/renderer/app/font-metrics.ts
+++ b/apps/tauri/src/renderer/app/font-metrics.ts
@@ -1,0 +1,89 @@
+/**
+ * xterm and Monaco cache glyph dimensions in their canvas renderers. In a
+ * packaged webview a local font can finish loading, or the window can move to
+ * a display with a different scale factor, after either component is mounted.
+ * A regular DOM layout corrects itself in that situation; canvas-backed text
+ * does not. Keep the font stack local to the app bundle and provide one
+ * observer that asks consumers to remeasure at both boundaries.
+ */
+export const FILETERM_MONO_FONT_FAMILY = '"JetBrains Mono", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+const FILETERM_MONO_FONT_FAMILY_REFRESH =
+  '"JetBrains Mono", "JetBrains Mono", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+const MONO_FONT_LOADS = ['400 12px "JetBrains Mono"', '600 13px "JetBrains Mono"']
+
+function nextPaint(callback: () => void) {
+  const firstFrame = window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(callback)
+  })
+  return () => window.cancelAnimationFrame(firstFrame)
+}
+
+/**
+ * Runs after bundled mono fonts become available and whenever WebView changes
+ * device pixel ratio. The returned disposer prevents a closed standalone
+ * editor from receiving a late font event.
+ */
+export function observeCanvasTextMetrics(onMetricsChanged: (fontFamily: string) => void) {
+  let disposed = false
+  let cancelPaint: (() => void) | null = null
+  let useRefreshFontStack = false
+  let pixelRatio = window.devicePixelRatio || 1
+  let pixelRatioQuery = window.matchMedia(`(resolution: ${pixelRatio}dppx)`)
+
+  const notify = () => {
+    if (disposed) {
+      return
+    }
+    cancelPaint?.()
+    cancelPaint = nextPaint(() => {
+      cancelPaint = null
+      if (disposed) {
+        return
+      }
+      useRefreshFontStack = !useRefreshFontStack
+      onMetricsChanged(useRefreshFontStack ? FILETERM_MONO_FONT_FAMILY_REFRESH : FILETERM_MONO_FONT_FAMILY)
+    })
+  }
+
+  const rebindPixelRatioQuery = () => {
+    pixelRatioQuery.removeEventListener('change', onPixelRatioChanged)
+    pixelRatio = window.devicePixelRatio || 1
+    pixelRatioQuery = window.matchMedia(`(resolution: ${pixelRatio}dppx)`)
+    pixelRatioQuery.addEventListener('change', onPixelRatioChanged)
+  }
+
+  const onPixelRatioChanged = () => {
+    rebindPixelRatioQuery()
+    notify()
+  }
+
+  const onViewportResize = () => {
+    const nextPixelRatio = window.devicePixelRatio || 1
+    if (Math.abs(nextPixelRatio - pixelRatio) > 0.001) {
+      rebindPixelRatioQuery()
+      notify()
+    }
+  }
+
+  pixelRatioQuery.addEventListener('change', onPixelRatioChanged)
+  window.addEventListener('resize', onViewportResize)
+  window.visualViewport?.addEventListener('resize', onViewportResize)
+
+  void Promise.all(MONO_FONT_LOADS.map((font) => document.fonts.load(font)))
+    .catch(() => {
+      // A system fallback remains usable if a local font cannot be decoded.
+    })
+    .finally(() => {
+      void document.fonts.ready.then(notify).catch(notify)
+    })
+
+  return () => {
+    disposed = true
+    cancelPaint?.()
+    pixelRatioQuery.removeEventListener('change', onPixelRatioChanged)
+    window.removeEventListener('resize', onViewportResize)
+    window.visualViewport?.removeEventListener('resize', onViewportResize)
+  }
+}

--- a/apps/tauri/src/renderer/components/TerminalView.tsx
+++ b/apps/tauri/src/renderer/components/TerminalView.tsx
@@ -15,6 +15,7 @@ import { t } from '../i18n'
 import { ContextMenu } from '../features/common/ContextMenu'
 import { CloseButton } from '../features/common/CloseButton'
 import { AppIcon } from '../features/common/AppIcon'
+import { FILETERM_MONO_FONT_FAMILY, observeCanvasTextMetrics } from '../app/font-metrics'
 
 function localizeTerminalText(value: string) {
   return value
@@ -545,7 +546,7 @@ export const TerminalView = memo(function TerminalView({
     }
 
     const terminal = new Terminal({
-      fontFamily: '"SF Mono", Menlo, Consolas, monospace',
+      fontFamily: FILETERM_MONO_FONT_FAMILY,
       fontSize: 12,
       lineHeight: 1.05,
       cursorBlink: true,
@@ -744,6 +745,15 @@ export const TerminalView = memo(function TerminalView({
         resize(shouldForce, shouldFreezeCols, preserveVisibleBuffer)
       })
     }
+
+    // Font loading and a monitor-DPI transition occur outside ResizeObserver's
+    // CSS-box model. Refresh xterm's cached glyph/canvas metrics explicitly so
+    // packaged WebView2/WebKit builds cannot keep a fallback-font grid.
+    const disposeCanvasTextMetrics = observeCanvasTextMetrics((fontFamily) => {
+      terminal.options.fontFamily = fontFamily
+      terminal.refresh(0, Math.max(terminal.rows - 1, 0))
+      scheduleResize(true)
+    })
 
     const scheduleSettledHorizontalResize = () => {
       if (resizeSettleTimerRef.current !== null) {
@@ -1008,6 +1018,7 @@ export const TerminalView = memo(function TerminalView({
       pendingPromptResizeRef.current = false
       searchResultsDisposable.dispose()
       osc52Disposable.dispose()
+      disposeCanvasTextMetrics()
       resizeObserver.disconnect()
       hostRef.current?.removeEventListener('contextmenu', onContextMenu)
       window.removeEventListener('keydown', onKeyDown, true)

--- a/apps/tauri/src/renderer/features/files/FileEditorModal.tsx
+++ b/apps/tauri/src/renderer/features/files/FileEditorModal.tsx
@@ -4,6 +4,7 @@ import OpenCC from 'opencc-js'
 import * as monacoEditor from 'monaco-editor'
 import type { FileContentSnapshot } from '@fileterm/core'
 import { t } from '../../i18n'
+import { FILETERM_MONO_FONT_FAMILY, observeCanvasTextMetrics } from '../../app/font-metrics'
 import { CloseButton } from '../common/CloseButton'
 import { AppIcon } from '../common/AppIcon'
 import {
@@ -91,6 +92,7 @@ export function FileEditorModal({
 
   const editorRef = useRef<EditorInstance | null>(null)
   const monacoRef = useRef<Monaco | null>(null)
+  const disposeCanvasTextMetricsRef = useRef<(() => void) | null>(null)
   const encodingRef = useRef(encoding)
   const shellRef = useRef<HTMLDivElement | null>(null)
 
@@ -102,6 +104,13 @@ export function FileEditorModal({
   useEffect(() => {
     encodingRef.current = encoding
   }, [encoding])
+
+  useEffect(() => {
+    return () => {
+      disposeCanvasTextMetricsRef.current?.()
+      disposeCanvasTextMetricsRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
     const onPointerDown = (event: PointerEvent) => {
@@ -142,6 +151,7 @@ export function FileEditorModal({
   const currentEncoding = findEncodingOption(encoding)
   const currentLanguage = languages.find((option) => option.id === language)?.label ?? language
   const handleMount: OnMount = (editor, monaco) => {
+    disposeCanvasTextMetricsRef.current?.()
     editorRef.current = editor
     monacoRef.current = monaco
     setLanguages(sortEditorLanguages(monaco.languages.getLanguages()))
@@ -149,6 +159,14 @@ export function FileEditorModal({
     defineFileTermMonacoTheme(monaco)
     monaco.editor.setTheme(themeMode === 'default-dark' ? MONACO_DARK_THEME : 'vs')
     setLanguage(editor.getModel()?.getLanguageId() ?? 'plaintext')
+
+    // Monaco caches both font widths and line rendering. Unlike normal DOM
+    // text it must be remeasured after local fonts or WebView DPI become ready.
+    disposeCanvasTextMetricsRef.current = observeCanvasTextMetrics((fontFamily) => {
+      editor.updateOptions({ fontFamily })
+      monaco.editor.remeasureFonts()
+      editor.layout()
+    })
 
     const position = editor.getPosition()
     if (position) {
@@ -360,7 +378,7 @@ export function FileEditorModal({
                     seedSearchStringFromSelection: 'always'
                   },
                   fixedOverflowWidgets: true,
-                  fontFamily: '"SF Mono", Menlo, Consolas, monospace',
+                  fontFamily: FILETERM_MONO_FONT_FAMILY,
                   fontLigatures: true,
                   fontSize: 13,
                   lineHeight: 20,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,6 +191,7 @@ platform probe
 - 应用更新通过 Rust/Tauri update service 统一管理，renderer 仅经 `Rust commands/events -> tauri-api.ts -> renderer` 查询状态和触发检查；Windows 使用 GitHub Release 的签名 `latest.json`、NSIS 安装器及其 `.sig` 和两段式“下载验签 → 重启安装”，macOS 发行构建使用 ad hoc 签名并保持检查后跳转 GitHub Release 下载页（不接入 Apple 证书、公证或应用内 updater）。
 - 原生关闭快捷键由 Rust/Tauri backend 统一收口：macOS 使用 `Cmd+Q` 请求应用退出确认、`Cmd+W` 请求关闭当前工作区项/子窗口；Windows/Linux 分别保持 `Alt+F4` 退出与 `Ctrl+W` 关闭窗口语义。最后一个工作区项只触发普通窗口关闭/隐藏，不得直接销毁主窗口；托盘退出和应用退出快捷键必须走同一确认与 transfer journal 清理链路。真正退出前还必须逐个等待独立 Monaco 编辑器完成保存或确认丢弃，任一编辑器取消都会中止 session/transfer shutdown。
 - 主题和语言属于 Rust backend 持久化的 UI preferences；Tauri 应用菜单、托盘菜单与 Windows 自绘 menubar 必须从同一份 locale 构建并在语言切换后刷新。macOS 应用菜单保留 About/Services/Hide/Bring All to Front 等标准角色，但 Quit 仍走 FileTerm 自己的脏编辑器、活动连接和 transfer cleanup 确认链路。资源监控是 SSH 连接配置，关闭后该连接不采集资源数据，工作区仅保留窄侧栏。
+- xterm 与 Monaco 属于缓存字体尺寸/像素比的画布渲染器，统一使用随包的 JetBrains Mono；本地字体完成加载、窗口缩放或跨显示器 DPI 变化后必须主动重测，不能把开发态的系统字体缓存当作正式包的稳定条件。
 - Renderer 的持久化操作必须返回并应用 Rust command 的最新 snapshot；跨窗口广播只负责同步其他窗口，不能作为发起窗口更新成功状态的唯一来源。弹窗、传输与隧道操作在 React 提交态之外还必须使用同步 guard，避免下一帧禁用按钮前的快速双击重复调用 backend。
 - Tauri workspace tab 状态由 Rust 枚举限制为 core `TabStatus` 的 `idle/connecting/connected/error/closed`；正常或主动断开使用 `closed`，worker/连接失败使用 `error`，renderer 不接受运行时自造状态字符串。
 - profile、folder、command 的持久化 mutation 由 Rust workspace 级锁串行化，成功后统一广播 `workspace:snapshot`；完整快照读取使用同一把锁，不能观察跨文件级联写入的中间态。广播失败只记录告警，不能把已经落盘的操作伪装成失败并诱发重复提交。

--- a/docs/quality/release-notes-2.0.1.md
+++ b/docs/quality/release-notes-2.0.1.md
@@ -1,0 +1,11 @@
+# FileTerm 2.0.1
+
+## 正式包终端与编辑器渲染修复
+
+修复 Rust + Tauri 正式包在 Windows 与 macOS 上可能出现的终端和 Monaco 文件编辑器字号异常、行层错位或画布残影问题。
+
+- 终端与 Monaco 统一使用随包提供的 JetBrains Mono，不再依赖各系统是否安装 SF Mono、Menlo 或 Consolas。
+- 本地字体完成加载后，自动重新测量 xterm 终端和 Monaco 编辑器的字形与布局。
+- 窗口缩放、跨显示器 DPI 变化或 WebView 像素比变化后，自动刷新终端与编辑器的缓存尺寸。
+
+如果仍有问题，请在 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交操作系统版本、显示缩放比例、FileTerm 版本、复现步骤和脱敏日志。请勿提交密码、私钥或 token。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,11 +33,11 @@
     },
     "apps/electron": {
       "name": "@fileterm/electron",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "@fileterm/core": "2.0.0",
-        "@fileterm/shared": "2.0.0",
-        "@fileterm/storage": "2.0.0",
+        "@fileterm/core": "2.0.1",
+        "@fileterm/shared": "2.0.1",
+        "@fileterm/storage": "2.0.1",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@xterm/addon-fit": "^0.11.0",
@@ -71,10 +71,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "@fileterm/core": "2.0.0",
-        "@fileterm/shared": "2.0.0",
+        "@fileterm/core": "2.0.1",
+        "@fileterm/shared": "2.0.1",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -8511,17 +8511,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.0.0"
+      "version": "2.0.1"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.0.0"
+      "version": "2.0.1"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "@fileterm/core": "2.0.0"
+        "@fileterm/core": "2.0.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.0"
+    "@fileterm/core": "2.0.1"
   }
 }


### PR DESCRIPTION
## Summary\n- use the bundled JetBrains Mono stack for xterm and Monaco in Tauri\n- remeasure canvas text after font readiness and DPI changes on Windows/macOS\n- bump the Tauri release to 2.0.1 and add user-facing release notes\n\n## Validation\n- npm run typecheck\n- targeted ESLint and Prettier checks\n- cargo fmt --check\n- cargo check\n- npm run build -w @fileterm/tauri -- --no-bundle\n\nThe full local Rust test executable cannot start in this Windows environment (STATUS_ENTRYPOINT_NOT_FOUND after compilation); GitHub CI runs the actual test suite on Linux and compile/fixture coverage on Windows.