### PR TITLE
fix: restore packaged terminal and editor styles

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/electron",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",
@@ -38,9 +38,9 @@
     "release:win": "npm run build && npm run package:win"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.1",
-    "@fileterm/shared": "2.0.1",
-    "@fileterm/storage": "2.0.1",
+    "@fileterm/core": "2.0.2",
+    "@fileterm/shared": "2.0.2",
+    "@fileterm/storage": "2.0.2",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -24,8 +24,8 @@
     "release:win": "node ./scripts/run-tauri.mjs build --target x86_64-pc-windows-msvc --config src-tauri/tauri.release.windows.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.1",
-    "@fileterm/shared": "2.0.1",
+    "@fileterm/core": "2.0.2",
+    "@fileterm/shared": "2.0.2",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "arboard",
  "async-trait",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.0.1"
+version = "2.0.2"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/src/services/ssh_keys.rs
+++ b/apps/tauri/src-tauri/src/services/ssh_keys.rs
@@ -464,7 +464,9 @@ fn lock_down_dir(_path: &Path) -> Result<(), AppError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{probably_encrypted, write_bytes_atomic};
+    use super::probably_encrypted;
+    #[cfg(unix)]
+    use super::write_bytes_atomic;
 
     #[test]
     fn recognizes_private_key_headers_without_treating_public_keys_as_private() {

--- a/apps/tauri/src-tauri/src/services/webdav.rs
+++ b/apps/tauri/src-tauri/src/services/webdav.rs
@@ -644,6 +644,22 @@ mod tests {
             assert!(count > 0, "client closed before completing HTTP headers");
             request.extend_from_slice(&byte[..count]);
         }
+
+        let headers = String::from_utf8(request.clone()).unwrap();
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().unwrap())
+            })
+            .unwrap_or_default();
+        if content_length > 0 {
+            let mut body = vec![0_u8; content_length];
+            socket.read_exact(&mut body).await.unwrap();
+            request.extend_from_slice(&body);
+        }
+
         String::from_utf8(request).unwrap()
     }
 
@@ -775,11 +791,10 @@ mod tests {
             last_etag: Some("\"etag-before-write\"".to_string()),
             content_hash: None,
         };
-        let error = upload_payload(&client().unwrap(), &config, b"{}".to_vec())
-            .await
-            .unwrap_err();
-        assert!(error.to_string().contains("ETag 冲突"));
+        let result = upload_payload(&client().unwrap(), &config, b"{}".to_vec()).await;
         server.await.unwrap();
+        let error = result.unwrap_err();
+        assert!(error.to_string().contains("ETag 冲突"), "{error}");
     }
 
     #[tokio::test]
@@ -805,8 +820,7 @@ mod tests {
             assert!(
                 put_request.contains(&format!("content-length: {}\r\n", expected_payload.len()))
             );
-            let mut body = vec![0_u8; expected_payload.len()];
-            put.read_exact(&mut body).await.unwrap();
+            let body = put_request.split_once("\r\n\r\n").unwrap().1.as_bytes();
             assert_eq!(body, expected_payload);
             put.write_all(
                 b"HTTP/1.1 201 Created\r\nETag: \"etag-after-write\"\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",

--- a/apps/tauri/src-tauri/src/sessions/local_files.rs
+++ b/apps/tauri/src-tauri/src/sessions/local_files.rs
@@ -542,9 +542,9 @@ fn encode_text(text: &str, encoding: &str) -> Vec<u8> {
 
 #[cfg(test)]
 mod permission_tests {
-    use super::{
-        app_change_local_permissions, LocalFileItem, PermissionApplyTarget, PermissionChangeOptions,
-    };
+    #[cfg(unix)]
+    use super::app_change_local_permissions;
+    use super::{LocalFileItem, PermissionApplyTarget, PermissionChangeOptions};
 
     #[test]
     fn local_file_items_serialize_with_core_camel_case_fields() {

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",
@@ -29,7 +29,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' asset: data: blob:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost http://localhost:5188 ws://localhost:5188; frame-src 'none'"
+      "csp": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' asset: data: blob:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost http://localhost:5188 ws://localhost:5188; frame-src 'none'",
+      "dangerousDisableAssetCspModification": ["style-src"]
     }
   },
   "bundle": {

--- a/apps/tauri/src-tauri/tests/contract.rs
+++ b/apps/tauri/src-tauri/tests/contract.rs
@@ -21,6 +21,10 @@
 //! 4. **Event naming contract** — every event emitted via `app.emit(...)`
 //!    uses the `namespace:name` form (`terminal:data`, `workspace:snapshot`,
 //!    `app:window-close-request`, ...). No bare names.
+//!
+//! 5. **Renderer style CSP contract** — xterm and Monaco generate runtime
+//!    styles, so Tauri must not add a nonce to `style-src` that disables the
+//!    configured `unsafe-inline`; script CSP modification remains enabled.
 
 use fileterm_lib::commands::OpenWindowInput;
 use fileterm_lib::services::profile_ops::{heal_profiles, strip_secret_fields_public};
@@ -286,6 +290,39 @@ fn contract_events_use_namespace_colon_name() {
             "event `{name}` must not have an empty namespace or name"
         );
     }
+}
+
+#[test]
+fn renderer_csp_allows_runtime_styles_without_relaxing_scripts() {
+    let config: Value = serde_json::from_str(include_str!("../tauri.conf.json"))
+        .expect("tauri.conf.json must remain valid JSON");
+    let security = config
+        .pointer("/app/security")
+        .and_then(Value::as_object)
+        .expect("Tauri security configuration must exist");
+    let csp = security
+        .get("csp")
+        .and_then(Value::as_str)
+        .expect("production CSP must be configured");
+
+    assert!(
+        csp.contains("style-src 'self' 'unsafe-inline'"),
+        "xterm and Monaco runtime style elements must be allowed"
+    );
+    assert!(
+        !csp.contains("script-src 'self' 'unsafe-inline'"),
+        "runtime styles must not weaken the script policy"
+    );
+
+    let disabled_directives = security
+        .get("dangerousDisableAssetCspModification")
+        .and_then(Value::as_array)
+        .expect("Tauri CSP modification exceptions must be directive-scoped");
+    assert_eq!(
+        disabled_directives,
+        &[Value::String("style-src".to_string())],
+        "only style-src nonce injection may be disabled"
+    );
 }
 
 #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,7 +191,7 @@ platform probe
 - 应用更新通过 Rust/Tauri update service 统一管理，renderer 仅经 `Rust commands/events -> tauri-api.ts -> renderer` 查询状态和触发检查；Windows 使用 GitHub Release 的签名 `latest.json`、NSIS 安装器及其 `.sig` 和两段式“下载验签 → 重启安装”，macOS 发行构建使用 ad hoc 签名并保持检查后跳转 GitHub Release 下载页（不接入 Apple 证书、公证或应用内 updater）。
 - 原生关闭快捷键由 Rust/Tauri backend 统一收口：macOS 使用 `Cmd+Q` 请求应用退出确认、`Cmd+W` 请求关闭当前工作区项/子窗口；Windows/Linux 分别保持 `Alt+F4` 退出与 `Ctrl+W` 关闭窗口语义。最后一个工作区项只触发普通窗口关闭/隐藏，不得直接销毁主窗口；托盘退出和应用退出快捷键必须走同一确认与 transfer journal 清理链路。真正退出前还必须逐个等待独立 Monaco 编辑器完成保存或确认丢弃，任一编辑器取消都会中止 session/transfer shutdown。
 - 主题和语言属于 Rust backend 持久化的 UI preferences；Tauri 应用菜单、托盘菜单与 Windows 自绘 menubar 必须从同一份 locale 构建并在语言切换后刷新。macOS 应用菜单保留 About/Services/Hide/Bring All to Front 等标准角色，但 Quit 仍走 FileTerm 自己的脏编辑器、活动连接和 transfer cleanup 确认链路。资源监控是 SSH 连接配置，关闭后该连接不采集资源数据，工作区仅保留窄侧栏。
-- xterm 与 Monaco 属于缓存字体尺寸/像素比的画布渲染器，统一使用随包的 JetBrains Mono；本地字体完成加载、窗口缩放或跨显示器 DPI 变化后必须主动重测，不能把开发态的系统字体缓存当作正式包的稳定条件。
+- xterm 与 Monaco 会缓存字体尺寸/像素比并生成运行时样式，统一使用随包的 JetBrains Mono；本地字体完成加载、窗口缩放或跨显示器 DPI 变化后必须主动重测。生产 CSP 仅禁止 Tauri 为 `style-src` 注入 nonce，使声明的 `unsafe-inline` 能供这两个受信任的本地组件生成样式；`script-src` 继续保留 Tauri 的 hash/nonce 加固。
 - Renderer 的持久化操作必须返回并应用 Rust command 的最新 snapshot；跨窗口广播只负责同步其他窗口，不能作为发起窗口更新成功状态的唯一来源。弹窗、传输与隧道操作在 React 提交态之外还必须使用同步 guard，避免下一帧禁用按钮前的快速双击重复调用 backend。
 - Tauri workspace tab 状态由 Rust 枚举限制为 core `TabStatus` 的 `idle/connecting/connected/error/closed`；正常或主动断开使用 `closed`，worker/连接失败使用 `error`，renderer 不接受运行时自造状态字符串。
 - profile、folder、command 的持久化 mutation 由 Rust workspace 级锁串行化，成功后统一广播 `workspace:snapshot`；完整快照读取使用同一把锁，不能观察跨文件级联写入的中间态。广播失败只记录告警，不能把已经落盘的操作伪装成失败并诱发重复提交。

--- a/docs/quality/release-notes-2.0.2.md
+++ b/docs/quality/release-notes-2.0.2.md
@@ -1,0 +1,10 @@
+# FileTerm 2.0.2
+
+## 正式包终端与编辑器渲染修复
+
+修复 Windows 与 macOS 正式安装包中 xterm 终端文字异常放大、行间挤压，以及 Monaco 文件编辑器文字错位和残影问题。
+
+- 修正 Tauri 生产 CSP 与 xterm、Monaco 运行时样式的兼容边界。
+- 仅关闭 Tauri 对 `style-src` 的 nonce 改写，使本地受信任组件可以应用动态样式。
+- `script-src` 继续保留 Tauri 的 hash/nonce 加固，未放宽脚本执行策略。
+- 增加 CSP 配置契约测试，防止开发态正常、正式包失效的问题再次出现。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,11 +33,11 @@
     },
     "apps/electron": {
       "name": "@fileterm/electron",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
-        "@fileterm/core": "2.0.1",
-        "@fileterm/shared": "2.0.1",
-        "@fileterm/storage": "2.0.1",
+        "@fileterm/core": "2.0.2",
+        "@fileterm/shared": "2.0.2",
+        "@fileterm/storage": "2.0.2",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@xterm/addon-fit": "^0.11.0",
@@ -71,10 +71,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
-        "@fileterm/core": "2.0.1",
-        "@fileterm/shared": "2.0.1",
+        "@fileterm/core": "2.0.2",
+        "@fileterm/shared": "2.0.2",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -8511,17 +8511,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.0.1"
+      "version": "2.0.2"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.0.1"
+      "version": "2.0.2"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
-        "@fileterm/core": "2.0.1"
+        "@fileterm/core": "2.0.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.1"
+    "@fileterm/core": "2.0.2"
   }
 }


### PR DESCRIPTION
## 问题

生产包的 Tauri CSP 会给 style-src 自动注入 nonce。xterm 与 Monaco 运行时生成的 style 标签没有该 nonce，因此样式在 Windows/macOS 正式包中被拦截；开发服务器没有生产 CSP，所以 npm 启动正常。

## 修复

- 仅禁止 Tauri 改写 style-src，让已声明的 unsafe-inline 对本地 xterm/Monaco 运行时样式生效
- 保持 script-src 的 hash/nonce 加固，不放宽脚本执行
- 增加 CSP 契约测试与 2.0.2 发布说明
- 修正 Windows WebDAV HTTP 测试未读取请求体导致 TCP reset 的问题，并清理平台条件导入
- 按根版本号同步规则升级到 2.0.2

## 验证

- Windows 正式包，150% DPI，真实 SSH 终端：字体 12px、行高正常，动态样式可用，无 CSP violation
- 独立 Monaco 编辑器：字体 13px、行高 20px，动态样式均已加载
- npm run typecheck
- npm run lint
- npx prettier --check apps/tauri packages/core packages/shared packages/storage
- npm run test:tauri：109 unit + 19 contract 全绿
- cargo clippy --locked --all-targets --all-features -- -D warnings
- npm run build -w @fileterm/tauri：MSI 与 NSIS 2.0.2 构建成功