### PR TITLE
fix: align macOS traffic lights and brand

### DIFF
--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -826,7 +826,7 @@ fn calibrate_macos_traffic_lights(window: &WebviewWindow<Wry>) {
     use objc2_app_kit::{NSView, NSWindowButton};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-    const BUTTON_SIZE: f64 = 16.0;
+    const BUTTON_SIZE: f64 = 17.0;
     const BUTTON_SPACING: f64 = 22.0;
     // Keep the packaged Overlay window's vertical compensation native so
     // renderer CSS does not have to know which build flavor launched the app.

--- a/apps/tauri/src/renderer/styles/features/shell.css
+++ b/apps/tauri/src/renderer/styles/features/shell.css
@@ -774,7 +774,7 @@
      its optical (not line-box) center. Scope this to Tauri: Electron
      hiddenInset uses a different native geometry. */
   position: relative;
-  top: -1px;
+  top: -0.5px;
 }
 
 .titlebar-tabarea {


### PR DESCRIPTION
Increase native macOS traffic lights from 16pt to 17pt and move the Tauri FileTerm brand text down by 0.5px.

Verification:
- cargo fmt --manifest-path apps/tauri/src-tauri/Cargo.toml -- --check
- cargo check --manifest-path apps/tauri/src-tauri/Cargo.toml
- npx prettier --check apps/tauri/src/renderer/styles/features/shell.css
- git diff --check
- repository pre-push typecheck passed