### PR TITLE
fix: scale packaged macOS traffic light content

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1343,6 +1343,7 @@ dependencies = [
  "image",
  "objc2",
  "objc2-app-kit",
+ "objc2-quartz-core",
  "open",
  "rand",
  "raw-window-handle",
@@ -2920,6 +2921,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -53,6 +53,14 @@ objc2-app-kit = { version = "0.3.2", default-features = false, features = [
   "NSResponder",
   "NSView",
   "NSWindow",
+  "objc2-quartz-core",
+] }
+objc2-quartz-core = { version = "0.3.2", default-features = false, features = [
+  "std",
+  "CALayer",
+  "CATransaction",
+  "CATransform3D",
+  "objc2-core-foundation",
 ] }
 raw-window-handle = "0.6"
 

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -827,9 +827,11 @@ fn prefer_windows_native_rounded_corners(window: &WebviewWindow<Wry>) {
 fn calibrate_macos_traffic_lights(window: &WebviewWindow<Wry>) -> bool {
     use objc2::MainThreadMarker;
     use objc2_app_kit::{NSControlSize, NSView, NSWindowButton};
+    use objc2_quartz_core::{CATransaction, CATransform3D};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
     const BUTTON_SIZE: f64 = 14.0;
+    const APPKIT_DRAWN_CIRCLE_SIZE: f64 = 12.0;
     const BUTTON_SPACING: f64 = 23.0;
     // Keep the packaged Overlay window's vertical compensation native so
     // renderer CSS does not have to know which build flavor launched the app.
@@ -871,10 +873,16 @@ fn calibrate_macos_traffic_lights(window: &WebviewWindow<Wry>) -> bool {
     };
     let center_y = first_frame.origin.y + first_frame.size.height / 2.0 + vertical_offset;
     let center_x = first_frame.origin.x + first_frame.size.width / 2.0;
+    let release_content_scale = BUTTON_SIZE / APPKIT_DRAWN_CIRCLE_SIZE;
 
+    CATransaction::begin();
+    CATransaction::setDisableActions(true);
     for (index, button) in buttons.into_iter().enumerate() {
-        // AppKit draws the colored circle from NSControlSize. Changing only
-        // the view frame leaves the packaged app's 12pt circle unchanged.
+        // The packaged Overlay window keeps drawing a 12pt circle even when
+        // its native button frame and control size are 14pt. In release builds,
+        // scale the actual AppKit presentation layer around the button center
+        // so it matches the already-correct 14pt development rendering without
+        // moving the calibrated centers.
         button.setControlSize(NSControlSize::Regular);
         button.sizeToFit();
 
@@ -884,8 +892,20 @@ fn calibrate_macos_traffic_lights(window: &WebviewWindow<Wry>) -> bool {
         frame.size.width = BUTTON_SIZE;
         frame.size.height = BUTTON_SIZE;
         button.setFrame(frame);
+        if !cfg!(debug_assertions) {
+            button.setWantsLayer(true);
+            if let Some(layer) = button.layer() {
+                let mut transform =
+                    CATransform3D::new_scale(release_content_scale, release_content_scale, 1.0);
+                let centered_translation = BUTTON_SIZE / 2.0 * (1.0 - release_content_scale);
+                transform.m41 = centered_translation;
+                transform.m42 = centered_translation;
+                layer.setTransform(transform);
+            }
+        }
         NSView::setNeedsDisplay(button, true);
     }
+    CATransaction::commit();
 
     true
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,7 +187,7 @@ platform probe
 - Tauri 无边框子窗口在 macOS 与 Windows 使用透明原生表面，由 renderer 的 `standalone-window-frame` 统一裁切圆角；Windows 主窗口通过平台专用配置使用相同的 renderer 圆角，并在最大化时取消圆角。Windows 子窗口保持隐藏到 React 首帧完成以避免 WebView2 启动闪烁，Linux 继续使用不透明原生表面。
 - Windows 下严禁从同步 Tauri command、托盘回调或原生菜单回调直接执行 `WebviewWindowBuilder::build()`；WebView2 会在该上下文发生建窗死锁并阻塞后续全部 invoke。Renderer 建窗入口必须使用 async command，实际 builder 工作进入 blocking worker；原生事件入口也必须先交给 worker。
 - macOS 菜单栏托盘图标使用 `apps/tauri/build/trayTemplate*.png` template 资源，由 Rust/Tauri backend 设置 template 属性。
-- macOS 主窗口保留原生红黄绿按钮；开发态使用 `tauri.conf.json` 的 traffic-light 坐标，macOS Release 使用 `tauri.release.macos.conf.json` 针对打包后的 AppKit 几何做纵向校准。首个页面加载完成后，Rust 必须显式设置 AppKit `Regular` control size 并统一校准原生按钮 frame 与间距；只改 frame 不会改变系统圆点的实际绘制尺寸，renderer 也不得用 CSS 伪造或补偿原生按钮。
+- macOS 主窗口保留原生红黄绿按钮；开发态使用 `tauri.conf.json` 的 traffic-light 坐标，macOS Release 使用 `tauri.release.macos.conf.json` 针对打包后的 AppKit 几何做纵向校准。首个页面加载完成后，Rust 必须显式设置 AppKit `Regular` control size、统一校准原生按钮 frame 与间距；Release 中还要对仍固定为 12pt 的 AppKit 绘制层做中心缩放，使实际圆点达到与开发态一致的 14pt，renderer 不得用 CSS 伪造或补偿原生按钮。
 - Tauri 托盘由 Rust backend 显式创建：macOS 使用独立 template 图标，Windows/Linux 使用应用图标。主窗口与可见子窗口隐藏到托盘后会成组恢复；普通关闭请求与真正退出请求保持分离。
 - 应用更新通过 Rust/Tauri update service 统一管理，renderer 仅经 `Rust commands/events -> tauri-api.ts -> renderer` 查询状态和触发检查；Windows 使用 GitHub Release 的签名 `latest.json`、NSIS 安装器及其 `.sig` 和两段式“下载验签 → 重启安装”，macOS 发行构建使用 ad hoc 签名并保持检查后跳转 GitHub Release 下载页（不接入 Apple 证书、公证或应用内 updater）。
 - 原生关闭快捷键由 Rust/Tauri backend 统一收口：macOS 使用 `Cmd+Q` 请求应用退出确认、`Cmd+W` 请求关闭当前工作区项/子窗口；Windows/Linux 分别保持 `Alt+F4` 退出与 `Ctrl+W` 关闭窗口语义。最后一个工作区项只触发普通窗口关闭/隐藏，不得直接销毁主窗口；托盘退出和应用退出快捷键必须走同一确认与 transfer journal 清理链路。真正退出前还必须逐个等待独立 Monaco 编辑器完成保存或确认丢弃，任一编辑器取消都会中止 session/transfer shutdown。


### PR DESCRIPTION
## What changed

- keep the existing 14pt native button frames, 23pt center spacing, and calibrated vertical position
- scale the Release-only AppKit presentation layer from the observed 12pt circle to 14pt around each button center
- leave development rendering unscaled because it already renders at the target size
- document the native macOS release calibration boundary

## Root cause

Changing `NSButton` frame and `NSControlSize` did not change the colored circle rendered by the packaged Overlay window. Pixel comparison showed Beta 6 centers and spacing already matched the development reference exactly, while the circle remained 12pt (24 physical pixels) instead of 14pt (28 physical pixels).

## Validation

- `cargo fmt --manifest-path apps/tauri/src-tauri/Cargo.toml -- --check`
- `cargo check --manifest-path apps/tauri/src-tauri/Cargo.toml`
- `cargo check --release --manifest-path apps/tauri/src-tauri/Cargo.toml`
- pre-push workspace typecheck