### PR TITLE
fix: enlarge macOS traffic lights

### DIFF
--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -826,7 +826,7 @@ fn calibrate_macos_traffic_lights(window: &WebviewWindow<Wry>) {
     use objc2_app_kit::{NSView, NSWindowButton};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-    const BUTTON_SIZE: f64 = 15.0;
+    const BUTTON_SIZE: f64 = 16.0;
     const BUTTON_SPACING: f64 = 22.0;
     // Keep the packaged Overlay window's vertical compensation native so
     // renderer CSS does not have to know which build flavor launched the app.


### PR DESCRIPTION
Increase the native macOS traffic light button size from 15pt to 16pt while keeping the refined 22pt spacing and vertical position.

Verification:
- cargo fmt --manifest-path apps/tauri/src-tauri/Cargo.toml -- --check
- cargo check --manifest-path apps/tauri/src-tauri/Cargo.toml
- git diff --check
- repository pre-push typecheck passed