### PR TITLE
fix: enlarge and lower macOS FileTerm wordmark

### DIFF
--- a/apps/tauri/src/renderer/styles/features/shell.css
+++ b/apps/tauri/src/renderer/styles/features/shell.css
@@ -772,10 +772,11 @@
      rather than each button's frame. With y: 26 the traffic lights share the
      48px renderer tab bar's visual center. The previous -0.5px lift left the
      brand glyph optically high after the native traffic-light calibration, so
-     restore the line-box baseline. Scope this to Tauri: Electron hiddenInset
-     uses a different native geometry. */
+     lower it by another 0.5px and use the larger 16px wordmark. Scope this to
+     Tauri: Electron hiddenInset uses a different native geometry. */
   position: relative;
-  top: 0;
+  top: 0.5px;
+  font-size: 16px;
 }
 
 .titlebar-tabarea {


### PR DESCRIPTION
## What changed

- increase the Tauri/macOS FileTerm wordmark from 15px to 16px
- lower it by another 0.5px relative to Beta 8
- leave traffic lights, tab spacing, tab labels, and all other platforms unchanged

## Validation

- `npx prettier --check apps/tauri/src/renderer/styles/features/shell.css`
- `npm run typecheck -w @fileterm/tauri`
- pre-push workspace typecheck