### PR TITLE
fix: lower macOS FileTerm brand baseline

### DIFF
--- a/apps/tauri/src/renderer/styles/features/shell.css
+++ b/apps/tauri/src/renderer/styles/features/shell.css
@@ -770,11 +770,12 @@
 :root[data-runtime='tauri'][data-platform='darwin'] .titlebar-brand strong {
   /* In Tauri Overlay, trafficLightPosition y shifts the title-bar container
      rather than each button's frame. With y: 26 the traffic lights share the
-     48px renderer tab bar's visual center, so compensate the brand glyph for
-     its optical (not line-box) center. Scope this to Tauri: Electron
-     hiddenInset uses a different native geometry. */
+     48px renderer tab bar's visual center. The previous -0.5px lift left the
+     brand glyph optically high after the native traffic-light calibration, so
+     restore the line-box baseline. Scope this to Tauri: Electron hiddenInset
+     uses a different native geometry. */
   position: relative;
-  top: -0.5px;
+  top: 0;
 }
 
 .titlebar-tabarea {


### PR DESCRIPTION
## What changed

- remove the Tauri/macOS-only `-0.5px` upward offset from the FileTerm title-bar wordmark
- move the wordmark down by exactly 0.5px relative to Beta 7
- leave native traffic-light sizing, positions, spacing, and the tab strip unchanged

## Why

After the native traffic-light calibration, the FileTerm wordmark remained optically high. Restoring the normal line-box baseline aligns it more closely with the traffic-light visual center.

## Validation

- `npx prettier --check apps/tauri/src/renderer/styles/features/shell.css`
- `npm run typecheck -w @fileterm/tauri`
- pre-push workspace typecheck