### PR TITLE
fix: apply macOS traffic light control size

### DIFF
--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ objc2 = { version = "0.6", default-features = false, features = ["std"] }
 objc2-app-kit = { version = "0.3.2", default-features = false, features = [
   "std",
   "NSButton",
+  "NSCell",
   "NSControl",
   "NSResponder",
   "NSView",

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -74,6 +74,9 @@ struct HiddenWithMainRegistry {
     labels: Mutex<HashSet<String>>,
 }
 
+#[cfg(target_os = "macos")]
+static MACOS_TRAFFIC_LIGHTS_CALIBRATED: AtomicBool = AtomicBool::new(false);
+
 impl FileEditorCloseRegistry {
     fn request(&self, label: &str) -> bool {
         self.state
@@ -821,42 +824,42 @@ fn prefer_windows_native_rounded_corners(window: &WebviewWindow<Wry>) {
 }
 
 #[cfg(target_os = "macos")]
-fn calibrate_macos_traffic_lights(window: &WebviewWindow<Wry>) {
+fn calibrate_macos_traffic_lights(window: &WebviewWindow<Wry>) -> bool {
     use objc2::MainThreadMarker;
-    use objc2_app_kit::{NSView, NSWindowButton};
+    use objc2_app_kit::{NSControlSize, NSView, NSWindowButton};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-    const BUTTON_SIZE: f64 = 17.0;
-    const BUTTON_SPACING: f64 = 22.0;
+    const BUTTON_SIZE: f64 = 14.0;
+    const BUTTON_SPACING: f64 = 23.0;
     // Keep the packaged Overlay window's vertical compensation native so
     // renderer CSS does not have to know which build flavor launched the app.
-    const RELEASE_VERTICAL_OFFSET: f64 = 1.0;
+    const RELEASE_VERTICAL_OFFSET: f64 = 0.5;
 
     let Ok(handle) = window.window_handle() else {
-        return;
+        return false;
     };
     let RawWindowHandle::AppKit(handle) = handle.as_raw() else {
-        return;
+        return false;
     };
     let Some(_main_thread) = MainThreadMarker::new() else {
-        return;
+        return false;
     };
 
     // Tauri exposes the AppKit view through raw-window-handle. AppKit objects
-    // are main-thread-only, and this function is called from setup on macOS.
+    // are main-thread-only, and this runs after the first page load on macOS.
     let view = unsafe { &*(handle.ns_view.as_ptr() as *const NSView) };
     let Some(ns_window) = view.window() else {
-        return;
+        return false;
     };
     let Some(close) = ns_window.standardWindowButton(NSWindowButton::CloseButton) else {
-        return;
+        return false;
     };
     let Some(miniaturize) = ns_window.standardWindowButton(NSWindowButton::MiniaturizeButton)
     else {
-        return;
+        return false;
     };
     let Some(zoom) = ns_window.standardWindowButton(NSWindowButton::ZoomButton) else {
-        return;
+        return false;
     };
 
     let buttons = [&close, &miniaturize, &zoom];
@@ -870,13 +873,21 @@ fn calibrate_macos_traffic_lights(window: &WebviewWindow<Wry>) {
     let center_x = first_frame.origin.x + first_frame.size.width / 2.0;
 
     for (index, button) in buttons.into_iter().enumerate() {
+        // AppKit draws the colored circle from NSControlSize. Changing only
+        // the view frame leaves the packaged app's 12pt circle unchanged.
+        button.setControlSize(NSControlSize::Regular);
+        button.sizeToFit();
+
         let mut frame = button.frame();
         frame.origin.x = center_x + index as f64 * BUTTON_SPACING - BUTTON_SIZE / 2.0;
         frame.origin.y = center_y - BUTTON_SIZE / 2.0;
         frame.size.width = BUTTON_SIZE;
         frame.size.height = BUTTON_SIZE;
         button.setFrame(frame);
+        NSView::setNeedsDisplay(button, true);
     }
+
+    true
 }
 
 pub fn open_child_window(app: &AppHandle, input: OpenWindowInput) -> Result<(), AppError> {
@@ -1072,6 +1083,23 @@ pub fn run() {
     #[cfg(target_os = "windows")]
     let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
 
+    #[cfg(target_os = "macos")]
+    let builder = builder.on_page_load(|webview, payload| {
+        if webview.label() == "main"
+            && matches!(payload.event(), tauri::webview::PageLoadEvent::Finished)
+            && !MACOS_TRAFFIC_LIGHTS_CALIBRATED.load(Ordering::Acquire)
+        {
+            if let Some(window) = webview.get_webview_window("main") {
+                let calibration_window = window.clone();
+                let _ = window.run_on_main_thread(move || {
+                    if calibrate_macos_traffic_lights(&calibration_window) {
+                        MACOS_TRAFFIC_LIGHTS_CALIBRATED.store(true, Ordering::Release);
+                    }
+                });
+            }
+        }
+    });
+
     builder
         .setup(|app| {
             crate::storage::migrate_legacy_data_once(app.handle())?;
@@ -1098,13 +1126,10 @@ pub fn run() {
 
             // ── Platform-specific window chrome ────────────────────────────
             // macOS: keep decorations + Overlay titleBarStyle so the traffic
-            //        lights float over renderer content. AppKit button frames
-            //        are calibrated below so dev and packaged builds match.
+            //        lights float over renderer content. AppKit control size
+            //        and frames are calibrated after the first page load.
             // Windows: drop the OS frame so the renderer owns the title bar.
             // Linux: keep native decorations.
-            #[cfg(target_os = "macos")]
-            calibrate_macos_traffic_lights(&main_window);
-
             #[cfg(target_os = "windows")]
             {
                 let _ = main_window.set_decorations(false);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,7 +187,7 @@ platform probe
 - Tauri 无边框子窗口在 macOS 与 Windows 使用透明原生表面，由 renderer 的 `standalone-window-frame` 统一裁切圆角；Windows 主窗口通过平台专用配置使用相同的 renderer 圆角，并在最大化时取消圆角。Windows 子窗口保持隐藏到 React 首帧完成以避免 WebView2 启动闪烁，Linux 继续使用不透明原生表面。
 - Windows 下严禁从同步 Tauri command、托盘回调或原生菜单回调直接执行 `WebviewWindowBuilder::build()`；WebView2 会在该上下文发生建窗死锁并阻塞后续全部 invoke。Renderer 建窗入口必须使用 async command，实际 builder 工作进入 blocking worker；原生事件入口也必须先交给 worker。
 - macOS 菜单栏托盘图标使用 `apps/tauri/build/trayTemplate*.png` template 资源，由 Rust/Tauri backend 设置 template 属性。
-- macOS 主窗口保留原生红黄绿按钮；开发态使用 `tauri.conf.json` 的 traffic-light 坐标，macOS Release 使用 `tauri.release.macos.conf.json` 针对打包后的 AppKit 几何做纵向校准，Rust 启动时统一校准原生按钮的尺寸与间距，renderer 不得用 CSS 伪造或补偿原生按钮。
+- macOS 主窗口保留原生红黄绿按钮；开发态使用 `tauri.conf.json` 的 traffic-light 坐标，macOS Release 使用 `tauri.release.macos.conf.json` 针对打包后的 AppKit 几何做纵向校准。首个页面加载完成后，Rust 必须显式设置 AppKit `Regular` control size 并统一校准原生按钮 frame 与间距；只改 frame 不会改变系统圆点的实际绘制尺寸，renderer 也不得用 CSS 伪造或补偿原生按钮。
 - Tauri 托盘由 Rust backend 显式创建：macOS 使用独立 template 图标，Windows/Linux 使用应用图标。主窗口与可见子窗口隐藏到托盘后会成组恢复；普通关闭请求与真正退出请求保持分离。
 - 应用更新通过 Rust/Tauri update service 统一管理，renderer 仅经 `Rust commands/events -> tauri-api.ts -> renderer` 查询状态和触发检查；Windows 使用 GitHub Release 的签名 `latest.json`、NSIS 安装器及其 `.sig` 和两段式“下载验签 → 重启安装”，macOS 发行构建使用 ad hoc 签名并保持检查后跳转 GitHub Release 下载页（不接入 Apple 证书、公证或应用内 updater）。
 - 原生关闭快捷键由 Rust/Tauri backend 统一收口：macOS 使用 `Cmd+Q` 请求应用退出确认、`Cmd+W` 请求关闭当前工作区项/子窗口；Windows/Linux 分别保持 `Alt+F4` 退出与 `Ctrl+W` 关闭窗口语义。最后一个工作区项只触发普通窗口关闭/隐藏，不得直接销毁主窗口；托盘退出和应用退出快捷键必须走同一确认与 transfer journal 清理链路。真正退出前还必须逐个等待独立 Monaco 编辑器完成保存或确认丢弃，任一编辑器取消都会中止 session/transfer shutdown。


### PR DESCRIPTION
## Summary
- set native macOS window buttons to AppKit Regular control size instead of only resizing their view frames
- run calibration on the main thread after the first page finishes loading so AppKit cannot overwrite it during startup layout
- match the reference geometry: 14pt button size, 23pt center spacing, and a 0.5pt packaged vertical correction
- document the AppKit control-size boundary

## Measured target
- CI screenshot: 24×24px, center y 126.5, spacing 44px
- reference screenshot: 28×28px, center y 125.5, spacing 46px

## Verification
- cargo fmt --manifest-path apps/tauri/src-tauri/Cargo.toml -- --check
- cargo clippy --manifest-path apps/tauri/src-tauri/Cargo.toml --locked --all-targets --all-features -- -D warnings
- npx prettier --check docs/architecture.md
- git diff --check
- repository pre-push typecheck passed
- local AppKit offscreen render confirmed Regular control size is 14×14pt / 28×28 Retina pixels