### PR TITLE
fix(update): trigger update check on startup

### DIFF
--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -1238,6 +1238,15 @@ pub fn run() {
                 .build(app)
                 .map_err(|error| error.to_string())?;
 
+            // 启动后触发一次更新检查。延迟 1s 让前端先完成 onUpdateStatus
+            // 订阅，updates::check 内部已有 single-flight 互斥，用户在此
+            // 期间手动点击"检查更新"会复用同一次结果。错误不影响启动。
+            let startup_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                let _ = crate::services::updates::check(&startup_handle).await;
+            });
+
             Ok(())
         })
         .on_menu_event(|app, event| match event.id().as_ref() {


### PR DESCRIPTION
## Problem

None of the three platforms (macOS / Windows / Linux) auto-check for updates on launch. The Electron-era startup call (`apps/electron/src/main/main.ts:1083`) was not ported to the Tauri `setup` hook, while the i18n copy ("Updates are checked automatically when the app starts") and `docs/quality/auto-update-release-checklist.md` still claim it is.

As a result, the update status stays `idle` until the user manually clicks "Check for updates" in the sidebar or Settings panel.

## Fix

Spawn a delayed (1s) `crate::services::updates::check` call at the end of the Tauri `setup` hook in `apps/tauri/src-tauri/src/lib.rs`. All three platforms now run the same auto-check on launch.

## Why 1s

- Matches the Electron behavior of triggering the check right after the main window is created, but gives the renderer a brief window to subscribe to the `app:update-status` event before the first status emit.
- `updates::check` already writes its final status into `WorkspaceState.update_status`, so even if the renderer subscribes slightly late, the first `getUpdateStatus()` call will pick it up.

## Safety

- Runs in `tauri::async_runtime::spawn` — does not block setup or window creation.
- Errors are swallowed with `let _ =`; failure does not affect startup.
- Reuses the existing single-flight guard (`update_check` mutex in `WorkspaceState`) so concurrent manual clicks during the startup check share the same result instead of issuing duplicate network requests.

## Verification

Local quality gates all pass:

- `npm run typecheck -w @fileterm/tauri`
- `npm run lint`
- `npx prettier --check apps/tauri packages/core packages/shared packages/storage`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `npm run test:tauri` (128 unit + 19 contract)