### PR TITLE
chore: prepare FileTerm 2.0.5 release

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/electron",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",
@@ -38,9 +38,9 @@
     "release:win": "npm run build && npm run package:win"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.4",
-    "@fileterm/shared": "2.0.4",
-    "@fileterm/storage": "2.0.4",
+    "@fileterm/core": "2.0.5",
+    "@fileterm/shared": "2.0.5",
+    "@fileterm/storage": "2.0.5",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -25,8 +25,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.4",
-    "@fileterm/shared": "2.0.4",
+    "@fileterm/core": "2.0.5",
+    "@fileterm/shared": "2.0.5",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "arboard",
  "async-trait",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.0.4"
+version = "2.0.5"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/docs/quality/release-notes-2.0.5.md
+++ b/docs/quality/release-notes-2.0.5.md
@@ -1,0 +1,35 @@
+## FileTerm 2.0.5
+
+**Rust + Tauri 稳定性与 Windows 体验更新**
+
+FileTerm 2.x 继续维护 Rust/Tauri 主运行时，Electron 代码仅作为历史参考。本版本聚焦 SSH 会话稳定性、SMB 文件访问、Windows 图标与本地磁盘导航，以及命令管理器工作区交互。
+
+### 2.0.5 更新重点
+
+- **SSH 会话稳定性**：增加认证、键盘交互和隧道转发超时，修复远程转发与终端 worker 在异常情况下卡死的问题，并补充连接日志。
+- **SMB 共享访问**：完善凭据验证、共享目录选择和本地文件面板状态处理；Windows 在盘符根目录点击上级时可返回“此电脑”磁盘列表。
+- **命令管理器体验**：细化命令管理器工作区布局与交互状态，保持临时命令编辑器与工作区行为一致。
+- **Windows 图标与打包**：使用多尺寸 ICO 资源加载应用和托盘图标，避免开发态或高 DPI 环境选择低分辨率图标。
+- **质量门禁**：继续收紧 Tauri/Rust 格式、类型、协议夹具和依赖安全检查。
+
+### 本版本包含的主要 PR
+
+- [PR #131](https://github.com/St0ff3l/fileterm/pull/131)：修复 Windows 图标资源和本地磁盘根目录导航。
+- [PR #130](https://github.com/St0ff3l/fileterm/pull/130)：细化命令管理器工作区 UI。
+- [PR #129](https://github.com/St0ff3l/fileterm/pull/129)：完善 SMB 共享流程和界面本地化。
+- [PR #128](https://github.com/St0ff3l/fileterm/pull/128)：修复 SSH worker 卡死和标题栏接缝问题。
+- [PR #125–#127](https://github.com/St0ff3l/fileterm/compare/v2.0.4...v2.0.5)：SSH 中断响应、临时命令编辑器及 SMB/工作区稳定性改进。
+
+### 2.x 重构版包含
+
+- Rust/Tauri 主运行时、窗口、托盘、连接、终端、文件管理和传输链路。
+- Windows Tauri 签名应用内更新：下载后验签，重启安装。
+- macOS arm64/x64 ad hoc 签名 DMG；检查更新后跳转 GitHub Release 手动下载。
+- SSH、SFTP、FTP、WebDAV、凭据导入导出和跨平台窗口行为的兼容性修复。
+- Tauri-only 的质量检查、打包和 GitHub Release 工作流。
+
+遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
+
+也可以加入微信群交流：请打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81) 扫描二维码进微信群，也可加入 QQ 群 534418986。
+
+> Electron 版本不会通过这条 Tauri 更新链路自动升级。旧 Electron 安装包只能继续使用 Electron 自己的更新机制（如果该旧版本已配置），不能由 2.x 的 Tauri updater 直接覆盖安装。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,11 +33,11 @@
     },
     "apps/electron": {
       "name": "@fileterm/electron",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
-        "@fileterm/core": "2.0.4",
-        "@fileterm/shared": "2.0.4",
-        "@fileterm/storage": "2.0.4",
+        "@fileterm/core": "2.0.5",
+        "@fileterm/shared": "2.0.5",
+        "@fileterm/storage": "2.0.5",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@xterm/addon-fit": "^0.11.0",
@@ -232,10 +232,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
-        "@fileterm/core": "2.0.4",
-        "@fileterm/shared": "2.0.4",
+        "@fileterm/core": "2.0.5",
+        "@fileterm/shared": "2.0.5",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -8583,17 +8583,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.0.4"
+      "version": "2.0.5"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.0.4"
+      "version": "2.0.5"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
-        "@fileterm/core": "2.0.4"
+        "@fileterm/core": "2.0.5"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.4"
+    "@fileterm/core": "2.0.5"
   }
 }


### PR DESCRIPTION
## What changed

- Bump the root and all workspace package versions to 2.0.5 via `npm run sync:version`.
- Add the release notes consumed by the tag-based release workflow at `docs/quality/release-notes-2.0.5.md`.

## Release scope

This release includes the post-2.0.4 SSH stability, SMB/local file navigation, command manager UI, and Windows icon improvements already merged into `main`.

## Validation

- `npm run typecheck` passed.
- Version references are synchronized across package manifests, lockfile, Cargo metadata, and Tauri config.