### PR TITLE
feat: add terminal split panes and workspace persistence

### DIFF
--- a/apps/tauri/src-tauri/src/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/mod.rs
@@ -78,6 +78,19 @@ pub struct UiPreferencesInput {
     pub locale: Option<String>,
 }
 
+const DEFAULT_UI_THEME: &str = "default-dark";
+const DEFAULT_UI_LOCALE: &str = "zhCN";
+
+fn normalize_ui_preferences(mut preferences: UiPreferences) -> UiPreferences {
+    if !matches!(preferences.theme.as_str(), "default-dark" | "default-light") {
+        preferences.theme = DEFAULT_UI_THEME.to_string();
+    }
+    if !matches!(preferences.locale.as_str(), "zhCN" | "enUS") {
+        preferences.locale = DEFAULT_UI_LOCALE.to_string();
+    }
+    preferences
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TerminalCommandHistoryEntry {
@@ -242,11 +255,11 @@ pub fn app_get_ui_preferences(app: AppHandle) -> Result<UiPreferences, AppError>
             std::fs::read_to_string(path).map_err(|error| AppError::Storage(error.to_string()))?;
         let preferences: UiPreferences = serde_json::from_str(&content)
             .map_err(|error| AppError::Serialization(error.to_string()))?;
-        Ok(preferences)
+        Ok(normalize_ui_preferences(preferences))
     } else {
         Ok(UiPreferences {
-            theme: "default-dark".to_string(),
-            locale: "zhCN".to_string(),
+            theme: DEFAULT_UI_THEME.to_string(),
+            locale: DEFAULT_UI_LOCALE.to_string(),
         })
     }
 }
@@ -264,6 +277,7 @@ pub fn app_set_ui_preferences(
     if let Some(locale) = input.locale {
         preferences.locale = locale;
     }
+    let preferences = normalize_ui_preferences(preferences);
     let content = serde_json::to_string_pretty(&preferences)
         .map_err(|error| AppError::Serialization(error.to_string()))?;
     std::fs::write(path, content).map_err(|error| AppError::Storage(error.to_string()))?;
@@ -867,6 +881,7 @@ pub(crate) async fn get_workspace_snapshot_unlocked(
     let active_tab_id = state.active_tab_id.read().await.clone();
     let sessions = state.sessions.read().await.clone();
     let transfers = state.transfers.read().await.clone();
+    let active_pane_tab_id_by_root = state.active_pane_tab_id_by_root.read().await.clone();
 
     // Read + heal profiles, then strip secrets before exposing in snapshot.
     let (profiles_with_secrets, folders) =
@@ -887,6 +902,7 @@ pub(crate) async fn get_workspace_snapshot_unlocked(
         "activeTabId": active_tab_id,
         "transfers": transfers,
         "sessions": sessions,
+        "activePaneTabIdByRoot": active_pane_tab_id_by_root,
     }))
 }
 
@@ -1038,23 +1054,18 @@ pub async fn shutdown_session_workers(app: &AppHandle) {
     }
 }
 
-#[tauri::command]
-pub async fn app_open_profile(
-    app: AppHandle,
-    profile_id: String,
-) -> Result<serde_json::Value, AppError> {
-    let state = app.state::<crate::services::workspace::WorkspaceState>();
-    let _library_guard = lock_library_after_transfer_hydration(&app).await?;
-    let profiles = read_json_array(&app, "profiles.json")?;
-    let profile = profiles
-        .iter()
-        .find(|p| p.get("id").and_then(|id| id.as_str()) == Some(&profile_id))
-        .ok_or_else(|| AppError::Storage("Profile not found".to_string()))?;
-
-    // Match Electron's open lifecycle: recency is about the user's intent to
-    // open a connection, not whether the later network handshake succeeds.
-    crate::services::profile_ops::touch_profile(&app, &profile_id)?;
-
+/// 为指定 profile 创建并启动一个新的 session（tab + session + worker）。
+/// 返回新 tab_id。调用者负责更新 active_tab_id、paneRoot 以及 emit snapshot。
+///
+/// 抽取自 `app_open_profile`，供 `app_split_tab` 复用：分屏时基于当前 profile
+/// 新建一个独立 session，不共享 PTY。
+async fn spawn_session_for_profile(
+    app: &AppHandle,
+    state: &crate::services::workspace::WorkspaceState,
+    profile: &serde_json::Value,
+    profile_id: &str,
+    pane_root_tab_id: Option<String>,
+) -> Result<String, AppError> {
     let profile_type = profile
         .get("type")
         .and_then(|t| t.as_str())
@@ -1065,13 +1076,17 @@ pub async fn app_open_profile(
         .unwrap_or("SSH Session");
 
     let tab_id = format!("tab-{}", uuid::Uuid::new_v4());
+    let capabilities =
+        crate::services::workspace::ConnectionCapabilities::for_session_type(profile_type);
     let new_tab = crate::services::WorkspaceTab {
         id: tab_id.clone(),
-        profile_id: profile_id.clone(),
+        profile_id: profile_id.to_string(),
         session_type: profile_type.to_string(),
         title: name.to_string(),
         layout: create_tab_layout(profile_type),
         status: crate::services::WorkspaceTabStatus::Connecting,
+        pane_root: None,
+        pane_root_tab_id,
     };
 
     let host = profile
@@ -1090,14 +1105,11 @@ pub async fn app_open_profile(
     {
         let mut tabs = state.tabs.write().await;
         tabs.push(new_tab);
-        let mut active = state.active_tab_id.write().await;
-        *active = Some(tab_id.clone());
-
         let mut sessions = state.sessions.write().await;
         sessions.insert(
             tab_id.clone(),
             crate::services::SessionSnapshot {
-                profile_id: profile_id.clone(),
+                profile_id: profile_id.to_string(),
                 access_host: format!("{}:{}", host, port),
                 summary: format!("{}@{}", username, host),
                 terminal_transcript: "连接主机...\r\n".to_string(),
@@ -1114,9 +1126,7 @@ pub async fn app_open_profile(
                 shell_user: None,
                 connected: false,
                 system_metrics: None,
-                capabilities: crate::services::workspace::ConnectionCapabilities::for_session_type(
-                    profile_type,
-                ),
+                capabilities,
                 reconnect_mode: crate::services::workspace::reconnect_mode_for_profile(profile),
             },
         );
@@ -1148,7 +1158,7 @@ pub async fn app_open_profile(
         .insert(tab_id.clone(), worker_control.clone());
 
     start_session_worker(
-        tab_id,
+        tab_id.clone(),
         profile.clone(),
         rx,
         terminal_input_rx,
@@ -1156,7 +1166,404 @@ pub async fn app_open_profile(
         worker_control,
     );
 
+    Ok(tab_id)
+}
+
+#[tauri::command]
+pub async fn app_open_profile(
+    app: AppHandle,
+    profile_id: String,
+) -> Result<serde_json::Value, AppError> {
+    let state = app.state::<crate::services::workspace::WorkspaceState>();
+    let _library_guard = lock_library_after_transfer_hydration(&app).await?;
+    let profiles = read_json_array(&app, "profiles.json")?;
+    let profile = profiles
+        .iter()
+        .find(|p| p.get("id").and_then(|id| id.as_str()) == Some(&profile_id))
+        .ok_or_else(|| AppError::Storage("Profile not found".to_string()))?;
+
+    // Match Electron's open lifecycle: recency is about the user's intent to
+    // open a connection, not whether the later network handshake succeeds.
+    crate::services::profile_ops::touch_profile(&app, &profile_id)?;
+
+    let tab_id = spawn_session_for_profile(&app, &state, profile, &profile_id, None).await?;
+
+    {
+        let mut active = state.active_tab_id.write().await;
+        *active = Some(tab_id);
+    }
+
     get_workspace_snapshot_and_emit(&app).await
+}
+
+/// 分屏：基于当前 profile 新建一个独立 session，并在 pane tree 中把 source leaf
+/// 替换为 split(source_leaf, new_leaf)。
+///
+/// - `direction = "row"`：左右分（垂直分屏），新 pane 在右
+/// - `direction = "column"`：上下分（水平分屏），新 pane 在下
+///
+/// 只支持 SSH session。FTP / Telnet / Serial 暂不支持分屏。
+#[tauri::command]
+pub async fn app_split_tab(
+    app: AppHandle,
+    source_tab_id: String,
+    direction: String,
+) -> Result<serde_json::Value, AppError> {
+    let state = app.state::<crate::services::workspace::WorkspaceState>();
+    let _library_guard = lock_library_after_transfer_hydration(&app).await?;
+
+    let split_direction = match direction.as_str() {
+        "row" => crate::services::SplitDirection::Row,
+        "column" => crate::services::SplitDirection::Column,
+        _ => {
+            return Err(AppError::Storage(format!(
+                "Invalid split direction: {}",
+                direction
+            )))
+        }
+    };
+
+    // 找到 source tab，并解析其所属的顶层 workspace tab。分屏 leaf 始终
+    // 归属一个 root，而不是第二个顶栏 tab。
+    let (profile_id, pane_root_tab_id) = {
+        let tabs = state.tabs.read().await;
+        let source = tabs
+            .iter()
+            .find(|t| t.id == source_tab_id)
+            .ok_or_else(|| AppError::Storage(format!("Tab not found: {}", source_tab_id)))?;
+        // 只支持 SSH 分屏
+        if source.session_type != "ssh" {
+            return Err(AppError::Storage(format!(
+                "Split pane is only supported for SSH sessions, got: {}",
+                source.session_type
+            )));
+        }
+        let root_tab_id = source.pane_root_tab_id.clone().unwrap_or_else(|| {
+            if source.pane_root.is_some() {
+                source.id.clone()
+            } else {
+                tabs.iter()
+                    .find(|tab| {
+                        tab.pane_root
+                            .as_ref()
+                            .map(|root| root.leaf_tab_ids().iter().any(|id| id == &source_tab_id))
+                            .unwrap_or(false)
+                    })
+                    .map(|tab| tab.id.clone())
+                    .unwrap_or_else(|| source.id.clone())
+            }
+        });
+        (source.profile_id.clone(), root_tab_id)
+    };
+
+    // 读 profile
+    let profiles = read_json_array(&app, "profiles.json")?;
+    let profile = profiles
+        .iter()
+        .find(|p| p.get("id").and_then(|id| id.as_str()) == Some(&profile_id))
+        .ok_or_else(|| AppError::Storage("Profile not found".to_string()))?;
+
+    // 创建新 session（不 touch_profile，分屏不算独立打开）
+    let new_tab_id =
+        spawn_session_for_profile(&app, &state, profile, &profile_id, Some(pane_root_tab_id))
+            .await?;
+
+    // 更新 paneRoot，并保留承载该分屏树的 root tab id。
+    let root_tab_id = {
+        let mut tabs = state.tabs.write().await;
+
+        // 先找 source 是否已经是 root（有 paneRoot）
+        let root_idx = tabs
+            .iter()
+            .position(|t| t.id == source_tab_id && t.pane_root.is_some());
+
+        if let Some(idx) = root_idx {
+            // source 是 root，在其 paneRoot 里替换 source leaf
+            let root_tab = &mut tabs[idx];
+            if let Some(ref mut pane_root) = root_tab.pane_root {
+                let replacement = crate::services::PaneNode::Split {
+                    direction: split_direction,
+                    children: vec![
+                        crate::services::PaneNode::Leaf {
+                            tab_id: source_tab_id.clone(),
+                        },
+                        crate::services::PaneNode::Leaf {
+                            tab_id: new_tab_id.clone(),
+                        },
+                    ],
+                    weights: vec![0.5, 0.5],
+                };
+                pane_root.replace_leaf(&source_tab_id, replacement);
+            }
+            source_tab_id.clone()
+        } else {
+            // source 不是 root，可能是独立 tab 或某个 root 的 leaf
+            // 先检查它是否是某个 root 的 leaf
+            let containing_root_idx = tabs.iter().position(|t| {
+                t.pane_root
+                    .as_ref()
+                    .map(|root| root.leaf_tab_ids().iter().any(|id| id == &source_tab_id))
+                    .unwrap_or(false)
+            });
+
+            if let Some(idx) = containing_root_idx {
+                // source 是某个 root 的 leaf，在该 root 的 paneRoot 里替换
+                let root_tab = &mut tabs[idx];
+                if let Some(ref mut pane_root) = root_tab.pane_root {
+                    let replacement = crate::services::PaneNode::Split {
+                        direction: split_direction,
+                        children: vec![
+                            crate::services::PaneNode::Leaf {
+                                tab_id: source_tab_id.clone(),
+                            },
+                            crate::services::PaneNode::Leaf {
+                                tab_id: new_tab_id.clone(),
+                            },
+                        ],
+                        weights: vec![0.5, 0.5],
+                    };
+                    pane_root.replace_leaf(&source_tab_id, replacement);
+                }
+                root_tab.id.clone()
+            } else {
+                // source 是独立 tab，变成 root
+                let source_idx = tabs
+                    .iter()
+                    .position(|t| t.id == source_tab_id)
+                    .ok_or_else(|| AppError::Storage("Source tab vanished".to_string()))?;
+                tabs[source_idx].pane_root = Some(crate::services::PaneNode::Split {
+                    direction: split_direction,
+                    children: vec![
+                        crate::services::PaneNode::Leaf {
+                            tab_id: source_tab_id.clone(),
+                        },
+                        crate::services::PaneNode::Leaf {
+                            tab_id: new_tab_id.clone(),
+                        },
+                    ],
+                    weights: vec![0.5, 0.5],
+                });
+                source_tab_id.clone()
+            }
+        }
+    };
+
+    // 无论当前 source 是 root、leaf 还是独立 tab，顶层都必须停留在 root。
+    // 新 session 只作为 active pane，不得成为一个新的顶栏 tab。
+    {
+        let mut active_tab = state.active_tab_id.write().await;
+        *active_tab = Some(root_tab_id.clone());
+
+        let mut active_panes = state.active_pane_tab_id_by_root.write().await;
+        active_panes.insert(root_tab_id, new_tab_id.clone());
+    }
+
+    get_workspace_snapshot_and_emit(&app).await
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct PaneCloseOutcome {
+    root_tab_id: String,
+    remaining_pane_tab_ids: Vec<String>,
+    keeps_split: bool,
+}
+
+/// Remove a leaf from a split root while preserving the invariant that a
+/// top-level tab is always backed by a live session. When the original root
+/// leaf is closed, a surviving leaf is promoted to be the new root rather
+/// than leaving a tree whose container points at a closed terminal.
+fn remove_split_pane_from_tabs(
+    tabs: &mut Vec<crate::services::WorkspaceTab>,
+    root_tab_id: &str,
+    pane_tab_id: &str,
+) -> Result<PaneCloseOutcome, AppError> {
+    let root_idx = tabs
+        .iter()
+        .position(|tab| tab.id == root_tab_id)
+        .ok_or_else(|| AppError::Storage(format!("Root tab not found: {root_tab_id}")))?;
+    let mut next_pane_root = tabs[root_idx]
+        .pane_root
+        .clone()
+        .ok_or_else(|| AppError::Storage("Tab does not have a split pane layout".to_string()))?;
+    let before = next_pane_root.leaf_tab_ids();
+    if before.len() < 2 {
+        return Err(AppError::Storage(
+            "Cannot close the only pane through the split-pane command".to_string(),
+        ));
+    }
+    if !before.iter().any(|id| id == pane_tab_id) {
+        return Err(AppError::Storage(format!("Pane not found: {pane_tab_id}")));
+    }
+
+    next_pane_root.remove_leaf(pane_tab_id);
+    let remaining_pane_tab_ids = next_pane_root.leaf_tab_ids();
+    let keeps_split = remaining_pane_tab_ids.len() > 1;
+
+    if pane_tab_id != root_tab_id {
+        let root_tab = &mut tabs[root_idx];
+        root_tab.pane_root = keeps_split.then_some(next_pane_root);
+        tabs.retain(|tab| tab.id != pane_tab_id);
+        return Ok(PaneCloseOutcome {
+            root_tab_id: root_tab_id.to_string(),
+            remaining_pane_tab_ids,
+            keeps_split,
+        });
+    }
+
+    // The original root session is itself a leaf. If it is the pane being
+    // closed, turn the first surviving session into the new top-level tab and
+    // repoint all remaining leaves at it. This mirrors Ghostty's separation of
+    // tab container and terminal surface without requiring us to rename a
+    // running SSH worker.
+    let promoted_root_tab_id = remaining_pane_tab_ids
+        .first()
+        .cloned()
+        .ok_or_else(|| AppError::Storage("Split pane has no surviving leaf".to_string()))?;
+    tabs.retain(|tab| tab.id != root_tab_id);
+
+    let promoted_root = tabs
+        .iter_mut()
+        .find(|tab| tab.id == promoted_root_tab_id)
+        .ok_or_else(|| AppError::Storage("Surviving pane tab not found".to_string()))?;
+    promoted_root.pane_root = keeps_split.then_some(next_pane_root);
+    promoted_root.pane_root_tab_id = None;
+
+    for tab in tabs.iter_mut() {
+        if tab.id != promoted_root_tab_id && remaining_pane_tab_ids.iter().any(|id| id == &tab.id) {
+            tab.pane_root_tab_id = keeps_split.then(|| promoted_root_tab_id.clone());
+        }
+    }
+
+    Ok(PaneCloseOutcome {
+        root_tab_id: promoted_root_tab_id,
+        remaining_pane_tab_ids,
+        keeps_split,
+    })
+}
+
+/// 关闭分屏中的单个 pane。若 pane tree 只剩一个 leaf，退化回普通 tab。
+#[tauri::command]
+pub async fn app_close_pane(
+    app: AppHandle,
+    root_tab_id: String,
+    pane_tab_id: String,
+) -> Result<serde_json::Value, AppError> {
+    let state = app.state::<crate::services::workspace::WorkspaceState>();
+    let _library_guard = lock_library_after_transfer_hydration(&app).await?;
+
+    // Validate before stopping the session. Closing the final pane is a
+    // top-level-tab action and must go through its confirmation flow instead.
+    {
+        let tabs = state.tabs.read().await;
+        let root_tab = tabs
+            .iter()
+            .find(|tab| tab.id == root_tab_id)
+            .ok_or_else(|| AppError::Storage(format!("Root tab not found: {root_tab_id}")))?;
+        let leaves = root_tab
+            .pane_root
+            .as_ref()
+            .map(crate::services::PaneNode::leaf_tab_ids)
+            .ok_or_else(|| {
+                AppError::Storage("Tab does not have a split pane layout".to_string())
+            })?;
+        if leaves.len() < 2 {
+            return Err(AppError::Storage(
+                "Cannot close the only pane through the split-pane command".to_string(),
+            ));
+        }
+        if !leaves.iter().any(|id| id == &pane_tab_id) {
+            return Err(AppError::Storage(format!("Pane not found: {pane_tab_id}")));
+        }
+    }
+
+    let previous_active_pane = state
+        .active_pane_tab_id_by_root
+        .read()
+        .await
+        .get(&root_tab_id)
+        .cloned();
+
+    // 暂停该 pane 关联的传输，并清理对应 worker。
+    let _ = crate::services::transfers::pause_for_tab(
+        &app,
+        &pane_tab_id,
+        "Pane 关闭后已暂停，可在重连后继续传输",
+    )
+    .await;
+    stop_session_worker(&state, &pane_tab_id).await;
+
+    let outcome = {
+        let mut tabs = state.tabs.write().await;
+        remove_split_pane_from_tabs(&mut tabs, &root_tab_id, &pane_tab_id)?
+    };
+
+    state.sessions.write().await.remove(&pane_tab_id);
+
+    {
+        let mut active_tab = state.active_tab_id.write().await;
+        if active_tab.as_deref() == Some(root_tab_id.as_str()) {
+            *active_tab = Some(outcome.root_tab_id.clone());
+        }
+    }
+
+    {
+        let mut active_panes = state.active_pane_tab_id_by_root.write().await;
+        active_panes.remove(&root_tab_id);
+        if outcome.keeps_split {
+            let next_active_pane = previous_active_pane
+                .filter(|id| id != &pane_tab_id && outcome.remaining_pane_tab_ids.contains(id))
+                .unwrap_or_else(|| outcome.remaining_pane_tab_ids[0].clone());
+            active_panes.insert(outcome.root_tab_id, next_active_pane);
+        }
+    }
+
+    get_workspace_snapshot_and_emit(&app).await
+}
+
+/// 设置分屏中的活跃 pane。
+#[tauri::command]
+pub async fn app_set_active_pane(
+    app: AppHandle,
+    root_tab_id: String,
+    pane_tab_id: String,
+) -> Result<serde_json::Value, AppError> {
+    let state = app.state::<crate::services::workspace::WorkspaceState>();
+    {
+        let mut active_panes = state.active_pane_tab_id_by_root.write().await;
+        active_panes.insert(root_tab_id, pane_tab_id);
+    }
+    get_workspace_snapshot(app).await
+}
+
+/// 持久化分屏 weights（拖拽 resize 结束时调用）。
+#[tauri::command]
+pub async fn app_set_pane_weights(
+    app: AppHandle,
+    root_tab_id: String,
+    pane_path: Vec<usize>,
+    weights: Vec<f32>,
+) -> Result<serde_json::Value, AppError> {
+    let state = app.state::<crate::services::workspace::WorkspaceState>();
+    {
+        let mut tabs = state.tabs.write().await;
+        let root_idx = tabs
+            .iter()
+            .position(|t| t.id == root_tab_id)
+            .ok_or_else(|| AppError::Storage(format!("Root tab not found: {}", root_tab_id)))?;
+        let root_tab = &mut tabs[root_idx];
+        if let Some(ref mut pane_root) = root_tab.pane_root {
+            if !pane_root.set_split_weights_at_path(&pane_path, &weights) {
+                return Err(AppError::Storage(
+                    "Split pane path or weights are invalid".to_string(),
+                ));
+            }
+        } else {
+            return Err(AppError::Storage(
+                "Tab does not have a split pane layout".to_string(),
+            ));
+        }
+    }
+    get_workspace_snapshot(app).await
 }
 
 #[tauri::command]
@@ -1165,9 +1572,19 @@ pub async fn app_activate_tab(
     tab_id: String,
 ) -> Result<serde_json::Value, AppError> {
     let state = app.state::<crate::services::workspace::WorkspaceState>();
+    // A pane leaf owns a session but never owns a top-level tab. Normalizing
+    // here makes the invariant hold even for stale UI events.
+    let top_level_tab_id = state
+        .tabs
+        .read()
+        .await
+        .iter()
+        .find(|tab| tab.id == tab_id)
+        .and_then(|tab| tab.pane_root_tab_id.clone())
+        .unwrap_or(tab_id);
     {
         let mut active = state.active_tab_id.write().await;
-        *active = Some(tab_id);
+        *active = Some(top_level_tab_id);
     }
     get_workspace_snapshot(app).await
 }
@@ -1355,26 +1772,114 @@ pub async fn app_disconnect_tab(
 
 #[tauri::command]
 pub async fn app_close_tab(app: AppHandle, tab_id: String) -> Result<serde_json::Value, AppError> {
-    crate::services::transfers::pause_for_tab(
-        &app,
-        &tab_id,
-        "标签关闭后已暂停，可在重连后继续传输",
-    )
-    .await?;
     let state = app.state::<crate::services::workspace::WorkspaceState>();
-    stop_session_worker(&state, &tab_id).await;
-    {
-        let mut tabs = state.tabs.write().await;
-        tabs.retain(|t| t.id != tab_id);
 
-        let mut active = state.active_tab_id.write().await;
-        if *active == Some(tab_id.clone()) {
-            *active = tabs.last().map(|t| t.id.clone());
+    // 检查是否是分屏 root：如果是，关闭所有 leaf 的 worker 和传输
+    let pane_leaf_ids: Vec<String> = {
+        let tabs = state.tabs.read().await;
+        tabs.iter()
+            .find(|t| t.id == tab_id)
+            .and_then(|t| t.pane_root.as_ref())
+            .map(|root| root.leaf_tab_ids())
+            .unwrap_or_default()
+    };
+
+    // 检查是否是某个 root 的 leaf
+    let containing_root_id: Option<String> = if pane_leaf_ids.is_empty() {
+        let tabs = state.tabs.read().await;
+        tabs.iter()
+            .find(|t| {
+                t.pane_root
+                    .as_ref()
+                    .map(|root| root.leaf_tab_ids().iter().any(|id| id == &tab_id))
+                    .unwrap_or(false)
+            })
+            .map(|t| t.id.clone())
+    } else {
+        None
+    };
+
+    if let Some(root_id) = containing_root_id {
+        // tab_id 是某个 root 的 leaf，等价于 close_pane
+        // 暂停传输
+        let _ = crate::services::transfers::pause_for_tab(
+            &app,
+            &tab_id,
+            "Pane 关闭后已暂停，可在重连后继续传输",
+        )
+        .await;
+        stop_session_worker(&state, &tab_id).await;
+        {
+            let mut tabs = state.tabs.write().await;
+            let root_idx = tabs
+                .iter()
+                .position(|t| t.id == root_id)
+                .ok_or_else(|| AppError::Storage(format!("Root tab not found: {}", root_id)))?;
+            {
+                let root_tab = &mut tabs[root_idx];
+                if let Some(ref mut pane_root) = root_tab.pane_root {
+                    pane_root.remove_leaf(&tab_id);
+                    if let crate::services::PaneNode::Leaf { .. } = pane_root {
+                        root_tab.pane_root = None;
+                    }
+                }
+            }
+            tabs.retain(|t| t.id != tab_id);
+            let mut sessions = state.sessions.write().await;
+            sessions.remove(&tab_id);
+            let mut active_panes = state.active_pane_tab_id_by_root.write().await;
+            if let Some(root_tab) = tabs.get(root_idx) {
+                if root_tab.pane_root.is_none() {
+                    active_panes.remove(&root_id);
+                } else if let Some(ref pane_root) = root_tab.pane_root {
+                    let leaves = pane_root.leaf_tab_ids();
+                    if active_panes
+                        .get(&root_id)
+                        .map(|id| id == &tab_id || !leaves.contains(id))
+                        .unwrap_or(true)
+                    {
+                        if let Some(first) = leaves.first() {
+                            active_panes.insert(root_id.clone(), first.clone());
+                        }
+                    }
+                }
+            }
         }
+    } else {
+        // 普通关闭（可能是独立 tab 或分屏 root）
+        let all_ids_to_close = if pane_leaf_ids.is_empty() {
+            vec![tab_id.clone()]
+        } else {
+            pane_leaf_ids
+        };
 
-        let mut sessions = state.sessions.write().await;
-        sessions.remove(&tab_id);
+        for id in &all_ids_to_close {
+            crate::services::transfers::pause_for_tab(
+                &app,
+                id,
+                "标签关闭后已暂停，可在重连后继续传输",
+            )
+            .await?;
+            stop_session_worker(&state, id).await;
+        }
+        {
+            let mut tabs = state.tabs.write().await;
+            tabs.retain(|t| !all_ids_to_close.contains(&t.id));
+
+            let mut active = state.active_tab_id.write().await;
+            if *active == Some(tab_id.clone()) {
+                *active = tabs.last().map(|t| t.id.clone());
+            }
+
+            let mut sessions = state.sessions.write().await;
+            for id in &all_ids_to_close {
+                sessions.remove(id);
+            }
+            let mut active_panes = state.active_pane_tab_id_by_root.write().await;
+            active_panes.remove(&tab_id);
+        }
     }
+
     get_workspace_snapshot(app).await
 }
 
@@ -2206,6 +2711,107 @@ mod command_template_tests {
 }
 
 #[cfg(test)]
+mod split_pane_close_tests {
+    use super::remove_split_pane_from_tabs;
+    use crate::services::{PaneNode, SplitDirection, WorkspaceTab, WorkspaceTabStatus};
+
+    fn tab(id: &str, pane_root: Option<PaneNode>, pane_root_tab_id: Option<&str>) -> WorkspaceTab {
+        WorkspaceTab {
+            id: id.to_string(),
+            profile_id: "profile-1".to_string(),
+            session_type: "ssh".to_string(),
+            title: "Server".to_string(),
+            layout: "terminal-file".to_string(),
+            status: WorkspaceTabStatus::Connected,
+            pane_root,
+            pane_root_tab_id: pane_root_tab_id.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn closing_a_child_pane_keeps_the_existing_root_tab() {
+        let mut tabs = vec![
+            tab(
+                "root",
+                Some(PaneNode::Split {
+                    direction: SplitDirection::Row,
+                    children: vec![
+                        PaneNode::Leaf {
+                            tab_id: "root".to_string(),
+                        },
+                        PaneNode::Leaf {
+                            tab_id: "child".to_string(),
+                        },
+                    ],
+                    weights: vec![0.5, 0.5],
+                }),
+                None,
+            ),
+            tab("child", None, Some("root")),
+        ];
+
+        let outcome = remove_split_pane_from_tabs(&mut tabs, "root", "child").unwrap();
+
+        assert_eq!(outcome.root_tab_id, "root");
+        assert!(!outcome.keeps_split);
+        assert_eq!(outcome.remaining_pane_tab_ids, vec!["root"]);
+        assert_eq!(tabs.len(), 1);
+        assert_eq!(tabs[0].id, "root");
+        assert!(tabs[0].pane_root.is_none());
+    }
+
+    #[test]
+    fn closing_the_original_root_leaf_promotes_a_surviving_pane() {
+        let mut tabs = vec![
+            tab(
+                "root",
+                Some(PaneNode::Split {
+                    direction: SplitDirection::Row,
+                    children: vec![
+                        PaneNode::Leaf {
+                            tab_id: "root".to_string(),
+                        },
+                        PaneNode::Split {
+                            direction: SplitDirection::Column,
+                            children: vec![
+                                PaneNode::Leaf {
+                                    tab_id: "second".to_string(),
+                                },
+                                PaneNode::Leaf {
+                                    tab_id: "third".to_string(),
+                                },
+                            ],
+                            weights: vec![0.5, 0.5],
+                        },
+                    ],
+                    weights: vec![0.5, 0.5],
+                }),
+                None,
+            ),
+            tab("second", None, Some("root")),
+            tab("third", None, Some("root")),
+        ];
+
+        let outcome = remove_split_pane_from_tabs(&mut tabs, "root", "root").unwrap();
+
+        assert_eq!(outcome.root_tab_id, "second");
+        assert!(outcome.keeps_split);
+        assert_eq!(outcome.remaining_pane_tab_ids, vec!["second", "third"]);
+        assert_eq!(tabs.len(), 2);
+
+        let promoted_root = tabs.iter().find(|tab| tab.id == "second").unwrap();
+        assert!(promoted_root.pane_root.is_some());
+        assert!(promoted_root.pane_root_tab_id.is_none());
+        assert_eq!(
+            tabs.iter()
+                .find(|tab| tab.id == "third")
+                .and_then(|tab| tab.pane_root_tab_id.as_deref()),
+            Some("second")
+        );
+    }
+}
+
+#[cfg(test)]
 mod reconnect_tests {
     use super::claim_reconnect_tab;
     use crate::services::{WorkspaceTab, WorkspaceTabStatus};
@@ -2218,6 +2824,8 @@ mod reconnect_tests {
             title: "Server".to_string(),
             layout: "terminal-file".to_string(),
             status,
+            pane_root: None,
+            pane_root_tab_id: None,
         }
     }
 
@@ -2307,6 +2915,33 @@ mod ui_state_tests {
                 .and_then(|value| value.as_str()),
             Some("legacy-folders")
         );
+    }
+}
+
+#[cfg(test)]
+mod ui_preferences_tests {
+    use super::{normalize_ui_preferences, UiPreferences};
+
+    #[test]
+    fn falls_back_to_safe_values_for_unknown_preferences() {
+        let preferences = normalize_ui_preferences(UiPreferences {
+            theme: "unknown-theme".to_string(),
+            locale: "unknown-locale".to_string(),
+        });
+
+        assert_eq!(preferences.theme, "default-dark");
+        assert_eq!(preferences.locale, "zhCN");
+    }
+
+    #[test]
+    fn keeps_supported_preferences_unchanged() {
+        let preferences = normalize_ui_preferences(UiPreferences {
+            theme: "default-light".to_string(),
+            locale: "enUS".to_string(),
+        });
+
+        assert_eq!(preferences.theme, "default-light");
+        assert_eq!(preferences.locale, "enUS");
     }
 }
 

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -292,12 +292,21 @@ pub(crate) fn install_localized_tray_menu(
 }
 
 fn build_application_menu(app: &AppHandle<Wry>, is_english: bool) -> Result<Menu<Wry>, AppError> {
-    let (quit_accelerator, close_accelerator) = application_menu_accelerators(std::env::consts::OS);
+    let platform = std::env::consts::OS;
+    let (quit_accelerator, close_accelerator) = application_menu_accelerators(platform);
+    let new_tab_accelerator = workspace_new_tab_accelerator(platform);
     let new_connection_menu = MenuItemBuilder::with_id(
         "new-connection",
         localized(is_english, "New Connection", "新建连接"),
     )
     .accelerator("CmdOrCtrl+N")
+    .build(app)
+    .map_err(|error| AppError::Window(error.to_string()))?;
+    let new_tab_menu = MenuItemBuilder::with_id(
+        "workspace-new-tab",
+        localized(is_english, "New Tab", "新建标签页"),
+    )
+    .accelerator(new_tab_accelerator)
     .build(app)
     .map_err(|error| AppError::Window(error.to_string()))?;
     let connection_manager_menu = MenuItemBuilder::with_id(
@@ -316,6 +325,8 @@ fn build_application_menu(app: &AppHandle<Wry>, is_english: bool) -> Result<Menu
     .map_err(|error| AppError::Window(error.to_string()))?;
 
     let file_submenu_builder = SubmenuBuilder::new(app, localized(is_english, "File", "文件"))
+        .item(&new_tab_menu)
+        .separator()
         .item(&new_connection_menu)
         .item(&connection_manager_menu)
         .item(&command_manager_menu);
@@ -390,6 +401,68 @@ fn build_application_menu(app: &AppHandle<Wry>, is_english: bool) -> Result<Menu
         .build()
         .map_err(|error| AppError::Window(error.to_string()))?;
 
+    // View 菜单：分屏快捷键。终端聚焦时前端键盘事件会被 xterm 拦截，
+    // 原生菜单 accelerator 全局有效，与现有 Cmd+W 一致。
+    let (split_vertical_accelerator, split_horizontal_accelerator) =
+        split_pane_accelerators(platform);
+    let view_split_vertical = MenuItemBuilder::with_id(
+        "view-split-vertical",
+        localized(is_english, "Split Vertically", "垂直分屏"),
+    )
+    .accelerator(split_vertical_accelerator)
+    .build(app)
+    .map_err(|error| AppError::Window(error.to_string()))?;
+    let view_split_horizontal = MenuItemBuilder::with_id(
+        "view-split-horizontal",
+        localized(is_english, "Split Horizontally", "水平分屏"),
+    )
+    .accelerator(split_horizontal_accelerator)
+    .build(app)
+    .map_err(|error| AppError::Window(error.to_string()))?;
+    let view_submenu_builder = SubmenuBuilder::new(app, localized(is_english, "View", "视图"))
+        .item(&view_split_vertical)
+        .item(&view_split_horizontal);
+    #[cfg(target_os = "windows")]
+    let view_submenu_builder = {
+        let focus_pane_left = MenuItemBuilder::with_id(
+            "view-focus-pane-left",
+            localized(is_english, "Focus Pane Left", "聚焦左侧窗格"),
+        )
+        .accelerator("Alt+Left")
+        .build(app)
+        .map_err(|error| AppError::Window(error.to_string()))?;
+        let focus_pane_right = MenuItemBuilder::with_id(
+            "view-focus-pane-right",
+            localized(is_english, "Focus Pane Right", "聚焦右侧窗格"),
+        )
+        .accelerator("Alt+Right")
+        .build(app)
+        .map_err(|error| AppError::Window(error.to_string()))?;
+        let focus_pane_up = MenuItemBuilder::with_id(
+            "view-focus-pane-up",
+            localized(is_english, "Focus Pane Up", "聚焦上方窗格"),
+        )
+        .accelerator("Alt+Up")
+        .build(app)
+        .map_err(|error| AppError::Window(error.to_string()))?;
+        let focus_pane_down = MenuItemBuilder::with_id(
+            "view-focus-pane-down",
+            localized(is_english, "Focus Pane Down", "聚焦下方窗格"),
+        )
+        .accelerator("Alt+Down")
+        .build(app)
+        .map_err(|error| AppError::Window(error.to_string()))?;
+        view_submenu_builder
+            .separator()
+            .item(&focus_pane_left)
+            .item(&focus_pane_right)
+            .item(&focus_pane_up)
+            .item(&focus_pane_down)
+    };
+    let view_submenu = view_submenu_builder
+        .build()
+        .map_err(|error| AppError::Window(error.to_string()))?;
+
     let menu_builder = MenuBuilder::new(app);
     #[cfg(target_os = "macos")]
     let menu_builder = {
@@ -441,6 +514,7 @@ fn build_application_menu(app: &AppHandle<Wry>, is_english: bool) -> Result<Menu
     menu_builder
         .item(&file_submenu)
         .item(&edit_submenu)
+        .item(&view_submenu)
         .item(&window_submenu)
         .build()
         .map_err(|error| AppError::Window(error.to_string()))
@@ -464,6 +538,25 @@ fn application_menu_accelerators(platform: &str) -> (&'static str, &'static str)
         ("Cmd+Q", "Cmd+W")
     } else {
         ("Alt+F4", "Ctrl+W")
+    }
+}
+
+/// Keep Cmd+T on macOS, while avoiding Ctrl+T collisions with terminals and
+/// WebViews on Windows/Linux.
+fn workspace_new_tab_accelerator(platform: &str) -> &'static str {
+    if platform == "macos" {
+        "Cmd+T"
+    } else {
+        "Ctrl+Shift+T"
+    }
+}
+
+/// Align split shortcuts with the host terminal where a convention exists.
+fn split_pane_accelerators(platform: &str) -> (&'static str, &'static str) {
+    match platform {
+        "macos" => ("Cmd+D", "Cmd+Shift+D"),
+        "windows" => ("Alt+Shift+D", "Alt+Shift+-"),
+        _ => ("Ctrl+Shift+D", "Ctrl+Alt+Shift+D"),
     }
 }
 
@@ -1326,6 +1419,41 @@ pub fn run() {
                     }
                 }
             }
+            "workspace-new-tab" => {
+                if let Some(window) = focused_webview_window(app) {
+                    let _ = window.emit("app:new-tab-request", ());
+                }
+            }
+            "view-split-vertical" => {
+                if let Some(window) = focused_webview_window(app) {
+                    let _ = window.emit("app:split-pane-request", "row");
+                }
+            }
+            "view-split-horizontal" => {
+                if let Some(window) = focused_webview_window(app) {
+                    let _ = window.emit("app:split-pane-request", "column");
+                }
+            }
+            "view-focus-pane-left" => {
+                if let Some(window) = focused_webview_window(app) {
+                    let _ = window.emit("app:focus-pane-request", "left");
+                }
+            }
+            "view-focus-pane-right" => {
+                if let Some(window) = focused_webview_window(app) {
+                    let _ = window.emit("app:focus-pane-request", "right");
+                }
+            }
+            "view-focus-pane-up" => {
+                if let Some(window) = focused_webview_window(app) {
+                    let _ = window.emit("app:focus-pane-request", "up");
+                }
+            }
+            "view-focus-pane-down" => {
+                if let Some(window) = focused_webview_window(app) {
+                    let _ = window.emit("app:focus-pane-request", "down");
+                }
+            }
             "window-minimize" => {
                 if let Some(window) = focused_webview_window(app) {
                     let _ = window.minimize();
@@ -1397,6 +1525,10 @@ pub fn run() {
             crate::commands::app_reconnect_tab,
             crate::commands::app_disconnect_tab,
             crate::commands::app_close_tab,
+            crate::commands::app_split_tab,
+            crate::commands::app_close_pane,
+            crate::commands::app_set_active_pane,
+            crate::commands::app_set_pane_weights,
             crate::commands::app_write_terminal,
             crate::commands::app_subscribe_terminal_data,
             crate::commands::app_resize_terminal,
@@ -1477,9 +1609,9 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::{
-        application_menu_accelerators, child_window_should_be_transparent,
-        tray_icon_should_be_template, tray_menu_labels, FileEditorCloseRegistry,
-        QuitPreparationRegistry, WindowMenuKind,
+        application_menu_accelerators, child_window_should_be_transparent, split_pane_accelerators,
+        tray_icon_should_be_template, tray_menu_labels, workspace_new_tab_accelerator,
+        FileEditorCloseRegistry, QuitPreparationRegistry, WindowMenuKind,
     };
 
     #[cfg(target_os = "windows")]
@@ -1510,6 +1642,26 @@ mod tests {
             ("Alt+F4", "Ctrl+W")
         );
         assert_eq!(application_menu_accelerators("linux"), ("Alt+F4", "Ctrl+W"));
+    }
+
+    #[test]
+    fn uses_a_non_conflicting_new_tab_shortcut_outside_macos() {
+        assert_eq!(workspace_new_tab_accelerator("macos"), "Cmd+T");
+        assert_eq!(workspace_new_tab_accelerator("windows"), "Ctrl+Shift+T");
+        assert_eq!(workspace_new_tab_accelerator("linux"), "Ctrl+Shift+T");
+    }
+
+    #[test]
+    fn matches_windows_terminal_split_shortcuts_on_windows() {
+        assert_eq!(split_pane_accelerators("macos"), ("Cmd+D", "Cmd+Shift+D"));
+        assert_eq!(
+            split_pane_accelerators("windows"),
+            ("Alt+Shift+D", "Alt+Shift+-")
+        );
+        assert_eq!(
+            split_pane_accelerators("linux"),
+            ("Ctrl+Shift+D", "Ctrl+Alt+Shift+D")
+        );
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/services/mod.rs
+++ b/apps/tauri/src-tauri/src/services/mod.rs
@@ -7,4 +7,6 @@ pub mod updates;
 pub mod webdav;
 pub mod workspace;
 
-pub use workspace::{SessionSnapshot, WorkspaceState, WorkspaceTab, WorkspaceTabStatus};
+pub use workspace::{
+    PaneNode, SessionSnapshot, SplitDirection, WorkspaceState, WorkspaceTab, WorkspaceTabStatus,
+};

--- a/apps/tauri/src-tauri/src/services/workspace.rs
+++ b/apps/tauri/src-tauri/src/services/workspace.rs
@@ -44,6 +44,161 @@ pub struct WorkspaceTab {
     pub title: String,
     pub layout: String, // "terminal-file" | "file-only" | "terminal-only"
     pub status: WorkspaceTabStatus,
+    /// 分屏树根节点；普通 tab 为 None。只有分屏的根 tab 持有。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pane_root: Option<PaneNode>,
+    /// 分屏 leaf 所属的顶层 workspace tab。leaf 仍保留独立 session，但绝不作为顶栏 tab。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pane_root_tab_id: Option<String>,
+}
+
+/// 分屏方向：row = 左右分（垂直分屏），column = 上下分（水平分屏）
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SplitDirection {
+    Row,
+    Column,
+}
+
+/// 分屏树节点。leaf 引用一个真实 tab id；split 递归持有子节点。
+#[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum PaneNode {
+    Leaf {
+        // The renderer's core contract uses `tabId`. Keep accepting the
+        // previous Rust-shaped spelling so a restored in-memory snapshot does
+        // not make the layout unreadable during an upgrade.
+        #[serde(rename = "tabId", alias = "tab_id")]
+        tab_id: String,
+    },
+    Split {
+        direction: SplitDirection,
+        children: Vec<PaneNode>,
+        /// 每个子节点占比，长度与 children 一致，和为 1。
+        weights: Vec<f32>,
+    },
+}
+
+impl PaneNode {
+    /// 递归收集所有 leaf 的 tab_id。
+    pub fn leaf_tab_ids(&self) -> Vec<String> {
+        match self {
+            PaneNode::Leaf { tab_id } => vec![tab_id.clone()],
+            PaneNode::Split { children, .. } => {
+                children.iter().flat_map(|c| c.leaf_tab_ids()).collect()
+            }
+        }
+    }
+
+    /// 递归查找并替换指定 leaf 节点为新子树。返回是否替换成功。
+    /// 用于分屏：把当前 leaf 替换为 split(leaf, new_leaf)。
+    pub fn replace_leaf(&mut self, target_tab_id: &str, replacement: PaneNode) -> bool {
+        match self {
+            PaneNode::Leaf { tab_id } if tab_id == target_tab_id => {
+                *self = replacement;
+                true
+            }
+            PaneNode::Leaf { .. } => false,
+            PaneNode::Split { children, .. } => {
+                for child in children.iter_mut() {
+                    if child.replace_leaf(target_tab_id, replacement.clone()) {
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
+
+    /// 递归移除指定 leaf 节点。移除后规整：
+    ///
+    /// - split 只剩一个子节点时，用唯一子节点替换该 split
+    ///
+    /// 返回 true 表示子树中发生了移除。
+    pub fn remove_leaf(&mut self, target_tab_id: &str) -> bool {
+        match self {
+            PaneNode::Leaf { tab_id } if tab_id == target_tab_id => true,
+            PaneNode::Leaf { .. } => false,
+            PaneNode::Split {
+                children, weights, ..
+            } => {
+                // 先检查直接 children 里有没有匹配的 leaf
+                let direct_idx = children.iter().position(|c| match c {
+                    PaneNode::Leaf { tab_id } => tab_id == target_tab_id,
+                    PaneNode::Split { .. } => false,
+                });
+
+                if let Some(idx) = direct_idx {
+                    children.remove(idx);
+                    if weights.len() > idx {
+                        weights.remove(idx);
+                    }
+                } else {
+                    // 递归到子 split
+                    let mut found_in_child = false;
+                    for child in children.iter_mut() {
+                        if child.remove_leaf(target_tab_id) {
+                            found_in_child = true;
+                            break;
+                        }
+                    }
+                    if !found_in_child {
+                        return false;
+                    }
+                }
+
+                normalize_weights(weights);
+                // 规整：split 只剩一个子节点时用唯一子节点替换自身
+                if children.len() == 1 {
+                    let only = children.pop().unwrap();
+                    *self = only;
+                }
+                true
+            }
+        }
+    }
+
+    /// 更新指定 split 节点的 weights。`pane_path` 使用从根节点到该 split 的 child index。
+    pub fn set_split_weights_at_path(&mut self, pane_path: &[usize], next_weights: &[f32]) -> bool {
+        let PaneNode::Split {
+            children, weights, ..
+        } = self
+        else {
+            return false;
+        };
+
+        if pane_path.is_empty() {
+            if weights.len() != next_weights.len() {
+                return false;
+            }
+            weights.clone_from_slice(next_weights);
+            normalize_weights(weights);
+            return true;
+        }
+
+        let Some(child) = children.get_mut(pane_path[0]) else {
+            return false;
+        };
+        child.set_split_weights_at_path(&pane_path[1..], next_weights)
+    }
+}
+
+/// 归一化 weights 数组：确保和为 1，且长度 >= 2 时每项 > 0。
+fn normalize_weights(weights: &mut [f32]) {
+    if weights.is_empty() {
+        return;
+    }
+    let sum: f32 = weights.iter().sum();
+    if sum <= 0.0 || !sum.is_finite() {
+        let n = weights.len() as f32;
+        for w in weights.iter_mut() {
+            *w = 1.0 / n;
+        }
+        return;
+    }
+    for w in weights.iter_mut() {
+        *w /= sum;
+    }
 }
 
 /// Rust-side mirror of `packages/core::TabStatus`. Keeping this as an enum
@@ -245,6 +400,8 @@ pub struct WorkspaceState {
     /// Serializes updater downloads and installation so a double click cannot
     /// start competing installers or overwrite a verified package in memory.
     pub update_operation: Arc<Mutex<()>>,
+    /// 分屏 root tabId -> 当前活跃 leaf tabId。用于终端输入/文件操作/命令发送定位。
+    pub active_pane_tab_id_by_root: Arc<RwLock<HashMap<String, String>>>,
     /// Windows keeps the verified updater payload in memory until the user
     /// confirms the restart. It is intentionally never persisted to user data.
     #[cfg(target_os = "windows")]
@@ -277,6 +434,7 @@ impl Default for WorkspaceState {
             update_status: Arc::new(RwLock::new(None)),
             update_check: Arc::new(Mutex::new(())),
             update_operation: Arc::new(Mutex::new(())),
+            active_pane_tab_id_by_root: Arc::new(RwLock::new(HashMap::new())),
             #[cfg(target_os = "windows")]
             windows_downloaded_update: Arc::new(Mutex::new(None)),
         }
@@ -327,7 +485,7 @@ impl WorkspaceState {
 mod tests {
     use super::{
         initial_remote_path_for_profile, reconnect_mode_for_profile, ConnectionCapabilities,
-        TransferRunHandle, WorkspaceState, WorkspaceTabStatus,
+        PaneNode, SplitDirection, TransferRunHandle, WorkspaceState, WorkspaceTabStatus,
     };
     use std::sync::{Arc, Mutex};
     use tauri::ipc::Channel;
@@ -426,6 +584,61 @@ mod tests {
             assert_eq!(payload["tabId"], "tab-load");
             assert_eq!(payload["chunk"], format!("{index}\r\n"));
         }
+    }
+
+    #[test]
+    fn split_weights_update_only_the_targeted_nested_split() {
+        let mut pane_root = PaneNode::Split {
+            direction: SplitDirection::Row,
+            weights: vec![0.5, 0.5],
+            children: vec![
+                PaneNode::Leaf {
+                    tab_id: "left".to_string(),
+                },
+                PaneNode::Split {
+                    direction: SplitDirection::Column,
+                    weights: vec![0.5, 0.5],
+                    children: vec![
+                        PaneNode::Leaf {
+                            tab_id: "top-right".to_string(),
+                        },
+                        PaneNode::Leaf {
+                            tab_id: "bottom-right".to_string(),
+                        },
+                    ],
+                },
+            ],
+        };
+
+        assert!(pane_root.set_split_weights_at_path(&[1], &[0.25, 0.75]));
+
+        let PaneNode::Split {
+            weights, children, ..
+        } = pane_root
+        else {
+            panic!("root should remain a split");
+        };
+        assert_eq!(weights, vec![0.5, 0.5]);
+        let PaneNode::Split {
+            weights: nested_weights,
+            ..
+        } = &children[1]
+        else {
+            panic!("right pane should remain a split");
+        };
+        assert_eq!(nested_weights, &vec![0.25, 0.75]);
+    }
+
+    #[test]
+    fn pane_nodes_serialize_with_the_core_camel_case_shape() {
+        let value = serde_json::to_value(PaneNode::Leaf {
+            tab_id: "pane-1".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(value["kind"], "leaf");
+        assert_eq!(value["tabId"], "pane-1");
+        assert!(value.get("tab_id").is_none());
     }
 
     #[tokio::test]

--- a/apps/tauri/src-tauri/src/sessions/ssh.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant};
 use base64::Engine;
 use russh::client::{Handle, Handler};
 use russh::keys::PrivateKeyWithHashAlg;
-use russh::{Channel, ChannelMsg, ChannelWriteHalf, Sig};
+use russh::{Channel, ChannelMsg, ChannelWriteHalf, Disconnect, Sig};
 use russh_sftp::client::error::Error as SftpError;
 use russh_sftp::client::fs::Metadata as SftpMetadata;
 use russh_sftp::client::SftpSession;
@@ -47,6 +47,11 @@ const SSH_INTERACTION_TIMEOUT: Duration = Duration::from_secs(300);
 const SSH_TRANSPORT_TIMEOUT: Duration = Duration::from_secs(30);
 const SSH_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 const SSH_PASSWORD_AUTH_TIMEOUT: Duration = Duration::from_secs(30);
+/// HTTP/SOCKS5 代理单步 IO 超时。代理服务器或中间网络卡住时，TCP 连接、
+/// CONNECT 请求写入、响应逐字节读取都不能让外层 30s 超时全部消耗在
+/// 单次 read 上——慢速代理可以每 29s 发一个字节拖满整个阶段。8s 覆盖
+/// 正常代理 RTT，超时后立即给出明确错误。
+const PROXY_IO_TIMEOUT: Duration = Duration::from_secs(8);
 /// A remote PTY write must not pin the SSH worker forever when the server has
 /// stopped consuming the channel or the channel window is exhausted.
 const TERMINAL_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -1708,14 +1713,25 @@ fn fingerprint_sha256_base64(key: &russh::keys::PublicKey) -> String {
 /// accept/reject prompt when the fingerprint already matches.
 /// Load a jump host profile from the profiles.json storage by its id.
 /// Mirrors Electron's `resolveProfile(jumpProfileId)`.
+/// 校验 profile 类型必须为 ssh：UI 层已过滤，但存储层可能被篡改或残留
+/// 旧数据，FTP/Serial/ Telnet profile 无法作为 SSH 跳板，提前拒绝避免
+/// 在 russh 握手阶段才失败、错误信息不清晰。
 fn load_jump_profile(app: &AppHandle, profile_id: &str) -> Result<Value, String> {
     let profiles = crate::storage::read_json_array(app, "profiles.json")
         .map_err(|e| format!("Failed to read profiles.json for jump host: {}", e))?;
-    profiles
+    let profile = profiles
         .iter()
         .find(|p| p.get("id").and_then(|id| id.as_str()) == Some(profile_id))
         .cloned()
-        .ok_or_else(|| format!("Jump Host profile '{}' not found", profile_id))
+        .ok_or_else(|| format!("Jump Host profile '{}' not found", profile_id))?;
+    let profile_type = profile.get("type").and_then(Value::as_str).unwrap_or("");
+    if profile_type != "ssh" {
+        return Err(format!(
+            "Jump Host profile '{}' must be an SSH profile, got '{}'",
+            profile_id, profile_type
+        ));
+    }
+    Ok(profile)
 }
 
 trait SshTransport: AsyncRead + AsyncWrite + Unpin + Send {}
@@ -1787,6 +1803,8 @@ async fn connect_ssh_transport(
         .unwrap_or("none");
 
     if proxy_type == "none" {
+        // 外层 wait_for_ssh_stage(SSH_TRANSPORT_TIMEOUT) 已提供 30s 超时保护，
+        // 此处无需再加内层 timeout。
         let stream = TcpStream::connect((host, port))
             .await
             .map_err(|error| format!("SSH connect failed: {error}"))?;
@@ -1799,6 +1817,7 @@ async fn connect_ssh_transport(
         .and_then(Value::as_str)
         .filter(|value| !value.trim().is_empty())
         .ok_or_else(|| "Proxy host is required".to_string())?;
+    validate_proxy_host(proxy_host)?;
     let proxy_port = proxy
         .and_then(|value| value.get("port"))
         .and_then(Value::as_u64)
@@ -1813,21 +1832,30 @@ async fn connect_ssh_transport(
         .and_then(|value| value.get("password"))
         .and_then(Value::as_str)
         .unwrap_or("");
+    validate_proxy_credentials(username, password)?;
 
     match proxy_type {
         "socks5" => {
             let stream = if username.is_empty() {
-                Socks5Stream::connect((proxy_host, proxy_port), (host, port))
-                    .await
-                    .map_err(|error| format!("SOCKS5 proxy connect failed: {error}"))?
-            } else {
-                Socks5Stream::connect_with_password(
-                    (proxy_host, proxy_port),
-                    (host, port),
-                    username,
-                    password,
+                timeout(
+                    PROXY_IO_TIMEOUT,
+                    Socks5Stream::connect((proxy_host, proxy_port), (host, port)),
                 )
                 .await
+                .map_err(|_| "SOCKS5 proxy connect timed out".to_string())?
+                .map_err(|error| format!("SOCKS5 proxy connect failed: {error}"))?
+            } else {
+                timeout(
+                    PROXY_IO_TIMEOUT,
+                    Socks5Stream::connect_with_password(
+                        (proxy_host, proxy_port),
+                        (host, port),
+                        username,
+                        password,
+                    ),
+                )
+                .await
+                .map_err(|_| "SOCKS5 proxy authentication timed out".to_string())?
                 .map_err(|error| format!("SOCKS5 proxy authentication failed: {error}"))?
             };
             Ok(Box::new(stream))
@@ -1839,6 +1867,41 @@ async fn connect_ssh_transport(
     }
 }
 
+/// 校验代理主机名：拒绝控制字符（含 CRLF，防止 HTTP CONNECT 头注入；
+/// SOCKS5 虽是二进制协议，但控制字符 host 对任何代理都是非法输入），
+/// 拒绝超长 host（RFC 1035 限制 253 字符，留余量到 255）。
+fn validate_proxy_host(host: &str) -> Result<(), String> {
+    if host.len() > 255 {
+        return Err("Proxy host is too long (max 255 characters)".to_string());
+    }
+    if host.bytes().any(|b| b < 0x20 || b == 0x7f) {
+        return Err("Proxy host contains control characters".to_string());
+    }
+    Ok(())
+}
+
+/// 校验代理凭据：SOCKS5 用户名/密码认证（RFC 1929）限制各 255 字节；
+/// HTTP Basic Auth 无硬限制，但超长值既无意义又可能是注入尝试。
+/// 控制字符检查防止 HTTP CONNECT 头注入（build_http_connect_request
+/// 已检查 CRLF，这里作为纵深防御覆盖 SOCKS5 路径）。
+fn validate_proxy_credentials(username: &str, password: &str) -> Result<(), String> {
+    for (field, label) in [(username, "username"), (password, "password")] {
+        if field.len() > 255 {
+            return Err(format!(
+                "Proxy {} is too long (max 255 bytes, RFC 1929)",
+                label
+            ));
+        }
+        if field.bytes().any(|b| b < 0x20 || b == 0x7f) {
+            return Err(format!(
+                "Proxy {} contains control characters",
+                label
+            ));
+        }
+    }
+    Ok(())
+}
+
 async fn connect_http_proxy(
     proxy_host: &str,
     proxy_port: u16,
@@ -1847,14 +1910,20 @@ async fn connect_http_proxy(
     username: &str,
     password: &str,
 ) -> Result<TcpStream, String> {
-    let mut stream = TcpStream::connect((proxy_host, proxy_port))
+    let mut stream = timeout(PROXY_IO_TIMEOUT, TcpStream::connect((proxy_host, proxy_port)))
         .await
+        .map_err(|_| {
+            format!(
+                "HTTP proxy connect timed out after {} seconds",
+                PROXY_IO_TIMEOUT.as_secs()
+            )
+        })?
         .map_err(|error| format!("HTTP proxy connect failed: {error}"))?;
     let _ = stream.set_nodelay(true);
     let request = build_http_connect_request(host, port, username, password)?;
-    stream
-        .write_all(&request)
+    timeout(PROXY_IO_TIMEOUT, stream.write_all(&request))
         .await
+        .map_err(|_| "HTTP proxy CONNECT write timed out".to_string())?
         .map_err(|error| format!("HTTP proxy CONNECT write failed: {error}"))?;
 
     let mut response = Vec::with_capacity(1024);
@@ -1866,9 +1935,9 @@ async fn connect_http_proxy(
         if response.len() >= 32 * 1024 {
             return Err("HTTP proxy response headers are too large".to_string());
         }
-        let read = stream
-            .read(&mut chunk)
+        let read = timeout(PROXY_IO_TIMEOUT, stream.read(&mut chunk))
             .await
+            .map_err(|_| "HTTP proxy CONNECT read timed out".to_string())?
             .map_err(|error| format!("HTTP proxy CONNECT read failed: {error}"))?;
         if read == 0 {
             return Err("HTTP proxy closed before CONNECT completed".to_string());
@@ -1885,11 +1954,34 @@ async fn connect_http_proxy(
         .lines()
         .next()
         .unwrap_or("");
-    let status = status_line.split_whitespace().nth(1).unwrap_or("");
-    if status != "200" {
+    let status = parse_http_connect_status(status_line)?;
+    if status != 200 {
         return Err(format!("HTTP proxy CONNECT failed: {status_line}"));
     }
     Ok(stream)
+}
+
+/// 从 HTTP CONNECT 响应状态行提取并校验状态码。
+/// 状态行格式：`HTTP/1.1 200 Connection established`。校验 `HTTP/` 前缀
+/// 防止恶意代理返回非 HTTP 文本伪装成功；状态码必须是 3 位 ASCII 数字，
+/// 避免 `split_whitespace().nth(1)` 在异常格式下取到非状态码字段。
+fn parse_http_connect_status(status_line: &str) -> Result<u16, String> {
+    let mut parts = status_line.split_whitespace();
+    let version = parts.next().unwrap_or("");
+    if !version.starts_with("HTTP/") {
+        return Err(format!(
+            "HTTP proxy returned a malformed status line: {status_line}"
+        ));
+    }
+    let code = parts.next().unwrap_or("");
+    if code.len() != 3 || !code.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(format!(
+            "HTTP proxy returned a malformed status code: {status_line}"
+        ));
+    }
+    code.parse::<u16>().map_err(|_| {
+        format!("HTTP proxy returned an invalid status code: {status_line}")
+    })
 }
 
 fn build_http_connect_request(
@@ -2027,6 +2119,40 @@ async fn ensure_password_credentials(
     Ok(())
 }
 
+/// 构造兼容老服务器的算法偏好列表。
+///
+/// russh 0.62 的 `Preferred::DEFAULT` 注释明确"SHA-1 MAC variants are
+/// excluded from defaults"，KEX 也只列出 SHA-2 系（DH_G14_SHA256 等）。
+/// 这对 OpenSSH 4.x/5.x 时代的老服务器（只支持 hmac-sha1 / diffie-hellman
+/// -group14-sha1 / diffie-hellman-group1-sha1）会导致 `NoCommonAlgo` 握手
+/// 失败。
+///
+/// 这里把 SHA-1 类算法**追加到默认列表末尾**——SHA-2 仍然优先，只有当
+/// 服务器不支持 SHA-2 时才回退到 SHA-1。RSA-SHA1 host key 已在默认列表
+/// （`Algorithm::Rsa { hash: None }` 即 ssh-rsa），无需额外追加。
+fn build_legacy_preferred() -> russh::Preferred {
+    use std::borrow::Cow;
+
+    let mut kex_list: Vec<russh::kex::Name> = russh::Preferred::DEFAULT.kex.to_vec();
+    // SHA-1 KEX（按强度降序：group14 > group1 > gex-sha1）
+    kex_list.push(russh::kex::DH_G14_SHA1);
+    kex_list.push(russh::kex::DH_G1_SHA1);
+    kex_list.push(russh::kex::DH_GEX_SHA1);
+
+    let mut mac_list: Vec<russh::mac::Name> = russh::Preferred::DEFAULT.mac.to_vec();
+    // SHA-1 MAC（ETM 优先于非 ETM，与默认列表风格一致）
+    mac_list.push(russh::mac::HMAC_SHA1_ETM);
+    mac_list.push(russh::mac::HMAC_SHA1);
+
+    russh::Preferred {
+        kex: Cow::Owned(kex_list),
+        key: russh::Preferred::DEFAULT.key.clone(),
+        cipher: russh::Preferred::DEFAULT.cipher.clone(),
+        mac: Cow::Owned(mac_list),
+        compression: russh::Preferred::DEFAULT.compression.clone(),
+    }
+}
+
 async fn open_session(
     profile: &Value,
     app: &AppHandle,
@@ -2071,6 +2197,14 @@ async fn open_session(
         .and_then(|id| id.as_str())
         .unwrap_or("")
         .to_string();
+    // 兼容老服务器（OpenSSH 4.x/5.x 时代）：默认算法列表只允许 SHA-2 类
+    // MAC/KEX，对只支持 SHA-1 的服务器握手会因 NoCommonAlgo 被拒。开启
+    // legacyAlgorithms 后追加 SHA-1 类算法到列表末尾——SHA-2 仍然优先，
+    // 只有双方没交集时才回退到 SHA-1。
+    let legacy_algorithms = profile
+        .get("legacyAlgorithms")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
     let config = russh::client::Config {
         inactivity_timeout: Some(Duration::from_secs(300)),
         // Keepalive：NAT/firewall 会静默掐掉空闲 TCP 连接，用户下次操作时
@@ -2081,6 +2215,11 @@ async fn open_session(
         // 30s interval + electerm 的 keepaliveCountMax 设计。
         keepalive_interval: Some(Duration::from_secs(30)),
         keepalive_max: 3,
+        preferred: if legacy_algorithms {
+            build_legacy_preferred()
+        } else {
+            russh::Preferred::default()
+        },
         ..Default::default()
     };
     let config = Arc::new(config);
@@ -2097,6 +2236,22 @@ async fn open_session(
         .map(|s| s.to_string());
 
     if let Some(jpid) = jump_profile_id {
+        // Proxy + JumpHost 互斥校验：参考 OpenSSH ProxyJump 与 ProxyCommand
+        // 互斥的设计。如果 profile 同时配了 proxy 和 jumpProfileId，proxy
+        // 会被静默忽略——目标主机是通过跳板机的 direct-tcpip 通道到达的，
+        // 不经过 SOCKS5/HTTP 代理。用户以为走了代理其实没走，既是安全隐患
+        // （流量没走预期路径）也是 UX 问题（调试困难）。
+        let proxy_type = profile
+            .get("proxy")
+            .and_then(|p| p.get("type"))
+            .and_then(Value::as_str)
+            .unwrap_or("none");
+        if proxy_type != "none" {
+            return Err(
+                "Proxy and Jump Host are mutually exclusive: the target is reached via the jump host's direct-tcpip channel, the proxy setting is ignored. Please remove one of them.".to_string()
+            );
+        }
+
         crate::services::logging::session(app, "INFO", "ssh", tab_id, "resolving jump host");
         // Load the jump profile from disk (same directory as profiles.json)
         let jump_profile = load_jump_profile(app, &jpid)?;
@@ -2136,58 +2291,116 @@ async fn open_session(
             "jump host connected; opening target channel",
         );
 
-        let mut target_handle = connect_target_through_jump(
-            &jump_handle,
-            config.clone(),
-            new_client_handler(app, tab_id, &profile_id, &host, port, trusted.clone()),
-            &host,
-            port,
-        )
-        .await?;
-        match try_authenticate(
-            &mut target_handle,
-            &username,
-            &auth_type,
-            profile,
-            app,
-            tab_id,
-        )
-        .await?
-        {
-            AuthenticationResult::Authenticated => return Ok(target_handle),
-            AuthenticationResult::NeedsFreshKeyboardInteractive => {
-                // russh cannot switch from a rejected password/public-key
-                // exchange to keyboard-interactive on the same handle. Open a
-                // new channel through the already-authenticated jump host.
-                let mut retry_handle = connect_target_through_jump(
-                    &jump_handle,
-                    config,
-                    new_client_handler(app, tab_id, &profile_id, &host, port, trusted),
-                    &host,
-                    port,
-                )
-                .await?;
-                if try_keyboard_interactive(
-                    &mut retry_handle,
-                    &username,
-                    profile
-                        .get("password")
-                        .and_then(Value::as_str)
-                        .unwrap_or(""),
-                    app,
-                    tab_id,
-                    &profile_id,
-                    &host,
-                    port,
-                )
-                .await?
-                {
-                    return Ok(retry_handle);
+        // 将跳板机目标连接 + 认证封装在 async block 中，以便在失败路径上
+        // 显式发送 SSH_MSG_DISCONNECT 清理每个 session。参考 OpenSSH
+        // 在 ProxyJump 失败时对每跳发送 disconnect 的做法——仅靠 Drop 不会
+        // 发送 disconnect 消息，服务端可能残留半开 session 直到 TCP 超时。
+        // target / retry handle 也需要显式 disconnect，否则目标机的
+        // MaxStartups 统计可能虚高，极端情况下导致后续连接被拒绝。
+        let target_result: Result<Handle<ClientHandler>, String> = async {
+            let mut target_handle = connect_target_through_jump(
+                &jump_handle,
+                config.clone(),
+                new_client_handler(app, tab_id, &profile_id, &host, port, trusted.clone()),
+                &host,
+                port,
+            )
+            .await?;
+            match try_authenticate(
+                &mut target_handle,
+                &username,
+                &auth_type,
+                profile,
+                app,
+                tab_id,
+            )
+            .await?
+            {
+                AuthenticationResult::Authenticated => Ok(target_handle),
+                AuthenticationResult::NeedsFreshKeyboardInteractive => {
+                    // russh cannot switch from a rejected password/public-key
+                    // exchange to keyboard-interactive on the same handle.
+                    // Disconnect the old handle, then open a new channel
+                    // through the already-authenticated jump host.
+                    let _ = timeout(
+                        Duration::from_secs(3),
+                        target_handle.disconnect(
+                            Disconnect::ByApplication,
+                            "switching to keyboard-interactive",
+                            "en",
+                        ),
+                    )
+                    .await;
+                    let mut retry_handle = connect_target_through_jump(
+                        &jump_handle,
+                        config,
+                        new_client_handler(app, tab_id, &profile_id, &host, port, trusted),
+                        &host,
+                        port,
+                    )
+                    .await?;
+                    if try_keyboard_interactive(
+                        &mut retry_handle,
+                        &username,
+                        profile
+                            .get("password")
+                            .and_then(Value::as_str)
+                            .unwrap_or(""),
+                        app,
+                        tab_id,
+                        &profile_id,
+                        &host,
+                        port,
+                    )
+                    .await?
+                    {
+                        Ok(retry_handle)
+                    } else {
+                        let _ = timeout(
+                            Duration::from_secs(3),
+                            retry_handle.disconnect(
+                                Disconnect::ByApplication,
+                                "keyboard-interactive authentication failed",
+                                "en",
+                            ),
+                        )
+                        .await;
+                        Err("SSH Authentication failed (via jump host)".to_string())
+                    }
+                }
+                AuthenticationResult::Rejected => {
+                    let _ = timeout(
+                        Duration::from_secs(3),
+                        target_handle.disconnect(
+                            Disconnect::ByApplication,
+                            "authentication rejected",
+                            "en",
+                        ),
+                    )
+                    .await;
+                    Err("SSH Authentication failed (via jump host)".to_string())
                 }
             }
-            AuthenticationResult::Rejected => {}
         }
-        return Err("SSH Authentication failed (via jump host)".to_string());
+        .await;
+
+        match target_result {
+            Ok(handle) => return Ok(handle),
+            Err(error) => {
+                // 显式断开跳板机 session，3s 超时防止 disconnect 本身卡住
+                // （网络已中断时 russh 可能无法发送 disconnect 消息）。
+                let _ = timeout(
+                    Duration::from_secs(3),
+                    jump_handle.disconnect(
+                        Disconnect::ByApplication,
+                        "target authentication failed",
+                        "en",
+                    ),
+                )
+                .await;
+                return Err(error);
+            }
+        }
     }
 
     let stream = wait_for_ssh_stage(
@@ -2212,6 +2425,15 @@ async fn open_session(
             // See the equivalent jump-host path above: reconnect before
             // keyboard-interactive fallback so russh never stalls on a
             // rejected authentication handle.
+            let _ = timeout(
+                Duration::from_secs(3),
+                handle.disconnect(
+                    Disconnect::ByApplication,
+                    "switching to keyboard-interactive",
+                    "en",
+                ),
+            )
+            .await;
             let stream = wait_for_ssh_stage(
                 "SSH transport reconnection",
                 SSH_TRANSPORT_TIMEOUT,
@@ -2248,10 +2470,30 @@ async fn open_session(
             {
                 Ok(retry_handle)
             } else {
+                let _ = timeout(
+                    Duration::from_secs(3),
+                    retry_handle.disconnect(
+                        Disconnect::ByApplication,
+                        "keyboard-interactive authentication failed",
+                        "en",
+                    ),
+                )
+                .await;
                 Err("SSH Authentication failed".to_string())
             }
         }
-        AuthenticationResult::Rejected => Err("SSH Authentication failed".to_string()),
+        AuthenticationResult::Rejected => {
+            let _ = timeout(
+                Duration::from_secs(3),
+                handle.disconnect(
+                    Disconnect::ByApplication,
+                    "authentication rejected",
+                    "en",
+                ),
+            )
+            .await;
+            Err("SSH Authentication failed".to_string())
+        }
     }
 }
 
@@ -6230,16 +6472,16 @@ fn format_perm(perm: u32, is_dir: bool, is_link: bool) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_http_connect_request, capture_sudo_password_input, coalesce_terminal_input,
-        contains_interrupt_byte, default_ssh_key_paths, enqueue_tunnel_command,
-        format_sftp_unavailable_reason, is_password_prompt, looks_like_mfa_prompt,
-        looks_like_root_prompt, looks_like_shell_prompt, missing_password_credential,
-        parent_remote_item, parent_remote_path, remote_bind_host_matches,
-        resolve_shell_file_access, resource_monitoring_enabled, suppress_shell_setup_echo,
-        track_cwd_and_user, track_sudo_prompt_from_terminal, trim_string_front,
-        try_keyboard_interactive_with_responder, tunnel_bind_address, validate_tunnel_rule,
-        wait_for_ssh_stage, KeyboardInteractiveRequest, ShellSetupEchoSuppression, SshTunnelRule,
-        TunnelCommand, SHELL_SETUP_SETTLE_DELAY,
+        build_http_connect_request, build_legacy_preferred, capture_sudo_password_input,
+        coalesce_terminal_input, contains_interrupt_byte, default_ssh_key_paths,
+        enqueue_tunnel_command, format_sftp_unavailable_reason, is_password_prompt,
+        looks_like_mfa_prompt, looks_like_root_prompt, looks_like_shell_prompt,
+        missing_password_credential, parent_remote_item, parent_remote_path,
+        remote_bind_host_matches, resolve_shell_file_access, resource_monitoring_enabled,
+        suppress_shell_setup_echo, track_cwd_and_user, track_sudo_prompt_from_terminal,
+        trim_string_front, try_keyboard_interactive_with_responder, tunnel_bind_address,
+        validate_tunnel_rule, wait_for_ssh_stage, KeyboardInteractiveRequest,
+        ShellSetupEchoSuppression, SshTunnelRule, TunnelCommand, SHELL_SETUP_SETTLE_DELAY,
     };
     #[cfg(unix)]
     use super::{forward_local_connection, forward_socks5_connection};
@@ -7161,5 +7403,50 @@ mod tests {
         assert!(!remote_bind_host_matches("127.0.0.1", "10.0.0.4"));
         assert!(remote_bind_host_matches("0.0.0.0", "10.0.0.4"));
         assert!(remote_bind_host_matches("::", "2001:db8::4"));
+    }
+
+    #[test]
+    fn legacy_preferred_appends_sha1_algorithms_after_sha2() {
+        use russh::{kex, mac};
+
+        let preferred = build_legacy_preferred();
+
+        // SHA-2 类 MAC 应在 SHA-1 之前（保持 SHA-2 优先）
+        let sha256_pos = preferred
+            .mac
+            .iter()
+            .position(|m| *m == mac::HMAC_SHA256)
+            .expect("SHA-256 MAC must remain in legacy list");
+        let sha1_etm_pos = preferred
+            .mac
+            .iter()
+            .position(|m| *m == mac::HMAC_SHA1_ETM)
+            .expect("SHA-1 ETM MAC must be appended for legacy servers");
+        let sha1_pos = preferred
+            .mac
+            .iter()
+            .position(|m| *m == mac::HMAC_SHA1)
+            .expect("SHA-1 MAC must be appended for legacy servers");
+        assert!(sha256_pos < sha1_etm_pos);
+        assert!(sha1_etm_pos < sha1_pos);
+
+        // SHA-2 类 KEX（DH_G14_SHA256）应在 SHA-1 类（DH_G14_SHA1）之前
+        let sha256_kex_pos = preferred
+            .kex
+            .iter()
+            .position(|k| *k == kex::DH_G14_SHA256)
+            .expect("SHA-256 KEX must remain in legacy list");
+        let sha1_kex_pos = preferred
+            .kex
+            .iter()
+            .position(|k| *k == kex::DH_G14_SHA1)
+            .expect("SHA-1 KEX must be appended for legacy servers");
+        let g1_pos = preferred
+            .kex
+            .iter()
+            .position(|k| *k == kex::DH_G1_SHA1)
+            .expect("DH-G1-SHA1 must be appended for very old servers");
+        assert!(sha256_kex_pos < sha1_kex_pos);
+        assert!(sha1_kex_pos < g1_pos);
     }
 }

--- a/apps/tauri/src-tauri/src/sessions/ssh.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh.rs
@@ -1893,10 +1893,7 @@ fn validate_proxy_credentials(username: &str, password: &str) -> Result<(), Stri
             ));
         }
         if field.bytes().any(|b| b < 0x20 || b == 0x7f) {
-            return Err(format!(
-                "Proxy {} contains control characters",
-                label
-            ));
+            return Err(format!("Proxy {} contains control characters", label));
         }
     }
     Ok(())
@@ -1910,15 +1907,18 @@ async fn connect_http_proxy(
     username: &str,
     password: &str,
 ) -> Result<TcpStream, String> {
-    let mut stream = timeout(PROXY_IO_TIMEOUT, TcpStream::connect((proxy_host, proxy_port)))
-        .await
-        .map_err(|_| {
-            format!(
-                "HTTP proxy connect timed out after {} seconds",
-                PROXY_IO_TIMEOUT.as_secs()
-            )
-        })?
-        .map_err(|error| format!("HTTP proxy connect failed: {error}"))?;
+    let mut stream = timeout(
+        PROXY_IO_TIMEOUT,
+        TcpStream::connect((proxy_host, proxy_port)),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "HTTP proxy connect timed out after {} seconds",
+            PROXY_IO_TIMEOUT.as_secs()
+        )
+    })?
+    .map_err(|error| format!("HTTP proxy connect failed: {error}"))?;
     let _ = stream.set_nodelay(true);
     let request = build_http_connect_request(host, port, username, password)?;
     timeout(PROXY_IO_TIMEOUT, stream.write_all(&request))
@@ -1979,9 +1979,8 @@ fn parse_http_connect_status(status_line: &str) -> Result<u16, String> {
             "HTTP proxy returned a malformed status code: {status_line}"
         ));
     }
-    code.parse::<u16>().map_err(|_| {
-        format!("HTTP proxy returned an invalid status code: {status_line}")
-    })
+    code.parse::<u16>()
+        .map_err(|_| format!("HTTP proxy returned an invalid status code: {status_line}"))
 }
 
 fn build_http_connect_request(
@@ -2485,11 +2484,7 @@ async fn open_session(
         AuthenticationResult::Rejected => {
             let _ = timeout(
                 Duration::from_secs(3),
-                handle.disconnect(
-                    Disconnect::ByApplication,
-                    "authentication rejected",
-                    "en",
-                ),
+                handle.disconnect(Disconnect::ByApplication, "authentication rejected", "en"),
             )
             .await;
             Err("SSH Authentication failed".to_string())

--- a/apps/tauri/src-tauri/src/sessions/system_metrics.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics.rs
@@ -1606,7 +1606,10 @@ mod tests {
         assert_eq!(metrics["diskRows"].as_array().map(Vec::len), Some(2));
         assert_eq!(metrics["topProcesses"].as_array().map(Vec::len), Some(2));
         // 按到达顺序，第一行是 systemd
-        assert_eq!(metrics["topProcesses"][0]["command"], "/usr/lib/systemd/systemd");
+        assert_eq!(
+            metrics["topProcesses"][0]["command"],
+            "/usr/lib/systemd/systemd"
+        );
         assert_eq!(metrics["topProcesses"][0]["pid"], 1);
         assert_eq!(metrics["topProcesses"][0]["user"], "root");
         assert_eq!(metrics["topProcesses"][0]["cpu"], "0.1");

--- a/apps/tauri/src-tauri/src/sessions/system_metrics.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics.rs
@@ -3,8 +3,6 @@
 // `probe_remote_platform` and `exec_command[_with_stdin]` are async and
 // operate on a `russh::client::Handle`. All parsing/formatting helpers
 // below are pure functions and unchanged from the ssh2 era.
-
-use std::collections::HashMap;
 use std::io::Write;
 use std::time::Duration;
 
@@ -573,49 +571,46 @@ pub fn parse_system_metrics(raw: &str, fallback_platform: &str) -> serde_json::V
         }
     }
 
-    // Top processes
+    // Top processes: shell 端已用 `ps --sort=-pcpu` 按 pcpu 降序取 top 40，
+    // 这里按到达顺序逐行解析，不做 comm 分组。每行一个 PID，保留 pid/user
+    // 字段供排查使用，command 用 args（完整命令行）而非 comm。
+    // 格式：pid|user|rss(M)|pcpu|pmem|args（args 内部空格保留）
     let transient_collector_commands: std::collections::HashSet<&str> =
         ["ps", "awk", "bash", "sleep", "sh", "powershell", "pwsh"]
             .iter()
             .cloned()
             .collect();
-    let mut grouped_processes: HashMap<String, (f64, f64, f64)> = HashMap::new();
+    let mut top_processes: Vec<serde_json::Value> = Vec::new();
     for line in read_block("__PROCS_START__", "__PROCS_END__") {
-        let parts: Vec<&str> = line.split('|').collect();
-        if parts.len() >= 4 {
-            let memory_str = parts[0].to_lowercase();
-            let memory_mb: f64 = memory_str.replace('m', "").parse().unwrap_or(0.0);
-            let cpu_val: f64 = parts[1].parse().unwrap_or(0.0);
-            let elapsed: f64 = parts[2].parse().unwrap_or(0.0);
-            let command = parts[3].to_string();
-
-            if !transient_collector_commands.contains(command.as_str()) {
-                let entry = grouped_processes.entry(command).or_insert((0.0, 0.0, 0.0));
-                entry.0 += memory_mb;
-                entry.1 += cpu_val;
-                entry.2 = entry.2.max(elapsed);
-            }
+        // splitn(6) 保留 args 内部所有字符（含 |），避免误切
+        let parts: Vec<&str> = line.splitn(6, '|').collect();
+        if parts.len() < 6 {
+            continue;
         }
+        let pid: u32 = parts[0].parse().unwrap_or(0);
+        let user = parts[1].to_string();
+        let memory_str = parts[2].to_lowercase();
+        let memory_mb: f64 = memory_str.replace('m', "").parse().unwrap_or(0.0);
+        let cpu_val: f64 = parts[3].parse().unwrap_or(0.0);
+        let _mem_percent: f64 = parts[4].parse().unwrap_or(0.0);
+        let command = parts[5].to_string();
+
+        // 过滤采集器自身（ps/awk/sh 等），按 args 首字段匹配
+        let comm = command.split_whitespace().next().unwrap_or("");
+        let comm_basename = comm.rsplit('/').next().unwrap_or(comm);
+        if transient_collector_commands.contains(comm_basename) {
+            continue;
+        }
+
+        top_processes.push(serde_json::json!({
+            "pid": pid,
+            "user": user,
+            "memory": format_process_megabytes(memory_mb),
+            "cpu": format!("{:.1}", cpu_val),
+            "command": command,
+            "elapsedSeconds": 0_i64,
+        }));
     }
-    // Sort numeric values before formatting them. The old implementation
-    // formatted all values, then compiled a Regex for every comparison while
-    // sorting. On hosts with large process tables that consumed multiple CPU
-    // cores continuously and starved Tauri's window/event loop.
-    let mut grouped_processes: Vec<(String, (f64, f64, f64))> =
-        grouped_processes.into_iter().collect();
-    grouped_processes.sort_by(|a, b| b.1 .0.total_cmp(&a.1 .0));
-    let top_processes: Vec<serde_json::Value> = grouped_processes
-        .into_iter()
-        .take(128)
-        .map(|(command, (memory_mb, cpu, elapsed))| {
-            serde_json::json!({
-                "memory": format_process_megabytes(memory_mb),
-                "cpu": format!("{:.1}", cpu),
-                "command": command,
-                "elapsedSeconds": elapsed as i64,
-            })
-        })
-        .collect();
 
     let mem_used_bytes_num = mem_used_bytes
         .parse::<f64>()
@@ -1157,12 +1152,24 @@ else
 fi
 disk=$(printf "%s\n" "$df_output" | awk 'NR>1 {{printf "%s|%sK/%sK\n", $6, $4, $2}}' | head -n 12)
 filesystems=$(printf "%s\n" "$df_output" | awk 'NR>1 {{printf "%s|%sK|%sK|%s|%sK|%s\n", $1, $2, $3, $5, $4, $6}}' | head -n 20)
+# 进程采集：参考 meatshell 的做法，让 ps 直接按 pcpu 降序排序后取 top 40，
+# Rust 端按到达顺序逐行解析，不做 comm 分组。这样：
+# 1. 高 CPU 进程排在最前面，shell 端排序比 Rust 端再排更省资源；
+# 2. 每个 PID 一行，能看到同名进程的不同实例（如 nginx 多个 worker）；
+# 3. 用 args 而不是 comm，命令列信息量更大，能区分同名进程的不同启动参数。
+# 输出格式：pid|user|rss(M)|pcpu|pmem|args（args 内部空格保留，cut 截断到 200 字符）
 if has_bounded_runner; then
-  procs=$(run_bounded 1 ps -eo rss=,pcpu=,etimes=,comm= 2>/dev/null | head -n 128 | awk 'NF >= 4 {{printf "%.1fM|%s|%s|%s\n", $1/1024, $2, $3, $4}}')
-  [ -z "$procs" ] && procs=$(run_bounded 1 ps 2>/dev/null | head -n 128 | awk 'NR>1 && NF >= 5 {{proc_name=$5; sub(/^.*\//, "", proc_name); printf "%.1fM|0|0|%s\n", $3/1024, proc_name}}')
+  procs=$(run_bounded 1 ps -eo pid=,user=,rss=,pcpu=,pmem=,args= --sort=-pcpu 2>/dev/null | head -n 40 | awk 'NF >= 6 {{rss=$3/1024; args=$6; for(i=7;i<=NF;i++) args=args" "$i; printf "%s|%s|%.1fM|%s|%s|%s\n", $1, $2, rss, $4, $5, substr(args,1,200)}}')
 else
-  procs=$(ps -eo rss=,pcpu=,etimes=,comm= 2>/dev/null | head -n 128 | awk 'NF >= 4 {{printf "%.1fM|%s|%s|%s\n", $1/1024, $2, $3, $4}}')
-  [ -z "$procs" ] && procs=$(ps 2>/dev/null | head -n 128 | awk 'NR>1 && NF >= 5 {{proc_name=$5; sub(/^.*\//, "", proc_name); printf "%.1fM|0|0|%s\n", $3/1024, proc_name}}')
+  procs=$(ps -eo pid=,user=,rss=,pcpu=,pmem=,args= --sort=-pcpu 2>/dev/null | head -n 40 | awk 'NF >= 6 {{rss=$3/1024; args=$6; for(i=7;i<=NF;i++) args=args" "$i; printf "%s|%s|%.1fM|%s|%s|%s\n", $1, $2, rss, $4, $5, substr(args,1,200)}}')
+fi
+if [ -z "$procs" ]; then
+  # fallback：极简 ps（如某些 BusyBox 不支持 --sort 或 -o args=）
+  if has_bounded_runner; then
+    procs=$(run_bounded 1 ps 2>/dev/null | head -n 40 | awk 'NR>1 && NF >= 5 {{printf "0|-|%.1fM|0|0|%s\n", $3/1024, $5}}')
+  else
+    procs=$(ps 2>/dev/null | head -n 40 | awk 'NR>1 && NF >= 5 {{printf "0|-|%.1fM|0|0|%s\n", $3/1024, $5}}')
+  fi
 fi
 echo "__PLATFORM__{}"
 echo "__OS__$os_name"
@@ -1562,7 +1569,8 @@ mod tests {
         let command = build_posix_metrics_command("linux");
 
         assert!(command.contains(r#"printf "%s|%sK/%sK\n"#));
-        assert!(command.contains(r#"printf "%.1fM|%s|%s|%s\n"#));
+        // 进程输出格式：pid|user|rss(M)|pcpu|pmem|args
+        assert!(command.contains(r#"printf "%s|%s|%.1fM|%s|%s|%s\n"#));
         assert!(command.contains("getconf _NPROCESSORS_ONLN"));
         assert!(command.contains("for (row_index = 1; row_index <= model_count; row_index++)"));
         assert!(!command.contains("for (index = 1; index <= model_count; index++)"));
@@ -1571,15 +1579,50 @@ mod tests {
     }
 
     #[test]
+    fn posix_metrics_command_sorts_processes_by_pcpu_at_shell_level() {
+        // 参考 meatshell：让 ps 直接 --sort=-pcpu 降序输出 top 40，Rust 端
+        // 不再分组或排序。验证 shell 命令包含关键片段。
+        let command = build_posix_metrics_command("linux");
+
+        // ps 直接按 pcpu 降序取 top 40
+        assert!(command.contains("ps -eo pid=,user=,rss=,pcpu=,pmem=,args= --sort=-pcpu"));
+        assert!(command.contains("head -n 40"));
+        // 输出格式：pid|user|rss(M)|pcpu|pmem|args
+        assert!(command.contains(r#"printf "%s|%s|%.1fM|%s|%s|%s\n""#));
+        // 不应再有进程相关的 sort 命令（cpuinfo/disk 去重可能仍用 awk）
+        assert!(!command.contains("sort -t'|' -k2,2rn"));
+        assert!(!command.contains("sort -t'|' -k1,1rn"));
+    }
+
+    #[test]
     fn parser_keeps_disk_and_process_rows_separate() {
+        // 新格式：pid|user|rss(M)|pcpu|pmem|args
+        // Rust 端不排序，按 shell 端 --sort=-pcpu 的到达顺序保留
         let metrics = parse_system_metrics(
-            "__PLATFORM__linux\n__CPU__10\n__MEM__1|2|50|0|0|0\n__MEM_BYTES__1048576|2097152|1048576|50|0|0|0\n__SWAP__0|0|0\n__SWAP_BYTES__0|0|0|0\n__CPU_USAGE__1|2|0|97|0|0|0|0\n__DISK_START__\n/|10K/20K\n/dev|30K/40K\n__DISK_END__\n__PROCS_START__\n1.0M|0.1|4|systemd\n2.0M|0.2|5|sshd\n__PROCS_END__\n",
+            "__PLATFORM__linux\n__CPU__10\n__MEM__1|2|50|0|0|0\n__MEM_BYTES__1048576|2097152|1048576|50|0|0|0\n__SWAP__0|0|0\n__SWAP_BYTES__0|0|0|0\n__CPU_USAGE__1|2|0|97|0|0|0|0\n__DISK_START__\n/|10K/20K\n/dev|30K/40K\n__DISK_END__\n__PROCS_START__\n1|root|1.0M|0.1|0.5|/usr/lib/systemd/systemd\n2|root|2.0M|0.2|1.0|/usr/sbin/sshd -D\n__PROCS_END__\n",
             "linux",
         );
 
         assert_eq!(metrics["diskRows"].as_array().map(Vec::len), Some(2));
         assert_eq!(metrics["topProcesses"].as_array().map(Vec::len), Some(2));
-        assert_eq!(metrics["topProcesses"][0]["command"], "sshd");
+        // 按到达顺序，第一行是 systemd
+        assert_eq!(metrics["topProcesses"][0]["command"], "/usr/lib/systemd/systemd");
+        assert_eq!(metrics["topProcesses"][0]["pid"], 1);
+        assert_eq!(metrics["topProcesses"][0]["user"], "root");
+        assert_eq!(metrics["topProcesses"][0]["cpu"], "0.1");
+    }
+
+    #[test]
+    fn parser_filters_transient_collector_processes() {
+        // ps/awk/bash 等采集器自身进程应被过滤，不显示给用户
+        let metrics = parse_system_metrics(
+            "__PLATFORM__linux\n__CPU__10\n__MEM__1|2|50|0|0|0\n__MEM_BYTES__1048576|2097152|1048576|50|0|0|0\n__SWAP__0|0|0\n__SWAP_BYTES__0|0|0|0\n__CPU_USAGE__1|2|0|97|0|0|0|0\n__PROCS_START__\n100|root|1.0M|0.1|0.5|/usr/bin/sleep 1\n101|root|2.0M|0.2|1.0|/usr/sbin/nginx -g 'daemon off;'\n102|root|1.5M|0.3|0.8|ps -eo pid=,user=,rss=,pcpu=,pmem=,args= --sort=-pcpu\n__PROCS_END__\n",
+            "linux",
+        );
+
+        let procs = metrics["topProcesses"].as_array().unwrap();
+        assert_eq!(procs.len(), 1);
+        assert_eq!(procs[0]["command"], "/usr/sbin/nginx -g 'daemon off;'");
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/sessions/telnet.rs
+++ b/apps/tauri/src-tauri/src/sessions/telnet.rs
@@ -4,6 +4,7 @@ use tauri::AppHandle;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
 use tokio_socks::tcp::Socks5Stream;
 
 use super::telnet_direct::connect_direct_telnet;
@@ -20,6 +21,15 @@ const SB: u8 = 250;
 const SE: u8 = 240;
 const TERMINAL_TYPE: u8 = 24;
 const NAWS: u8 = 31;
+/// Telnet 传输层连接（直连或经代理）整体超时。Telnet 服务器或代理无响应时，
+/// `TcpStream::connect` 和 SOCKS5/HTTP CONNECT 握手都会永久 await，导致
+/// 标签页卡在 connecting 状态无法重试。30s 与 SSH 侧 SSH_TRANSPORT_TIMEOUT 对齐。
+const TELNET_TRANSPORT_TIMEOUT: Duration = Duration::from_secs(30);
+/// HTTP/SOCKS5 代理单步 IO 超时。代理服务器或中间网络卡住时，TCP 连接、
+/// CONNECT 请求写入、响应逐字节读取都不能让外层 30s 超时全部消耗在
+/// 单次 read 上——慢速代理可以每 29s 发一个字节拖满整个阶段。8s 覆盖
+/// 正常代理 RTT，超时后立即给出明确错误。
+const PROXY_IO_TIMEOUT: Duration = Duration::from_secs(8);
 
 trait TelnetTransport: AsyncRead + AsyncWrite + Unpin + Send {}
 impl<T: AsyncRead + AsyncWrite + Unpin + Send> TelnetTransport for T {}
@@ -250,8 +260,16 @@ async fn connect_transport(
         .and_then(Value::as_str)
         .unwrap_or("none");
     if proxy_type == "none" {
-        return connect_direct_telnet(host, port)
+        // 直连路径整体超时：Telnet 服务器无响应时 TcpStream::connect 会永久
+        // await，标签页卡在 connecting 状态无法重试。
+        return timeout(TELNET_TRANSPORT_TIMEOUT, connect_direct_telnet(host, port))
             .await
+            .map_err(|_| {
+                format!(
+                    "Telnet connect timed out after {} seconds",
+                    TELNET_TRANSPORT_TIMEOUT.as_secs()
+                )
+            })?
             .map(|stream| Box::new(stream) as Box<dyn TelnetTransport>);
     }
     let proxy_host = proxy
@@ -259,6 +277,7 @@ async fn connect_transport(
         .and_then(Value::as_str)
         .filter(|value| !value.trim().is_empty())
         .ok_or_else(|| "Telnet proxy host is required".to_string())?;
+    validate_proxy_host(proxy_host)?;
     let proxy_port = proxy
         .and_then(|proxy| proxy.get("port"))
         .and_then(Value::as_u64)
@@ -272,27 +291,73 @@ async fn connect_transport(
         .and_then(|proxy| proxy.get("password"))
         .and_then(Value::as_str)
         .unwrap_or("");
+    validate_proxy_credentials(username, password)?;
+
     match proxy_type {
         "socks5" if username.is_empty() => {
-            Socks5Stream::connect((proxy_host, proxy_port), (host, port))
-                .await
-                .map(|stream| Box::new(stream) as Box<dyn TelnetTransport>)
-                .map_err(|error| format!("Telnet SOCKS5 proxy connect failed: {error}"))
+            let stream = timeout(
+                PROXY_IO_TIMEOUT,
+                Socks5Stream::connect((proxy_host, proxy_port), (host, port)),
+            )
+            .await
+            .map_err(|_| "Telnet SOCKS5 proxy connect timed out".to_string())?
+            .map_err(|error| format!("Telnet SOCKS5 proxy connect failed: {error}"))?;
+            Ok(Box::new(stream) as Box<dyn TelnetTransport>)
         }
-        "socks5" => Socks5Stream::connect_with_password(
-            (proxy_host, proxy_port),
-            (host, port),
-            username,
-            password,
-        )
-        .await
-        .map(|stream| Box::new(stream) as Box<dyn TelnetTransport>)
-        .map_err(|error| format!("Telnet SOCKS5 proxy authentication failed: {error}")),
+        "socks5" => {
+            let stream = timeout(
+                PROXY_IO_TIMEOUT,
+                Socks5Stream::connect_with_password(
+                    (proxy_host, proxy_port),
+                    (host, port),
+                    username,
+                    password,
+                ),
+            )
+            .await
+            .map_err(|_| "Telnet SOCKS5 proxy authentication timed out".to_string())?
+            .map_err(|error| format!("Telnet SOCKS5 proxy authentication failed: {error}"))?;
+            Ok(Box::new(stream) as Box<dyn TelnetTransport>)
+        }
         "http" => connect_http_proxy(proxy_host, proxy_port, host, port, username, password)
             .await
             .map(|stream| Box::new(stream) as Box<dyn TelnetTransport>),
         other => Err(format!("Unsupported Telnet proxy type: {other}")),
     }
+}
+
+/// 校验代理主机名：拒绝控制字符（含 CRLF，防止 HTTP CONNECT 头注入；
+/// SOCKS5 虽是二进制协议，但控制字符 host 对任何代理都是非法输入），
+/// 拒绝超长 host（RFC 1035 限制 253 字符，留余量到 255）。
+fn validate_proxy_host(host: &str) -> Result<(), String> {
+    if host.len() > 255 {
+        return Err("Telnet proxy host is too long (max 255 characters)".to_string());
+    }
+    if host.bytes().any(|b| b < 0x20 || b == 0x7f) {
+        return Err("Telnet proxy host contains control characters".to_string());
+    }
+    Ok(())
+}
+
+/// 校验代理凭据：SOCKS5 用户名/密码认证（RFC 1929）限制各 255 字节；
+/// 控制字符检查防止 HTTP CONNECT 头注入（connect_http_proxy 已检查
+/// CRLF，这里作为纵深防御覆盖 SOCKS5 路径）。
+fn validate_proxy_credentials(username: &str, password: &str) -> Result<(), String> {
+    for (field, label) in [(username, "username"), (password, "password")] {
+        if field.len() > 255 {
+            return Err(format!(
+                "Telnet proxy {} is too long (max 255 bytes, RFC 1929)",
+                label
+            ));
+        }
+        if field.bytes().any(|b| b < 0x20 || b == 0x7f) {
+            return Err(format!(
+                "Telnet proxy {} contains control characters",
+                label
+            ));
+        }
+    }
+    Ok(())
 }
 
 async fn connect_http_proxy(
@@ -309,9 +374,16 @@ async fn connect_http_proxy(
     {
         return Err("Telnet proxy values must not contain line breaks".to_string());
     }
-    let mut stream = TcpStream::connect((proxy_host, proxy_port))
+    let mut stream = timeout(PROXY_IO_TIMEOUT, TcpStream::connect((proxy_host, proxy_port)))
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|_| {
+            format!(
+                "Telnet HTTP proxy connect timed out after {} seconds",
+                PROXY_IO_TIMEOUT.as_secs()
+            )
+        })?
+        .map_err(|error| format!("Telnet HTTP proxy connect failed: {error}"))?;
+    let _ = stream.set_nodelay(true);
     let authority = if host.contains(':') && !host.starts_with('[') {
         format!("[{host}]:{port}")
     } else {
@@ -326,10 +398,10 @@ async fn connect_http_proxy(
         request.push_str(&format!("Proxy-Authorization: Basic {encoded}\r\n"));
     }
     request.push_str("\r\n");
-    stream
-        .write_all(request.as_bytes())
+    timeout(PROXY_IO_TIMEOUT, stream.write_all(request.as_bytes()))
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|_| "Telnet HTTP proxy CONNECT write timed out".to_string())?
+        .map_err(|error| format!("Telnet HTTP proxy CONNECT write failed: {error}"))?;
     let mut response = Vec::new();
     // Read one byte at a time until the HTTP header boundary. Reading a larger
     // chunk could consume the first Telnet bytes sent immediately after a
@@ -340,25 +412,47 @@ async fn connect_http_proxy(
         if response.len() >= 32 * 1024 {
             return Err("Telnet proxy response headers are too large".to_string());
         }
-        let count = stream
-            .read(&mut chunk)
+        let count = timeout(PROXY_IO_TIMEOUT, stream.read(&mut chunk))
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|_| "Telnet HTTP proxy CONNECT read timed out".to_string())?
+            .map_err(|error| format!("Telnet HTTP proxy CONNECT read failed: {error}"))?;
         if count == 0 {
             return Err("Telnet proxy closed before CONNECT completed".to_string());
         }
         response.extend_from_slice(&chunk[..count]);
     }
-    let status = std::str::from_utf8(&response)
+    let status_line = std::str::from_utf8(&response)
         .map_err(|_| "Telnet proxy returned a non-text response".to_string())?
         .lines()
         .next()
-        .and_then(|line| line.split_whitespace().nth(1))
         .unwrap_or("");
-    if status != "200" {
-        return Err(format!("Telnet HTTP CONNECT failed: {status}"));
+    let status = parse_http_connect_status(status_line)?;
+    if status != 200 {
+        return Err(format!("Telnet HTTP CONNECT failed: {status_line}"));
     }
     Ok(stream)
+}
+
+/// 从 HTTP CONNECT 响应状态行提取并校验状态码。
+/// 状态行格式：`HTTP/1.1 200 Connection established`。校验 `HTTP/` 前缀
+/// 防止恶意代理返回非 HTTP 文本伪装成功；状态码必须是 3 位 ASCII 数字，
+/// 避免 `split_whitespace().nth(1)` 在异常格式下取到非状态码字段。
+fn parse_http_connect_status(status_line: &str) -> Result<u16, String> {
+    let mut parts = status_line.split_whitespace();
+    let version = parts.next().unwrap_or("");
+    if !version.starts_with("HTTP/") {
+        return Err(format!(
+            "Telnet proxy returned a malformed status line: {status_line}"
+        ));
+    }
+    let code = parts.next().unwrap_or("");
+    if code.len() != 3 || !code.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(format!(
+            "Telnet proxy returned a malformed status code: {status_line}"
+        ));
+    }
+    code.parse::<u16>()
+        .map_err(|_| format!("Telnet proxy returned an invalid status code: {status_line}"))
 }
 
 pub(crate) fn reject_unsupported(command: WorkerCmd, message: &str) {

--- a/apps/tauri/src-tauri/src/sessions/telnet.rs
+++ b/apps/tauri/src-tauri/src/sessions/telnet.rs
@@ -374,15 +374,18 @@ async fn connect_http_proxy(
     {
         return Err("Telnet proxy values must not contain line breaks".to_string());
     }
-    let mut stream = timeout(PROXY_IO_TIMEOUT, TcpStream::connect((proxy_host, proxy_port)))
-        .await
-        .map_err(|_| {
-            format!(
-                "Telnet HTTP proxy connect timed out after {} seconds",
-                PROXY_IO_TIMEOUT.as_secs()
-            )
-        })?
-        .map_err(|error| format!("Telnet HTTP proxy connect failed: {error}"))?;
+    let mut stream = timeout(
+        PROXY_IO_TIMEOUT,
+        TcpStream::connect((proxy_host, proxy_port)),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "Telnet HTTP proxy connect timed out after {} seconds",
+            PROXY_IO_TIMEOUT.as_secs()
+        )
+    })?
+    .map_err(|error| format!("Telnet HTTP proxy connect failed: {error}"))?;
     let _ = stream.set_nodelay(true);
     let authority = if host.contains(':') && !host.starts_with('[') {
         format!("[{host}]:{port}")

--- a/apps/tauri/src/bridge/tauri-api.ts
+++ b/apps/tauri/src/bridge/tauri-api.ts
@@ -411,6 +411,14 @@ export async function createTauriApi(): Promise<FileTermDesktopApi> {
     reconnectTab: (tabId: string) => invoke<WorkspaceSnapshot>('app_reconnect_tab', { tabId }),
     disconnectTab: (tabId: string) => invoke<WorkspaceSnapshot>('app_disconnect_tab', { tabId }),
     closeTab: (tabId: string) => invoke<WorkspaceSnapshot>('app_close_tab', { tabId }),
+    splitTab: (sourceTabId: string, direction: 'row' | 'column') =>
+      invoke<WorkspaceSnapshot>('app_split_tab', { sourceTabId, direction }),
+    closePane: (rootTabId: string, paneTabId: string) =>
+      invoke<WorkspaceSnapshot>('app_close_pane', { rootTabId, paneTabId }),
+    setActivePane: (rootTabId: string, paneTabId: string) =>
+      invoke<WorkspaceSnapshot>('app_set_active_pane', { rootTabId, paneTabId }),
+    setPaneWeights: (rootTabId: string, panePath: number[], weights: number[]) =>
+      invoke<WorkspaceSnapshot>('app_set_pane_weights', { rootTabId, panePath, weights }),
 
     writeTerminal: (tabId: string, data: string) => invoke<void>('app_write_terminal', { tabId, data }),
     resizeTerminal: (tabId: string, cols: number, rows: number, width: number, height: number) =>
@@ -470,6 +478,11 @@ export async function createTauriApi(): Promise<FileTermDesktopApi> {
       subscribe('app:window-close-request', listener),
     onRequestCloseActiveWorkspaceItem: (listener: () => void) =>
       subscribe('app:close-active-workspace-item-request', listener),
+    onNewTabRequest: (listener: () => void) => subscribe('app:new-tab-request', listener),
+    onSplitPaneRequest: (listener: (direction: 'row' | 'column') => void) =>
+      subscribe('app:split-pane-request', listener),
+    onFocusPaneRequest: (listener: (direction: 'left' | 'right' | 'up' | 'down') => void) =>
+      subscribe('app:focus-pane-request', listener),
     confirmCloseWindow: (action: 'quit' | 'hide' | 'cancel') => {
       if (action === 'cancel') return Promise.resolve()
       if (action === 'quit') {

--- a/apps/tauri/src/renderer/App.tsx
+++ b/apps/tauri/src/renderer/App.tsx
@@ -74,23 +74,34 @@ type ErrorDetails = {
   targetPath?: string
 }
 
-function readInitialTheme(searchParams: URLSearchParams): ThemeMode {
+type InitialUiPreferences = {
+  theme: ThemeMode
+  locale: AppLocale
+}
+
+function readInitialTheme(searchParams: URLSearchParams, persistedPreferences?: InitialUiPreferences): ThemeMode {
   const queryTheme = searchParams.get('theme')
   if (queryTheme === 'default-light' || queryTheme === 'default-dark') {
     return queryTheme
   }
+  if (persistedPreferences?.theme === 'default-light' || persistedPreferences?.theme === 'default-dark') {
+    return persistedPreferences.theme
+  }
   return 'default-dark'
 }
 
-function readInitialLocale(searchParams: URLSearchParams): AppLocale {
+function readInitialLocale(searchParams: URLSearchParams, persistedPreferences?: InitialUiPreferences): AppLocale {
   const queryLocale = searchParams.get('locale')
   if (queryLocale === 'enUS' || queryLocale === 'zhCN') {
     return queryLocale
   }
+  if (persistedPreferences?.locale === 'enUS' || persistedPreferences?.locale === 'zhCN') {
+    return persistedPreferences.locale
+  }
   return defaultLocale
 }
 
-export function App() {
+export function App({ initialUiPreferences }: { initialUiPreferences?: InitialUiPreferences } = {}) {
   const searchParams = new URLSearchParams(window.location.search)
   const windowMode = searchParams.get('window') ?? 'main'
   const isConnectionManagerWindow = windowMode === 'connection-manager'
@@ -123,8 +134,8 @@ export function App() {
   const [isWorkspaceTransitionActive, setIsWorkspaceTransitionActive] = useState(true)
   const [isWorkspaceSwitching, setIsWorkspaceSwitching] = useState(false)
   const hasRenderedWorkspaceRef = useRef(false)
-  const [themeMode, setThemeMode] = useState<ThemeMode>(() => readInitialTheme(searchParams))
-  const [locale, setLocaleState] = useState<AppLocale>(() => readInitialLocale(searchParams))
+  const [themeMode, setThemeMode] = useState<ThemeMode>(() => readInitialTheme(searchParams, initialUiPreferences))
+  const [locale, setLocaleState] = useState<AppLocale>(() => readInitialLocale(searchParams, initialUiPreferences))
   const [isFileEditorDiscardConfirmOpen, setIsFileEditorDiscardConfirmOpen] = useState(false)
   const [connectionImportPlan, setConnectionImportPlan] = useState<ConnectionImportPlan | null>(null)
 
@@ -182,6 +193,9 @@ export function App() {
     windowCloseRequest,
     clearWindowCloseRequest,
     closeActiveRequestVersion,
+    newTabRequestVersion,
+    splitPaneRequest,
+    paneFocusRequest,
     closeCurrentWindow,
     requestQuitApp
   } = useWorkspaceIpcSync({
@@ -191,6 +205,7 @@ export function App() {
     isConnectionManagerWindow,
     themeMode,
     locale,
+    initialUiPreferencesLoaded: initialUiPreferences !== undefined,
     onThemeModeChange: setThemeMode,
     onLocaleChange: (nextLocale) => {
       setLocale(nextLocale)
@@ -221,12 +236,14 @@ export function App() {
     activeLocalTab,
     visibleActiveSessionTabId,
     activeTab,
-    activeSession,
     addHomeTab,
     isHomeWorkspaceVisible,
     showSidebar,
     effectiveActiveLocalTabId,
+    activeSession,
     activeProfile,
+    activePaneTab,
+    activePaneSession,
     activeWorkspaceOrderKey,
     workspaceNavDirection,
     orderedTabs,
@@ -249,7 +266,11 @@ export function App() {
     activateHomeTab,
     closeHomeTab,
     closeSessionTab,
-    openSystemInfo
+    openSystemInfo,
+    splitPane,
+    closePane,
+    activatePane,
+    setPaneWeights
   } = useWorkspaceTabs({
     desktopApi,
     workspace,
@@ -258,6 +279,9 @@ export function App() {
     locale,
     isBusy,
     closeActiveRequestVersion,
+    newTabRequestVersion,
+    splitPaneRequest,
+    paneFocusRequest,
     onSnapshot: applySnapshot,
     onBusyChange: setIsBusy,
     onStatusMessage: (msg) => setError(msg),
@@ -855,7 +879,7 @@ export function App() {
 
     try {
       setIsBusy(true)
-      const targetIds = resolveSelectedTabIds(scope, activeTab, selectedTabIds, sessionSendTargets)
+      const targetIds = resolveSelectedTabIds(scope, activePaneTab, selectedTabIds, sessionSendTargets)
       const targetTabs = visibleWorkspaceTabs.filter((tab) => targetIds.includes(tab.id))
 
       // 并行发送，对照 Electron 原版的 fire-and-forget 行为。
@@ -1267,6 +1291,9 @@ export function App() {
                 activeProfile={activeProfile}
                 activeSession={activeSession}
                 activeTab={activeTab}
+                terminalActiveTab={activePaneTab ?? activeTab}
+                terminalActiveSession={activePaneSession ?? activeSession}
+                splitRootTab={activeTab?.paneRoot ? activeTab : undefined}
                 activeView={activeWorkspaceView}
                 commandPaneWidth={activeCommandPaneWidth}
                 onCommandPaneWidthChange={setActiveCommandPaneWidth}
@@ -1376,6 +1403,12 @@ export function App() {
                 tabBarProps={tabBarProps}
                 isResizingSidebar={isResizingSidebar}
                 onResizeStart={startSidebarResize}
+                sessions={workspace.sessions}
+                activePaneTabId={activePaneTab?.id}
+                onClosePane={closePane}
+                onSplitPane={splitPane}
+                onActivatePane={activatePane}
+                onSetPaneWeights={setPaneWeights}
               />
             </div>
           </div>

--- a/apps/tauri/src/renderer/app/app-data.ts
+++ b/apps/tauri/src/renderer/app/app-data.ts
@@ -39,6 +39,7 @@ export const defaultForm: CreateProfileInput = {
   enableExecChannel: true,
   enableResourceMonitoring: true,
   reconnectMode: 'none',
+  legacyAlgorithms: false,
   secure: false,
   securityMode: 'none',
   proxy: { type: 'none', host: '', port: 1080, username: '' },
@@ -74,6 +75,7 @@ export function profileToForm(profile: ConnectionProfile): CreateProfileInput {
     enableExecChannel: profile.type === 'ssh' ? (profile.enableExecChannel ?? true) : true,
     enableResourceMonitoring: profile.type === 'ssh' ? (profile.enableResourceMonitoring ?? true) : true,
     reconnectMode: profile.type === 'ssh' ? (profile.reconnectMode ?? 'none') : 'none',
+    legacyAlgorithms: profile.type === 'ssh' ? (profile.legacyAlgorithms ?? false) : false,
     secure: profile.type === 'ftp' ? profile.secure : false,
     securityMode: profile.type === 'ftp' ? (profile.securityMode ?? (profile.secure ? 'explicit' : 'none')) : 'none',
     proxy:

--- a/apps/tauri/src/renderer/components/TerminalView.tsx
+++ b/apps/tauri/src/renderer/components/TerminalView.tsx
@@ -78,6 +78,19 @@ const TERMINAL_RESIZE_SETTLE_MS = 140
 const TERMINAL_RESIZE_OUTPUT_QUIET_MS = 260
 // Bound one xterm parse pass without serializing the native input path.
 const TERMINAL_WRITE_FRAME_BUDGET = 16 * 1024
+
+type SplitPaneDirection = 'row' | 'column'
+
+function splitPaneShortcutsForPlatform(platform: string | undefined) {
+  if (platform === 'darwin') {
+    return { vertical: '⌘D', horizontal: '⇧⌘D' }
+  }
+  if (platform === 'win32') {
+    return { vertical: 'Alt+Shift+D', horizontal: 'Alt+Shift+-' }
+  }
+  return { vertical: 'Ctrl+Shift+D', horizontal: 'Ctrl+Alt+Shift+D' }
+}
+
 function trimTranscript(transcript: string) {
   if (transcript.length <= TERMINAL_TRANSCRIPT_LIMIT) {
     return transcript
@@ -114,7 +127,9 @@ export const TerminalView = memo(function TerminalView({
   connected = false,
   connecting = false,
   onStatus,
-  onReconnect
+  onReconnect,
+  onActivate,
+  onSplitPane
 }: {
   tabId: string
   bootText: string
@@ -122,6 +137,8 @@ export const TerminalView = memo(function TerminalView({
   connecting?: boolean
   onStatus?(message: string | null): void
   onReconnect?(): void | Promise<void>
+  onActivate?(): void
+  onSplitPane?(direction: SplitPaneDirection): void
 }) {
   const hostRef = useRef<HTMLDivElement | null>(null)
   const terminalRef = useRef<Terminal | null>(null)
@@ -182,7 +199,8 @@ export const TerminalView = memo(function TerminalView({
   const shortcuts = {
     copy: isMac ? '⌘C' : 'Ctrl+Shift+C',
     paste: isMac ? '⌘V' : 'Ctrl+Shift+V',
-    find: isMac ? '⌘F' : 'Ctrl+F'
+    find: isMac ? '⌘F' : 'Ctrl+F',
+    ...splitPaneShortcutsForPlatform(window.fileterm?.platform)
   }
 
   const readColor = (name: string, fallback: string) =>
@@ -360,6 +378,10 @@ export const TerminalView = memo(function TerminalView({
     }
     terminal.clear()
     terminal.focus()
+  }
+
+  const runSplitPane = (direction: SplitPaneDirection) => {
+    onSplitPane?.(direction)
   }
 
   const flushPendingWrite = () => {
@@ -969,7 +991,11 @@ export const TerminalView = memo(function TerminalView({
       }
     }
 
-    const handleFocusTerminal = () => {
+    const handleFocusTerminal = (event: Event) => {
+      const targetTabId = event instanceof CustomEvent && typeof event.detail === 'string' ? event.detail : null
+      if (targetTabId && targetTabId !== tabIdRef.current) {
+        return
+      }
       terminal.focus()
     }
     const handleTerminalCopy = () => {
@@ -1183,7 +1209,7 @@ export const TerminalView = memo(function TerminalView({
   }, [findCaseSensitive, findOpen, findQuery, findRegex])
 
   return (
-    <div className="terminal-view">
+    <div className="terminal-view" onFocusCapture={onActivate} onMouseDown={onActivate}>
       <div className="terminal-host">
         <div className="terminal-inner" ref={hostRef} />
       </div>
@@ -1252,6 +1278,21 @@ export const TerminalView = memo(function TerminalView({
           items={[
             { label: t.copy, shortcut: shortcuts.copy, disabled: !hasSelection, action: runCopy },
             { label: t.paste, shortcut: shortcuts.paste, action: () => void runPaste() },
+            ...(onSplitPane
+              ? [
+                  { separator: true },
+                  {
+                    label: t.splitVertically,
+                    shortcut: shortcuts.vertical,
+                    action: () => runSplitPane('row')
+                  },
+                  {
+                    label: t.splitHorizontally,
+                    shortcut: shortcuts.horizontal,
+                    action: () => runSplitPane('column')
+                  }
+                ]
+              : []),
             { separator: true },
             { label: t.find, shortcut: shortcuts.find, action: runFind },
             { label: t.clearScreen, action: runClear }

--- a/apps/tauri/src/renderer/features/connections/ConnectionModal.tsx
+++ b/apps/tauri/src/renderer/features/connections/ConnectionModal.tsx
@@ -415,6 +415,19 @@ export function ConnectionModal({
                         </label>
                         <p className="advanced-toggle-hint">{t.resourceMonitoringDescription}</p>
                       </div>
+                      <div className="advanced-toggle-row">
+                        <label className="ssh-checkbox advanced-toggle-label">
+                          <input
+                            checked={Boolean(form.legacyAlgorithms)}
+                            type="checkbox"
+                            onChange={(event) =>
+                              setForm((prev) => ({ ...prev, legacyAlgorithms: event.target.checked }))
+                            }
+                          />
+                          <span className="advanced-toggle-name">{t.legacyAlgorithms}</span>
+                        </label>
+                        <p className="advanced-toggle-hint">{t.legacyAlgorithmsHint}</p>
+                      </div>
                     </div>
                     <div className="reconnect-mode-group">
                       <div className="reconnect-mode-group__label">{t.disconnectBehavior}</div>

--- a/apps/tauri/src/renderer/features/system/SystemSidebar.tsx
+++ b/apps/tauri/src/renderer/features/system/SystemSidebar.tsx
@@ -41,9 +41,10 @@ export function SystemSidebar({
   const sortedProcesses = useMemo(() => {
     const procs = [...(metrics?.topProcesses ?? [])]
     if (sortMode === 'command') {
+      // 按命令名字典序，便于找同名进程；同命令按 CPU 降序
       return procs
-        .sort((a, b) => a.elapsedSeconds - b.elapsedSeconds || parseFloat(b.cpu) - parseFloat(a.cpu))
-        .slice(0, 20)
+        .sort((a, b) => a.command.localeCompare(b.command) || parseFloat(b.cpu) - parseFloat(a.cpu))
+        .slice(0, 40)
     }
     return procs
       .sort((a, b) => {
@@ -55,7 +56,7 @@ export function SystemSidebar({
         }
         return 0
       })
-      .slice(0, 4)
+      .slice(0, 40)
   }, [metrics?.topProcesses, sortMode])
 
   return (
@@ -411,21 +412,29 @@ function getMetricTone(percent: number) {
 }
 
 function ProcessTable({ rows }: { rows: SystemMetrics['topProcesses'] }) {
+  const processScrollRef = useRef<HTMLDivElement>(null)
   const displayRows = rows.length
     ? rows
-    : Array.from({ length: 4 }).map(() => ({ memory: '', cpu: '', command: '', elapsedSeconds: 0 }))
+    : Array.from({ length: 4 }).map(() => ({
+        pid: 0,
+        user: '',
+        memory: '',
+        cpu: '',
+        command: '',
+        elapsedSeconds: 0
+      }))
   return (
-    <div className="process-table scrollbar-scroll">
-      {displayRows.map((row, i) => (
-        <div
-          className="process-row"
-          key={rows.length ? `${row.command}-${row.memory}-${row.cpu}-${row.elapsedSeconds}` : `empty-${i}`}
-        >
-          <span>{row.memory}</span>
-          <span>{row.cpu}</span>
-          <span>{row.command}</span>
-        </div>
-      ))}
+    <div className="process-scroll-region">
+      <div className="process-table" ref={processScrollRef}>
+        {displayRows.map((row, i) => (
+          <div className="process-row" key={rows.length ? `${row.pid}-${row.command}-${row.cpu}-${i}` : `empty-${i}`}>
+            <span>{row.memory}</span>
+            <span>{row.cpu}</span>
+            <span title={row.command}>{row.command}</span>
+          </div>
+        ))}
+      </div>
+      <VerticalScrollbar ariaLabel={t.scrollContent} scrollRef={processScrollRef} />
     </div>
   )
 }

--- a/apps/tauri/src/renderer/features/terminal/TerminalDock.tsx
+++ b/apps/tauri/src/renderer/features/terminal/TerminalDock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import type { TerminalCommandHistoryEntry, WorkspaceTab } from '@fileterm/core'
 import { t } from '../../i18n'
 import { AppIcon } from '../common/AppIcon'
@@ -65,6 +65,9 @@ export function TerminalDock({
   const isReconnectingRef = useRef(false)
   const reconnectFeedbackTimerRef = useRef<number | null>(null)
   const [reconnectFeedbackVisible, setReconnectFeedbackVisible] = useState(false)
+  const focusTerminal = useCallback(() => {
+    window.dispatchEvent(new CustomEvent('fileterm:focus-terminal', { detail: activeTab.id }))
+  }, [activeTab.id])
 
   useEffect(() => {
     return () => {
@@ -200,7 +203,7 @@ export function TerminalDock({
           if (document.activeElement === inputRef.current || document.activeElement === historySearchInputRef.current) {
             inputRef.current?.blur()
             historySearchInputRef.current?.blur()
-            window.dispatchEvent(new CustomEvent('fileterm:focus-terminal'))
+            focusTerminal()
           } else {
             if (panel === 'history') {
               historySearchInputRef.current?.focus()
@@ -218,7 +221,7 @@ export function TerminalDock({
         setPanel((prev) => {
           const next = prev === 'history' ? null : 'history'
           if (next !== 'history') {
-            window.dispatchEvent(new CustomEvent('fileterm:focus-terminal'))
+            focusTerminal()
           }
           return next
         })
@@ -229,7 +232,7 @@ export function TerminalDock({
         if (event.key === 'Escape') {
           event.preventDefault()
           setPanel(null)
-          window.dispatchEvent(new CustomEvent('fileterm:focus-terminal'))
+          focusTerminal()
           return
         }
 
@@ -288,7 +291,7 @@ export function TerminalDock({
                 return trimmed ? `${trimmed} ${selectedToken}` : selectedToken
               })
               setPanel(null)
-              window.dispatchEvent(new CustomEvent('fileterm:focus-terminal'))
+              focusTerminal()
             }
           }
           return
@@ -297,7 +300,7 @@ export function TerminalDock({
     }
     window.addEventListener('keydown', handleGlobalKeyDown)
     return () => window.removeEventListener('keydown', handleGlobalKeyDown)
-  }, [panel, filteredHistory, activeHistoryIndex, activeTokenIndex])
+  }, [panel, filteredHistory, activeHistoryIndex, activeTokenIndex, focusTerminal])
 
   useEffect(() => {
     let canceled = false
@@ -464,7 +467,7 @@ export function TerminalDock({
                                 return trimmed ? `${trimmed} ${token}` : token
                               })
                               setPanel(null)
-                              window.dispatchEvent(new CustomEvent('fileterm:focus-terminal'))
+                              focusTerminal()
                             }}
                           >
                             {token}

--- a/apps/tauri/src/renderer/features/workspace/SessionWorkspace.tsx
+++ b/apps/tauri/src/renderer/features/workspace/SessionWorkspace.tsx
@@ -23,16 +23,26 @@ import { AppIcon } from '../common/AppIcon'
 import { FileManager } from '../files/FileManager'
 import { TerminalDock } from '../terminal/TerminalDock'
 import { t } from '../../i18n'
+import { SplitPaneLayout } from './SplitPaneLayout'
 
 const DEFAULT_FILE_PANEL_HEIGHT = 218
 
 export function SessionWorkspace({
   activeTab,
+  terminalActiveTab,
+  splitRootTab,
+  splitPaneSessions,
+  activePaneTabId,
+  onClosePane,
+  onSplitPane,
+  onActivatePane,
+  onSetPaneWeights,
   activeView,
   onActiveViewChange,
   commandPaneWidth,
   onCommandPaneWidthChange,
   activeSession,
+  terminalActiveSession,
   filePanelHeight,
   onFilePanelHeightChange,
   shouldAlignFilePanelOnMount,
@@ -88,11 +98,20 @@ export function SessionWorkspace({
   isWorkspaceFocusMode
 }: {
   activeTab: WorkspaceTab
+  terminalActiveTab: WorkspaceTab
+  splitRootTab?: WorkspaceTab
+  splitPaneSessions: Record<string, SessionSnapshot>
+  activePaneTabId?: string
+  onClosePane(paneTabId: string): void
+  onSplitPane(paneTabId: string, direction: 'row' | 'column'): void
+  onActivatePane(paneTabId: string): void
+  onSetPaneWeights(panePath: number[], weights: number[]): void
   activeView: 'file' | 'command' | 'tunnel'
   onActiveViewChange(view: 'file' | 'command' | 'tunnel'): void
   commandPaneWidth: number
   onCommandPaneWidthChange(width: number): void
   activeSession: SessionSnapshot
+  terminalActiveSession: SessionSnapshot
   filePanelHeight: number
   onFilePanelHeightChange: Dispatch<SetStateAction<number>>
   shouldAlignFilePanelOnMount: boolean
@@ -386,11 +405,12 @@ export function SessionWorkspace({
   }
 
   const reconnectOnEnter =
-    activeSession.reconnectMode === 'enter'
+    terminalActiveSession.reconnectMode === 'enter'
       ? async () => {
-          await window.fileterm?.reconnectTab(activeTab.id)
+          await window.fileterm?.reconnectTab(terminalActiveTab.id)
         }
       : undefined
+  const canSplitTerminal = terminalActiveTab.sessionType === 'ssh'
 
   return (
     <section
@@ -399,17 +419,30 @@ export function SessionWorkspace({
       style={{ '--file-panel-height': `${effectiveFilePanelHeight}px` } as CSSProperties}
     >
       {!isFileOnly ? (
-        <div className="terminal-area has-terminal-dock">
-          <TerminalView
-            tabId={activeTab.id}
-            bootText={activeSession.terminalTranscript ?? ''}
-            connected={activeSession.connected === true}
-            connecting={activeTab.status === 'connecting'}
-            onReconnect={reconnectOnEnter}
-          />
+        <div className={`terminal-area has-terminal-dock ${splitRootTab?.paneRoot ? 'is-terminal-split' : ''}`}>
+          {splitRootTab?.paneRoot ? (
+            <SplitPaneLayout
+              rootTab={splitRootTab}
+              sessions={splitPaneSessions}
+              activePaneTabId={activePaneTabId}
+              onClosePane={onClosePane}
+              onSplitPane={onSplitPane}
+              onActivatePane={onActivatePane}
+              onResizeEnd={onSetPaneWeights}
+            />
+          ) : (
+            <TerminalView
+              tabId={terminalActiveTab.id}
+              bootText={terminalActiveSession.terminalTranscript ?? ''}
+              connected={terminalActiveSession.connected === true}
+              connecting={terminalActiveTab.status === 'connecting'}
+              onReconnect={reconnectOnEnter}
+              onSplitPane={canSplitTerminal ? (direction) => onSplitPane(terminalActiveTab.id, direction) : undefined}
+            />
+          )}
           <TerminalDock
-            activeTab={activeTab}
-            connected={activeSession.connected === true}
+            activeTab={terminalActiveTab}
+            connected={terminalActiveSession.connected === true}
             selectedTabIds={terminalDockSelectedTabIds}
             sendScope={terminalDockSendScope}
             sendTargets={sendTargets}

--- a/apps/tauri/src/renderer/features/workspace/SplitPaneLayout.tsx
+++ b/apps/tauri/src/renderer/features/workspace/SplitPaneLayout.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import type { PaneNode, SessionSnapshot, WorkspaceTab } from '@fileterm/core'
+import { TerminalView } from '../../components/TerminalView'
+import { t } from '../../i18n'
+import { CloseButton } from '../common/CloseButton'
+
+interface SplitPaneLayoutProps {
+  rootTab: WorkspaceTab
+  sessions: Record<string, SessionSnapshot>
+  activePaneTabId?: string
+  onClosePane(paneTabId: string): void
+  onSplitPane(paneTabId: string, direction: 'row' | 'column'): void
+  onActivatePane(paneTabId: string): void
+  onResizeEnd(panePath: number[], weights: number[]): void
+}
+
+/**
+ * 分屏布局：递归渲染 PaneNode 树。
+ *
+ * 每个 leaf 渲染一个 TerminalView（独立 session，不共享 PTY）。
+ * split 节点按 direction（row=左右，column=上下）排列子节点，中间有 resizer；
+ * 组件由 SessionWorkspace 挂进终端区域，因此文件、命令和侧栏仍是共享工作区。
+ */
+export function SplitPaneLayout({
+  rootTab,
+  sessions,
+  activePaneTabId,
+  onClosePane,
+  onSplitPane,
+  onActivatePane,
+  onResizeEnd
+}: SplitPaneLayoutProps) {
+  if (!rootTab.paneRoot) {
+    return null
+  }
+
+  return (
+    <div className="split-pane-root">
+      <PaneRenderer
+        node={rootTab.paneRoot}
+        sessions={sessions}
+        rootTabId={rootTab.id}
+        panePath={[]}
+        activePaneTabId={activePaneTabId}
+        onClosePane={onClosePane}
+        onSplitPane={onSplitPane}
+        onActivatePane={onActivatePane}
+        onResizeEnd={onResizeEnd}
+      />
+    </div>
+  )
+}
+
+interface PaneRendererProps {
+  node: PaneNode
+  sessions: Record<string, SessionSnapshot>
+  rootTabId: string
+  panePath: number[]
+  activePaneTabId?: string
+  onClosePane(paneTabId: string): void
+  onSplitPane(paneTabId: string, direction: 'row' | 'column'): void
+  onActivatePane(paneTabId: string): void
+  onResizeEnd(panePath: number[], weights: number[]): void
+}
+
+function PaneRenderer({
+  node,
+  sessions,
+  rootTabId,
+  panePath,
+  activePaneTabId,
+  onClosePane,
+  onSplitPane,
+  onActivatePane,
+  onResizeEnd
+}: PaneRendererProps) {
+  if (node.kind === 'leaf') {
+    const session = sessions[node.tabId]
+    const isActive = activePaneTabId === node.tabId
+    return (
+      <div className={`split-pane-leaf ${isActive ? 'split-pane-leaf--active' : ''}`}>
+        <div className="split-pane-terminal">
+          <TerminalView
+            tabId={node.tabId}
+            bootText={session?.terminalTranscript ?? ''}
+            connected={session?.connected ?? false}
+            connecting={session?.connected === false}
+            onSplitPane={(direction) => onSplitPane(node.tabId, direction)}
+            onActivate={() => {
+              if (!isActive) {
+                onActivatePane(node.tabId)
+              }
+            }}
+          />
+        </div>
+        <CloseButton
+          aria-label={t.closeTab}
+          className="split-pane-leaf-close"
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={() => onClosePane(node.tabId)}
+          size="compact"
+        />
+      </div>
+    )
+  }
+
+  // split 节点
+  const isRow = node.direction === 'row'
+  const panes = node.children
+  const weights = node.weights.length === panes.length ? node.weights : panes.map(() => 1 / panes.length)
+
+  return (
+    <SplitContainer
+      isRow={isRow}
+      panes={panes}
+      initialWeights={weights}
+      sessions={sessions}
+      rootTabId={rootTabId}
+      panePath={panePath}
+      activePaneTabId={activePaneTabId}
+      onClosePane={onClosePane}
+      onSplitPane={onSplitPane}
+      onActivatePane={onActivatePane}
+      onResizeEnd={onResizeEnd}
+    />
+  )
+}
+
+interface SplitContainerProps {
+  isRow: boolean
+  panes: PaneNode[]
+  initialWeights: number[]
+  sessions: Record<string, SessionSnapshot>
+  rootTabId: string
+  panePath: number[]
+  activePaneTabId?: string
+  onClosePane(paneTabId: string): void
+  onSplitPane(paneTabId: string, direction: 'row' | 'column'): void
+  onActivatePane(paneTabId: string): void
+  onResizeEnd(panePath: number[], weights: number[]): void
+}
+
+function SplitContainer({
+  isRow,
+  panes,
+  initialWeights,
+  sessions,
+  rootTabId,
+  panePath,
+  activePaneTabId,
+  onClosePane,
+  onSplitPane,
+  onActivatePane,
+  onResizeEnd
+}: SplitContainerProps) {
+  const [weights, setWeights] = useState(initialWeights)
+  const [dragging, setDragging] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  // 当后端 weights 变化时（如新分屏），同步前端
+  useEffect(() => {
+    if (!dragging) {
+      setWeights(initialWeights)
+    }
+  }, [initialWeights, dragging])
+
+  const handleResizeStart = useCallback(
+    (event: React.MouseEvent, resizerIndex: number) => {
+      event.preventDefault()
+      event.stopPropagation()
+      // 只支持两个子节点的拖拽（MVP）
+      if (panes.length !== 2 || resizerIndex !== 0) return
+
+      setDragging(true)
+
+      const container = containerRef.current
+      if (!container) return
+
+      const rect = container.getBoundingClientRect()
+      const startXY = isRow ? event.clientX : event.clientY
+      const startWeights = [...weights]
+
+      const onMove = (e: MouseEvent) => {
+        const currentXY = isRow ? e.clientX : e.clientY
+        const totalSize = isRow ? rect.width : rect.height
+        const delta = (currentXY - startXY) / totalSize
+        const newFirst = Math.max(0.1, Math.min(0.9, startWeights[0] + delta))
+        const newSecond = 1 - newFirst
+        setWeights([newFirst, newSecond])
+      }
+
+      const onUp = () => {
+        setDragging(false)
+        document.removeEventListener('mousemove', onMove)
+        document.removeEventListener('mouseup', onUp)
+        setWeights((current) => {
+          onResizeEnd(panePath, current)
+          return current
+        })
+      }
+
+      document.addEventListener('mousemove', onMove)
+      document.addEventListener('mouseup', onUp)
+    },
+    [isRow, weights, panes.length, onResizeEnd]
+  )
+
+  // 交替渲染 child 和 resizer
+  const items: ReactNode[] = []
+  panes.forEach((child, idx) => {
+    items.push(
+      <div key={`child-${idx}`} className="split-pane-child" style={getChildStyle(isRow, weights, idx, panes.length)}>
+        <PaneRenderer
+          node={child}
+          sessions={sessions}
+          rootTabId={rootTabId}
+          panePath={[...panePath, idx]}
+          activePaneTabId={activePaneTabId}
+          onClosePane={onClosePane}
+          onSplitPane={onSplitPane}
+          onActivatePane={onActivatePane}
+          onResizeEnd={onResizeEnd}
+        />
+      </div>
+    )
+    if (idx < panes.length - 1) {
+      items.push(
+        <div
+          key={`resizer-${idx}`}
+          className={`split-pane-resizer ${isRow ? 'split-pane-resizer--row' : 'split-pane-resizer--column'}`}
+          onMouseDown={(e) => handleResizeStart(e, idx)}
+        />
+      )
+    }
+  })
+
+  return (
+    <div
+      ref={containerRef}
+      className={`split-pane-container ${isRow ? 'split-pane-container--row' : 'split-pane-container--column'}`}
+    >
+      {items}
+    </div>
+  )
+}
+
+function getChildStyle(isRow: boolean, weights: number[], idx: number, total: number): CSSProperties {
+  const weight = weights[idx] ?? 1 / total
+  const size = `${weight * 100}%`
+  return {
+    flex: `1 1 ${size}`,
+    minWidth: 0,
+    minHeight: 0,
+    overflow: 'hidden'
+  }
+}

--- a/apps/tauri/src/renderer/features/workspace/WorkspaceStage.tsx
+++ b/apps/tauri/src/renderer/features/workspace/WorkspaceStage.tsx
@@ -28,6 +28,9 @@ export function WorkspaceStage({
   activeProfile,
   activeSession,
   activeTab,
+  terminalActiveTab,
+  terminalActiveSession,
+  splitRootTab,
   activeView,
   onActiveViewChange,
   commandPaneWidth,
@@ -111,13 +114,22 @@ export function WorkspaceStage({
   isWorkspaceFocusMode,
   tabBarProps,
   isResizingSidebar,
-  onResizeStart
+  onResizeStart,
+  sessions,
+  activePaneTabId,
+  onClosePane,
+  onSplitPane,
+  onActivatePane,
+  onSetPaneWeights
 }: {
   activeLocalTab: ActiveLocalTab
   activeHomeTabId: string | null
   activeProfile: ConnectionProfile | null
   activeSession: SessionSnapshot | null
   activeTab: WorkspaceTab | null
+  terminalActiveTab: WorkspaceTab | null
+  terminalActiveSession: SessionSnapshot | null
+  splitRootTab?: WorkspaceTab
   activeView: 'file' | 'command' | 'tunnel'
   onActiveViewChange(view: 'file' | 'command' | 'tunnel'): void
   commandPaneWidth: number
@@ -213,6 +225,12 @@ export function WorkspaceStage({
   tabBarProps: Omit<TabBarProps, 'homeBrandContent'>
   isResizingSidebar: boolean
   onResizeStart(): void
+  sessions: Record<string, SessionSnapshot>
+  activePaneTabId?: string
+  onClosePane(paneTabId: string): void
+  onSplitPane(paneTabId: string, direction: 'row' | 'column'): void
+  onActivatePane(paneTabId: string): void
+  onSetPaneWeights(panePath: number[], weights: number[]): void
 }) {
   if (activeLocalTab?.kind === 'system') {
     return (
@@ -229,6 +247,15 @@ export function WorkspaceStage({
       <SessionWorkspace
         activeSession={activeSession}
         activeTab={activeTab}
+        terminalActiveTab={terminalActiveTab ?? activeTab}
+        terminalActiveSession={terminalActiveSession ?? activeSession}
+        splitRootTab={splitRootTab}
+        splitPaneSessions={sessions}
+        activePaneTabId={activePaneTabId}
+        onClosePane={onClosePane}
+        onSplitPane={onSplitPane}
+        onActivatePane={onActivatePane}
+        onSetPaneWeights={onSetPaneWeights}
         activeView={activeView}
         onActiveViewChange={onActiveViewChange}
         commandPaneWidth={commandPaneWidth}

--- a/apps/tauri/src/renderer/hooks/useWorkspaceIpcSync.ts
+++ b/apps/tauri/src/renderer/hooks/useWorkspaceIpcSync.ts
@@ -3,6 +3,7 @@ import {
   mergeSystemMetricsHistory,
   type FileTermDesktopApi,
   type LocalFileItem,
+  type PaneFocusDirection,
   type SessionMetricsUpdate,
   type TransferTask,
   type WorkspaceSnapshot
@@ -17,6 +18,16 @@ export type WorkspaceWindowCloseRequest = {
   isQuit: boolean
 }
 
+export type WorkspaceSplitPaneRequest = {
+  id: number
+  direction: 'row' | 'column'
+}
+
+export type WorkspacePaneFocusRequest = {
+  id: number
+  direction: PaneFocusDirection
+}
+
 export type UseWorkspaceIpcSyncOptions = {
   desktopApi?: FileTermDesktopApi
   isConnectionFormWindow: boolean
@@ -24,6 +35,7 @@ export type UseWorkspaceIpcSyncOptions = {
   isConnectionManagerWindow: boolean
   themeMode: ThemeMode
   locale: AppLocale
+  initialUiPreferencesLoaded: boolean
   onThemeModeChange(themeMode: ThemeMode): void
   onLocaleChange(locale: AppLocale): void
   onError(scope: string, error: unknown): void
@@ -45,6 +57,9 @@ export type UseWorkspaceIpcSyncResult = {
   windowCloseRequest: WorkspaceWindowCloseRequest | null
   clearWindowCloseRequest(): void
   closeActiveRequestVersion: number
+  newTabRequestVersion: number
+  splitPaneRequest: WorkspaceSplitPaneRequest | null
+  paneFocusRequest: WorkspacePaneFocusRequest | null
   closeCurrentWindow(): void
   requestQuitApp(): void
 }
@@ -72,6 +87,7 @@ export function useWorkspaceIpcSync({
   isConnectionManagerWindow,
   themeMode,
   locale,
+  initialUiPreferencesLoaded,
   onThemeModeChange,
   onLocaleChange,
   onError,
@@ -82,9 +98,18 @@ export function useWorkspaceIpcSync({
   const [localItems, setLocalItems] = useState<LocalFileItem[]>(localPreviewFiles)
   const [isLocalDirectoryLoading, setIsLocalDirectoryLoading] = useState(false)
   const [hasLoadedInitialSnapshot, setHasLoadedInitialSnapshot] = useState(false)
+  const [hasHydratedUiPreferences, setHasHydratedUiPreferences] = useState(
+    () => !desktopApi || initialUiPreferencesLoaded
+  )
+  const [canPersistUiPreferences, setCanPersistUiPreferences] = useState(() =>
+    Boolean(desktopApi && initialUiPreferencesLoaded)
+  )
   const [isMaximized, setIsMaximized] = useState(false)
   const [windowCloseRequest, setWindowCloseRequest] = useState<WorkspaceWindowCloseRequest | null>(null)
   const [closeActiveRequestVersion, setCloseActiveRequestVersion] = useState(0)
+  const [newTabRequestVersion, setNewTabRequestVersion] = useState(0)
+  const [splitPaneRequest, setSplitPaneRequest] = useState<WorkspaceSplitPaneRequest | null>(null)
+  const [paneFocusRequest, setPaneFocusRequest] = useState<WorkspacePaneFocusRequest | null>(null)
 
   const desktopApiRef = useLatestRef(desktopApi)
   const onThemeModeChangeRef = useLatestRef(onThemeModeChange)
@@ -92,6 +117,8 @@ export function useWorkspaceIpcSync({
   const onErrorRef = useLatestRef(onError)
   const onStatusMessageRef = useLatestRef(onStatusMessage)
   const nextWindowCloseRequestIdRef = useRef(0)
+  const nextSplitPaneRequestIdRef = useRef(0)
+  const nextPaneFocusRequestIdRef = useRef(0)
   const notifiedTransferFailuresRef = useRef(new Map<string, string>())
 
   const applySnapshot = useCallback((snapshot: WorkspaceSnapshot) => {
@@ -171,13 +198,57 @@ export function useWorkspaceIpcSync({
     }
 
     return desktopApi.onUiPreferencesChanged((preferences) => {
-      onThemeModeChangeRef.current(preferences.theme)
-      onLocaleChangeRef.current(preferences.locale)
+      if (preferences.theme === 'default-light' || preferences.theme === 'default-dark') {
+        onThemeModeChangeRef.current(preferences.theme)
+      }
+      if (preferences.locale === 'enUS' || preferences.locale === 'zhCN') {
+        onLocaleChangeRef.current(preferences.locale)
+      }
     })
   }, [desktopApi])
 
   useEffect(() => {
-    if (!desktopApi) {
+    if (!desktopApi || initialUiPreferencesLoaded) {
+      setHasHydratedUiPreferences(true)
+      setCanPersistUiPreferences(Boolean(desktopApi))
+      return
+    }
+
+    let canceled = false
+
+    void desktopApi
+      .getUiPreferences()
+      .then((preferences) => {
+        if (canceled) {
+          return
+        }
+        setCanPersistUiPreferences(true)
+        if (preferences.theme === 'default-light' || preferences.theme === 'default-dark') {
+          onThemeModeChangeRef.current(preferences.theme)
+        }
+        if (preferences.locale === 'enUS' || preferences.locale === 'zhCN') {
+          onLocaleChangeRef.current(preferences.locale)
+        }
+      })
+      .catch((error: unknown) => {
+        if (!canceled) {
+          setCanPersistUiPreferences(false)
+          onErrorRef.current('读取界面偏好', error)
+        }
+      })
+      .finally(() => {
+        if (!canceled) {
+          setHasHydratedUiPreferences(true)
+        }
+      })
+
+    return () => {
+      canceled = true
+    }
+  }, [desktopApi, initialUiPreferencesLoaded])
+
+  useEffect(() => {
+    if (!desktopApi || !hasHydratedUiPreferences || !canPersistUiPreferences) {
       return
     }
 
@@ -191,7 +262,7 @@ export function useWorkspaceIpcSync({
     return () => {
       canceled = true
     }
-  }, [desktopApi, locale, themeMode])
+  }, [canPersistUiPreferences, desktopApi, hasHydratedUiPreferences, locale, themeMode])
 
   useEffect(() => {
     if (!desktopApi || !isMainWorkspaceWindow) {
@@ -243,10 +314,30 @@ export function useWorkspaceIpcSync({
     const unsubscribeCloseActive = desktopApi.onRequestCloseActiveWorkspaceItem(() => {
       setCloseActiveRequestVersion((current) => current + 1)
     })
+    const unsubscribeNewTab = desktopApi.onNewTabRequest(() => {
+      setNewTabRequestVersion((current) => current + 1)
+    })
+    const unsubscribeSplitPane = desktopApi.onSplitPaneRequest((direction) => {
+      nextSplitPaneRequestIdRef.current += 1
+      setSplitPaneRequest({
+        id: nextSplitPaneRequestIdRef.current,
+        direction
+      })
+    })
+    const unsubscribePaneFocus = desktopApi.onFocusPaneRequest((direction) => {
+      nextPaneFocusRequestIdRef.current += 1
+      setPaneFocusRequest({
+        id: nextPaneFocusRequestIdRef.current,
+        direction
+      })
+    })
 
     return () => {
       unsubscribeWindowClose()
       unsubscribeCloseActive()
+      unsubscribeNewTab()
+      unsubscribeSplitPane()
+      unsubscribePaneFocus()
     }
   }, [desktopApi, isMainWorkspaceWindow])
 
@@ -452,6 +543,9 @@ export function useWorkspaceIpcSync({
     windowCloseRequest,
     clearWindowCloseRequest,
     closeActiveRequestVersion,
+    newTabRequestVersion,
+    splitPaneRequest,
+    paneFocusRequest,
     closeCurrentWindow,
     requestQuitApp
   }

--- a/apps/tauri/src/renderer/hooks/useWorkspaceTabs.ts
+++ b/apps/tauri/src/renderer/hooks/useWorkspaceTabs.ts
@@ -3,6 +3,8 @@ import type {
   ConnectionProfile,
   CommandExecutionOptions,
   FileTermDesktopApi,
+  PaneFocusDirection,
+  PaneNode,
   SessionSnapshot,
   WorkspaceSnapshot,
   WorkspaceTab
@@ -57,6 +59,14 @@ export type WorkspaceTabContextAction =
 export type WorkspaceStageKind = 'home' | 'session' | 'system'
 export type WorkspaceNavigationDirection = 'up' | 'down'
 
+type PaneBounds = {
+  tabId: string
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 export type UseWorkspaceTabsOptions = {
   desktopApi?: FileTermDesktopApi
   workspace: WorkspaceSnapshot
@@ -65,6 +75,9 @@ export type UseWorkspaceTabsOptions = {
   locale: AppLocale
   isBusy: boolean
   closeActiveRequestVersion: number
+  newTabRequestVersion: number
+  splitPaneRequest: { id: number; direction: 'row' | 'column' } | null
+  paneFocusRequest: { id: number; direction: PaneFocusDirection } | null
   onSnapshot(snapshot: WorkspaceSnapshot): void
   onBusyChange(isBusy: boolean): void
   onStatusMessage(message: string | null): void
@@ -107,6 +120,86 @@ function uniqueItemsById<T extends { id: string }>(items: T[]) {
     seen.add(item.id)
     return true
   })
+}
+
+function collectPaneBounds(node: PaneNode, x: number, y: number, width: number, height: number, result: PaneBounds[]) {
+  if (node.kind === 'leaf') {
+    result.push({ tabId: node.tabId, x, y, width, height })
+    return
+  }
+
+  const weights =
+    node.weights.length === node.children.length ? node.weights : node.children.map(() => 1 / node.children.length)
+  let offset = 0
+  node.children.forEach((child, index) => {
+    const weight = weights[index] ?? 1 / node.children.length
+    if (node.direction === 'row') {
+      const childWidth = width * weight
+      collectPaneBounds(child, x + offset, y, childWidth, height, result)
+      offset += childWidth
+      return
+    }
+
+    const childHeight = height * weight
+    collectPaneBounds(child, x, y + offset, width, childHeight, result)
+    offset += childHeight
+  })
+}
+
+function collectPaneLeafTabIds(node: PaneNode, result: string[] = []) {
+  if (node.kind === 'leaf') {
+    result.push(node.tabId)
+    return result
+  }
+
+  for (const child of node.children) {
+    collectPaneLeafTabIds(child, result)
+  }
+  return result
+}
+
+function findAdjacentPaneTabId(
+  paneRoot: PaneNode,
+  activePaneTabId: string,
+  direction: PaneFocusDirection
+): string | null {
+  const panes: PaneBounds[] = []
+  collectPaneBounds(paneRoot, 0, 0, 1, 1, panes)
+  const active = panes.find((pane) => pane.tabId === activePaneTabId)
+  if (!active) {
+    return null
+  }
+
+  const activeCenterX = active.x + active.width / 2
+  const activeCenterY = active.y + active.height / 2
+  const candidates = panes
+    .filter((pane) => pane.tabId !== activePaneTabId)
+    .map((pane) => {
+      const centerX = pane.x + pane.width / 2
+      const centerY = pane.y + pane.height / 2
+      const isInDirection =
+        (direction === 'left' && centerX < activeCenterX) ||
+        (direction === 'right' && centerX > activeCenterX) ||
+        (direction === 'up' && centerY < activeCenterY) ||
+        (direction === 'down' && centerY > activeCenterY)
+      if (!isInDirection) {
+        return null
+      }
+
+      const primaryDistance =
+        direction === 'left' || direction === 'right'
+          ? Math.abs(centerX - activeCenterX)
+          : Math.abs(centerY - activeCenterY)
+      const crossDistance =
+        direction === 'left' || direction === 'right'
+          ? Math.abs(centerY - activeCenterY)
+          : Math.abs(centerX - activeCenterX)
+      return { pane, score: primaryDistance * 2 + crossDistance }
+    })
+    .filter((candidate): candidate is { pane: PaneBounds; score: number } => candidate !== null)
+    .sort((left, right) => left.score - right.score)
+
+  return candidates[0]?.pane.tabId ?? null
 }
 
 function parseStoredMainTabUiState(raw: string | null | undefined): StoredMainTabUiState | null {
@@ -225,6 +318,9 @@ export function useWorkspaceTabs({
   locale,
   isBusy,
   closeActiveRequestVersion,
+  newTabRequestVersion,
+  splitPaneRequest,
+  paneFocusRequest,
   onSnapshot,
   onBusyChange,
   onStatusMessage,
@@ -254,6 +350,11 @@ export function useWorkspaceTabs({
   const pendingProfileOpenIdRef = useRef<string | null>(null)
   const hasSanitizedStoredPlaceholderRef = useRef(false)
   const handledCloseActiveRequestVersionRef = useRef(0)
+  const handledNewTabRequestVersionRef = useRef(0)
+  const handledSplitPaneRequestIdRef = useRef(0)
+  const handledPaneFocusRequestIdRef = useRef(0)
+  const splitCurrentPaneRef = useRef<(direction: 'row' | 'column') => Promise<void>>(async () => {})
+  const focusAdjacentPaneRef = useRef<(direction: PaneFocusDirection) => Promise<void>>(async () => {})
 
   useEffect(() => {
     localTabsRef.current = localTabs
@@ -298,9 +399,28 @@ export function useWorkspaceTabs({
   }, [desktopApi, isMainWorkspaceWindow])
 
   const closingSessionTabIdSet = useMemo(() => new Set(closingSessionTabIds), [closingSessionTabIds])
+  // 分屏 leaf tab id 集合：新建的 leaf 不在 tab bar 显示；持有 paneRoot 的
+  // root tab 仍需保留，不能因为它也作为树中的第一个 leaf 而被误隐藏。
+  const leafTabIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const tab of workspace.tabs) {
+      if (tab.paneRoot) {
+        for (const leafTabId of collectPaneLeafTabIds(tab.paneRoot)) {
+          ids.add(leafTabId)
+        }
+        ids.delete(tab.id)
+      }
+    }
+    return ids
+  }, [workspace.tabs])
   const visibleWorkspaceTabs = useMemo(
-    () => uniqueItemsById(workspace.tabs.filter((tab) => !closingSessionTabIdSet.has(tab.id))),
-    [closingSessionTabIdSet, workspace.tabs]
+    () =>
+      uniqueItemsById(
+        workspace.tabs.filter(
+          (tab) => !closingSessionTabIdSet.has(tab.id) && !tab.paneRootTabId && !leafTabIds.has(tab.id)
+        )
+      ),
+    [closingSessionTabIdSet, workspace.tabs, leafTabIds]
   )
 
   useEffect(() => {
@@ -492,6 +612,11 @@ export function useWorkspaceTabs({
     ? (visibleWorkspaceTabs.find((tab) => tab.id === displayedSessionTabId) ?? null)
     : null
   const activeSession = activeTab ? (workspace.sessions[activeTab.id] ?? null) : null
+  const activePaneTabId = activeTab?.paneRoot
+    ? (workspace.activePaneTabIdByRoot?.[activeTab.id] ?? activeTab.id)
+    : activeTab?.id
+  const activePaneTab = activePaneTabId ? (workspace.tabs.find((tab) => tab.id === activePaneTabId) ?? activeTab) : null
+  const activePaneSession = activePaneTab ? (workspace.sessions[activePaneTab.id] ?? null) : null
   const isSystemSidebarCollapsed = activeTab ? (systemSidebarCollapsedByTabId[activeTab.id] ?? false) : false
   const setIsSystemSidebarCollapsed = (nextCollapsed: boolean) => {
     if (!activeTab) {
@@ -521,6 +646,9 @@ export function useWorkspaceTabs({
     activeLocalTab?.id ?? (isHomeWorkspaceVisible ? resolveFallbackHomeTabId(localTabs, tabOrder) : null)
   const activeProfile = activeTab
     ? (workspace.profiles.find((profile) => profile.id === activeTab.profileId) ?? null)
+    : null
+  const activePaneProfile = activePaneTab
+    ? (workspace.profiles.find((profile) => profile.id === activePaneTab.profileId) ?? null)
     : null
   const activeWorkspaceOrderKey = activeLocalTab
     ? homeTabKey(activeLocalTab.id)
@@ -598,8 +726,8 @@ export function useWorkspaceTabs({
     [activeTab?.id, orderedTabs, workspace.sessions]
   )
 
-  const activeTerminalDockSendState = activeTab
-    ? (terminalDockSendStateByTabId[activeTab.id] ?? createDefaultTerminalDockSendState())
+  const activeTerminalDockSendState = activePaneTab
+    ? (terminalDockSendStateByTabId[activePaneTab.id] ?? createDefaultTerminalDockSendState())
     : createDefaultTerminalDockSendState()
 
   useEffect(() => {
@@ -607,7 +735,7 @@ export function useWorkspaceTabs({
       return
     }
 
-    const validTabIds = new Set(visibleWorkspaceTabs.map((tab) => tab.id))
+    const validTabIds = new Set(workspace.tabs.map((tab) => tab.id))
     setTerminalDockSendStateByTabId((current) => {
       const next = Object.fromEntries(Object.entries(current).filter(([tabId]) => validTabIds.has(tabId)))
       return Object.keys(next).length === Object.keys(current).length ? current : next
@@ -616,7 +744,7 @@ export function useWorkspaceTabs({
       const next = Object.fromEntries(Object.entries(current).filter(([tabId]) => validTabIds.has(tabId)))
       return Object.keys(next).length === Object.keys(current).length ? current : next
     })
-  }, [hasLoadedInitialSnapshot, visibleWorkspaceTabs])
+  }, [hasLoadedInitialSnapshot, visibleWorkspaceTabs, workspace.tabs])
 
   useEffect(() => {
     const availableTargetIds = new Set(sessionSendTargets.map((target) => target.tabId))
@@ -642,16 +770,16 @@ export function useWorkspaceTabs({
   }
 
   const updateTerminalDockSendState = (updater: (current: TerminalDockSendState) => TerminalDockSendState) => {
-    if (!activeTab) {
+    if (!activePaneTab) {
       return
     }
 
     setTerminalDockSendStateByTabId((currentByTabId) => {
-      const current = currentByTabId[activeTab.id] ?? createDefaultTerminalDockSendState()
+      const current = currentByTabId[activePaneTab.id] ?? createDefaultTerminalDockSendState()
       const next = updater(current)
       return {
         ...currentByTabId,
-        [activeTab.id]: {
+        [activePaneTab.id]: {
           ...next,
           selectedTabIds: next.selectedTabIds.filter((tabId) =>
             sessionSendTargets.some((target) => target.tabId === tabId)
@@ -685,7 +813,7 @@ export function useWorkspaceTabs({
     scope?: SendScope,
     selectedTabIds?: string[]
   ) => {
-    if (!desktopApi || !activeTab) {
+    if (!desktopApi || !activePaneTab) {
       return
     }
 
@@ -693,7 +821,7 @@ export function useWorkspaceTabs({
     const effectiveScope = scope ?? activeTerminalDockSendState.scope
     const effectiveSelectedTabIds = selectedTabIds ?? activeTerminalDockSendState.selectedTabIds
 
-    const targetIds = resolveSelectedTabIds(effectiveScope, activeTab, effectiveSelectedTabIds, sessionSendTargets)
+    const targetIds = resolveSelectedTabIds(effectiveScope, activePaneTab, effectiveSelectedTabIds, sessionSendTargets)
 
     if (!targetIds.length) {
       onStatusMessage(t.commandNoAvailableTargets)
@@ -716,10 +844,10 @@ export function useWorkspaceTabs({
       onError('发送终端命令', error)
       throw error
     } finally {
-      if (usesDockState && !activeTerminalDockSendState.rememberSelection && activeTab) {
+      if (usesDockState && !activeTerminalDockSendState.rememberSelection && activePaneTab) {
         setTerminalDockSendStateByTabId((current) => ({
           ...current,
-          [activeTab.id]: createDefaultTerminalDockSendState()
+          [activePaneTab.id]: createDefaultTerminalDockSendState()
         }))
       }
     }
@@ -890,6 +1018,128 @@ export function useWorkspaceTabs({
     return snapshot
   }
 
+  // ==========================================
+  // 分屏（Split Pane）操作
+  // ==========================================
+
+  /** 基于指定 pane 的 profile 新建独立 session，不共享 PTY。 */
+  const splitPane = async (sourceTabId: string, direction: 'row' | 'column') => {
+    if (!desktopApi) {
+      return
+    }
+    // 只对 SSH session 分屏
+    const sourceTab = workspace.tabs.find((tab) => tab.id === sourceTabId)
+    if (!sourceTab || sourceTab.sessionType !== 'ssh') {
+      return
+    }
+    try {
+      onBusyChange(true)
+      const snapshot = await desktopApi.splitTab(sourceTabId, direction)
+      onSnapshot(snapshot)
+    } catch (error) {
+      onError('splitPane', error)
+    } finally {
+      onBusyChange(false)
+    }
+  }
+
+  /**
+   * 分屏当前活跃 pane：基于当前 profile 新建独立 session。
+   * source tab id 优先取 activePaneTabIdByRoot[activeTabId]，退回到 activeTabId。
+   */
+  const splitCurrentPane = async (direction: 'row' | 'column') => {
+    if (!workspace.activeTabId) {
+      return
+    }
+    const rootTabId = workspace.activeTabId
+    const activePaneTabId = workspace.activePaneTabIdByRoot?.[rootTabId] ?? rootTabId
+    await splitPane(activePaneTabId, direction)
+  }
+
+  useEffect(() => {
+    splitCurrentPaneRef.current = splitCurrentPane
+  })
+
+  const focusAdjacentPane = async (direction: PaneFocusDirection) => {
+    if (!desktopApi || !workspace.activeTabId) {
+      return
+    }
+
+    const rootTabId = workspace.activeTabId
+    const rootTab = workspace.tabs.find((tab) => tab.id === rootTabId)
+    const activePaneTabId = workspace.activePaneTabIdByRoot?.[rootTabId] ?? rootTabId
+    if (!rootTab?.paneRoot) {
+      return
+    }
+
+    const targetPaneTabId = findAdjacentPaneTabId(rootTab.paneRoot, activePaneTabId, direction)
+    if (!targetPaneTabId) {
+      return
+    }
+
+    try {
+      const snapshot = await desktopApi.setActivePane(rootTabId, targetPaneTabId)
+      onSnapshot(snapshot)
+      window.dispatchEvent(new CustomEvent('fileterm:focus-terminal', { detail: targetPaneTabId }))
+    } catch (error) {
+      onError('focusAdjacentPane', error)
+    }
+  }
+
+  useEffect(() => {
+    focusAdjacentPaneRef.current = focusAdjacentPane
+  })
+
+  /** 关闭分屏中的单个 pane */
+  const closePane = async (paneTabId: string) => {
+    if (!desktopApi || !workspace.activeTabId) {
+      return
+    }
+    const rootTabId = workspace.activeTabId
+    const activePaneTabId = workspace.activePaneTabIdByRoot?.[rootTabId] ?? rootTabId
+    try {
+      const snapshot = await desktopApi.closePane(rootTabId, paneTabId)
+      onSnapshot(snapshot)
+      if (paneTabId === activePaneTabId) {
+        const nextRootTabId = snapshot.activeTabId ?? rootTabId
+        const nextPaneTabId = snapshot.activePaneTabIdByRoot?.[nextRootTabId] ?? nextRootTabId
+        window.requestAnimationFrame(() => {
+          window.dispatchEvent(new CustomEvent('fileterm:focus-terminal', { detail: nextPaneTabId }))
+        })
+      }
+    } catch (error) {
+      onError('closePane', error)
+    }
+  }
+
+  /** 设置分屏活跃 pane */
+  const activatePane = async (paneTabId: string) => {
+    if (!desktopApi || !workspace.activeTabId) {
+      return
+    }
+    const rootTabId = workspace.activeTabId
+    try {
+      const snapshot = await desktopApi.setActivePane(rootTabId, paneTabId)
+      onSnapshot(snapshot)
+    } catch (error) {
+      onError('activatePane', error)
+    }
+  }
+
+  /** 持久化分屏 weights */
+  const setPaneWeights = async (panePath: number[], weights: number[]) => {
+    if (!desktopApi || !workspace.activeTabId) {
+      return
+    }
+    const rootTabId = workspace.activeTabId
+    try {
+      const snapshot = await desktopApi.setPaneWeights(rootTabId, panePath, weights)
+      onSnapshot(snapshot)
+    } catch (error) {
+      onError('setPaneWeights', error)
+    }
+  }
+
   const closeHomeTabById = (homeTabId: string) => {
     setLocalTabs((current) => {
       const remaining = current.filter((tab) => tab.id !== homeTabId)
@@ -952,6 +1202,19 @@ export function useWorkspaceTabs({
     setActiveLocalTabId(nextId)
     onStatusMessage(null)
   }
+
+  useEffect(() => {
+    if (
+      !isMainWorkspaceWindow ||
+      newTabRequestVersion === 0 ||
+      newTabRequestVersion === handledNewTabRequestVersionRef.current
+    ) {
+      return
+    }
+
+    handledNewTabRequestVersionRef.current = newTabRequestVersion
+    addHomeTab()
+  }, [addHomeTab, isMainWorkspaceWindow, newTabRequestVersion])
 
   const openSystemInfo = () => {
     if (!activeTab) {
@@ -1027,6 +1290,22 @@ export function useWorkspaceTabs({
     }
 
     if (activeSessionTab) {
+      const paneLeafIds = activeSessionTab.paneRoot ? collectPaneLeafTabIds(activeSessionTab.paneRoot) : []
+      const activePaneTabId = workspace.activePaneTabIdByRoot?.[activeSessionTab.id] ?? activeSessionTab.id
+
+      // Cmd+W follows the terminal hierarchy: close the focused pane without
+      // interrupting the user with a dialog while its parent tab still has
+      // other panes. Once only one surface remains, fall through to the
+      // existing top-level tab confirmation flow below.
+      if (paneLeafIds.length > 1 && paneLeafIds.includes(activePaneTabId)) {
+        try {
+          await closePane(activePaneTabId)
+        } catch (error) {
+          onError('关闭当前分屏', error)
+        }
+        return
+      }
+
       const isLastSessionTab = visibleWorkspaceTabs.length === 1
       const needsDisconnectConfirm = isTabActivelyConnected(activeSessionTab)
 
@@ -1067,7 +1346,25 @@ export function useWorkspaceTabs({
 
     handledCloseActiveRequestVersionRef.current = closeActiveRequestVersion
     void closeActiveWorkspaceItem()
-  }, [closeActiveRequestVersion])
+  }, [closeActiveRequestVersion, isMainWorkspaceWindow])
+
+  useEffect(() => {
+    if (!isMainWorkspaceWindow || !splitPaneRequest || splitPaneRequest.id === handledSplitPaneRequestIdRef.current) {
+      return
+    }
+
+    handledSplitPaneRequestIdRef.current = splitPaneRequest.id
+    void splitCurrentPaneRef.current(splitPaneRequest.direction)
+  }, [splitPaneRequest, isMainWorkspaceWindow])
+
+  useEffect(() => {
+    if (!isMainWorkspaceWindow || !paneFocusRequest || paneFocusRequest.id === handledPaneFocusRequestIdRef.current) {
+      return
+    }
+
+    handledPaneFocusRequestIdRef.current = paneFocusRequest.id
+    void focusAdjacentPaneRef.current(paneFocusRequest.direction)
+  }, [paneFocusRequest, isMainWorkspaceWindow])
 
   const dismissShortcutCloseConfirm = () => {
     setShortcutCloseConfirm(null)
@@ -1255,6 +1552,9 @@ export function useWorkspaceTabs({
     activeTab,
     activeSession: activeSession as SessionSnapshot | null,
     activeProfile: activeProfile as ConnectionProfile | null,
+    activePaneTab,
+    activePaneSession: activePaneSession as SessionSnapshot | null,
+    activePaneProfile: activePaneProfile as ConnectionProfile | null,
     workspaceStageKind,
     isHomeWorkspaceVisible,
     isActiveRemoteSessionConnected,
@@ -1285,7 +1585,12 @@ export function useWorkspaceTabs({
     updateTerminalDockSendState,
     updateTerminalDockSendScope,
     updateTerminalDockSelectedTabIds,
-    sendTerminalCommand
+    sendTerminalCommand,
+    splitPane,
+    splitCurrentPane,
+    closePane,
+    activatePane,
+    setPaneWeights
   }
 }
 

--- a/apps/tauri/src/renderer/i18n.ts
+++ b/apps/tauri/src/renderer/i18n.ts
@@ -29,6 +29,8 @@ const zhCN = {
   findCaseSensitive: '区分大小写',
   findRegex: '使用正则表达式',
   clearScreen: '清屏',
+  splitVertically: '垂直分屏',
+  splitHorizontally: '水平分屏',
   findPrompt: '查找终端内容',
   findNotFound: '未找到匹配内容。',
   findResultLine: '第 {line} 行',
@@ -270,6 +272,9 @@ const zhCN = {
   enableExecChannel: '启用后台命令通道（Exec）',
   enableExecChannelHint:
     '用于读取系统信息、root 文件视图、终端目录跟随和用户状态同步。它会额外建立一条 SSH 命令连接；仅在连接后立即断开时才建议关闭。',
+  legacyAlgorithms: '兼容旧服务器算法（SHA-1）',
+  legacyAlgorithmsHint:
+    '老服务器（OpenSSH 4.x/5.x 时代）只支持 SHA-1 类 MAC/KEX，默认仅 SHA-2 会导致握手被拒。开启后追加 SHA-1 算法到列表末尾，SHA-2 仍优先；仅在连接失败时启用。',
   autoReconnect: '断线后自动重连',
   autoReconnectHint: '会话意外断线时后台自动重新连接，适合需要长期保持的后台会话。主动关闭标签不会触发重连。',
   reconnectEnter: '回车重连',
@@ -735,6 +740,8 @@ const enUS: typeof zhCN = {
   findCaseSensitive: 'Match case',
   findRegex: 'Use regular expression',
   clearScreen: 'Clear Screen',
+  splitVertically: 'Split Vertically',
+  splitHorizontally: 'Split Horizontally',
   findPrompt: 'Find in terminal',
   findNotFound: 'No match found.',
   findResultLine: 'Line {line}',
@@ -975,6 +982,9 @@ const enUS: typeof zhCN = {
   enableExecChannel: 'Enable background command channel (Exec)',
   enableExecChannelHint:
     'Used for system info, root file access, terminal directory following, and user-state sync. It opens one additional SSH command connection; turn it off only if the login disconnects immediately.',
+  legacyAlgorithms: 'Legacy server algorithms (SHA-1)',
+  legacyAlgorithmsHint:
+    'Old servers (OpenSSH 4.x/5.x era) only support SHA-1 MAC/KEX; the default SHA-2-only list causes handshake rejection. When enabled, SHA-1 algorithms are appended to the end of the preference list while SHA-2 stays preferred. Enable only if the connection fails.',
   autoReconnect: 'Auto-reconnect on disconnect',
   autoReconnectHint:
     'Automatically reconnects in the background when the session drops unexpectedly. Closing the tab intentionally will not trigger a reconnect.',

--- a/apps/tauri/src/renderer/main.tsx
+++ b/apps/tauri/src/renderer/main.tsx
@@ -4,7 +4,7 @@ import { App } from './App'
 import { ErrorBoundary } from './features/common/ErrorBoundary'
 import { createTauriApi } from '../bridge/tauri-api'
 import { getCurrentWindow } from '@tauri-apps/api/window'
-import { t } from './i18n'
+import { defaultLocale, setLocale, t } from './i18n'
 import './styles/index.css'
 
 const initialWindowMode = new URLSearchParams(window.location.search).get('window') ?? 'main'
@@ -56,13 +56,47 @@ void createTauriApi()
     // placeholder version, architecture, or platform fields.
     window.fileterm = api
     document.documentElement.dataset.platform = api.platform
-    root.render(
-      <React.StrictMode>
-        <ErrorBoundary>
-          <App />
-        </ErrorBoundary>
-      </React.StrictMode>
-    )
+
+    // Read durable UI preferences before mounting React. App state is then
+    // initialized from the saved values instead of briefly using defaults and
+    // writing those defaults back over the persisted file.
+    void api
+      .getUiPreferences()
+      .catch((error: unknown) => {
+        console.warn('Failed to load UI preferences:', error)
+        return undefined
+      })
+      .then((initialUiPreferences) => {
+        const searchParams = new URLSearchParams(window.location.search)
+        const queryTheme = searchParams.get('theme')
+        const initialTheme =
+          queryTheme === 'default-light' || queryTheme === 'default-dark'
+            ? queryTheme
+            : initialUiPreferences?.theme === 'default-light' || initialUiPreferences?.theme === 'default-dark'
+              ? initialUiPreferences.theme
+              : 'default-dark'
+        const queryLocale = searchParams.get('locale')
+        const initialLocale =
+          queryLocale === 'enUS' || queryLocale === 'zhCN'
+            ? queryLocale
+            : initialUiPreferences?.locale === 'enUS' || initialUiPreferences?.locale === 'zhCN'
+              ? initialUiPreferences.locale
+              : defaultLocale
+
+        // Apply the loaded values before the first React render so CSS and the
+        // proxy-backed translation table agree with App's initial state.
+        document.documentElement.dataset.theme = initialTheme
+        document.documentElement.style.colorScheme = initialTheme === 'default-light' ? 'light' : 'dark'
+        setLocale(initialLocale)
+
+        root.render(
+          <React.StrictMode>
+            <ErrorBoundary>
+              <App initialUiPreferences={initialUiPreferences} />
+            </ErrorBoundary>
+          </React.StrictMode>
+        )
+      })
   })
   .catch((error: unknown) => {
     console.error('Failed to initialize the Tauri desktop bridge:', error)

--- a/apps/tauri/src/renderer/styles/features/commands.css
+++ b/apps/tauri/src/renderer/styles/features/commands.css
@@ -419,7 +419,7 @@
   container-name: command-history-head;
   padding: 0 8px 0 12px;
   border-bottom: 1px solid var(--border-light);
-  background: #161616;
+  background: var(--command-history-head-bg);
 }
 
 .command-temporary-history-title {

--- a/apps/tauri/src/renderer/styles/features/modal-components.css
+++ b/apps/tauri/src/renderer/styles/features/modal-components.css
@@ -158,7 +158,7 @@
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   overflow: hidden;
-  background: rgb(27, 27, 27) !important;
+  background: var(--bg-card) !important;
 }
 
 .file-permission-dialog__header {
@@ -224,7 +224,7 @@
   height: 42px;
   border-radius: 8px;
   border: 1px solid var(--border-light);
-  background: rgb(26, 26, 26);
+  background: var(--input-bg);
   color: var(--primary);
   flex: 0 0 auto;
 }
@@ -268,7 +268,7 @@
 .file-permission-dialog__apply-option,
 .file-permission-dialog__mode-hint {
   border: 1px solid var(--border-light);
-  background: rgb(26, 26, 26);
+  background: var(--input-bg);
   box-shadow: none;
 }
 
@@ -303,7 +303,7 @@
   padding: 9px 10px;
   border: 1px solid var(--border-light);
   border-radius: 0;
-  background: rgb(26, 26, 26);
+  background: var(--input-bg);
 }
 
 .file-permission-dialog__matrix-label {
@@ -402,7 +402,7 @@
   padding: 0 10px;
   border-radius: 4px;
   border: 1px solid color-mix(in srgb, var(--copy-link) 42%, var(--border-light));
-  background: rgb(26, 26, 26);
+  background: var(--input-bg);
   color: var(--copy-link);
   font-family: 'Geist Mono', 'JetBrains Mono', Monaco, monospace;
   font-size: 16px;

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -1540,7 +1540,7 @@
   grid-template-rows: auto minmax(0, 1fr);
   gap: 0;
   padding: 0;
-  background: rgb(27, 27, 27) !important;
+  background: var(--bg-card) !important;
   overflow: hidden;
 }
 
@@ -1686,7 +1686,7 @@
   padding: 0 14px;
   border: 1px solid var(--border-light);
   border-radius: 4px;
-  background: rgb(26, 26, 26);
+  background: var(--input-bg);
   color: var(--text-main);
   font: inherit;
   font-size: 14px;
@@ -1734,7 +1734,7 @@
   padding: 10px 12px;
   border: 1px solid var(--border-light);
   border-radius: 0;
-  background: rgb(26, 26, 26);
+  background: var(--input-bg);
   font-size: 12px;
 }
 
@@ -2949,7 +2949,7 @@
 .modal-card.ssh-tunnel-dialog {
   width: min(560px, calc(100vw - 40px));
   padding: 0 !important;
-  background: rgb(27, 27, 27) !important;
+  background: var(--bg-card) !important;
   overflow: hidden;
 }
 .ssh-tunnel-dialog-header {
@@ -3020,7 +3020,7 @@
   border-radius: 4px;
   padding: 0 14px;
   color: var(--text-main);
-  background: rgb(26, 26, 26);
+  background: var(--input-bg);
   font: inherit;
   font-size: 14px;
 }
@@ -3048,7 +3048,7 @@
   padding: 10px 12px;
   border: 1px solid var(--border-light);
   border-left: 2px solid var(--copy-link);
-  background: rgb(26, 26, 26);
+  background: var(--input-bg);
   color: var(--text-secondary) !important;
   font-size: 12px !important;
   line-height: 1.6;
@@ -3192,4 +3192,141 @@
   .ssh-tunnel-state {
     display: none;
   }
+}
+
+/* ==========================================
+ * 分屏布局（Split Pane Layout）
+ * ========================================== */
+.split-pane-root {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  background: var(--terminal-bg);
+  overflow: hidden;
+}
+
+.split-pane-container {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.split-pane-container--row {
+  flex-direction: row;
+}
+
+.split-pane-container--column {
+  flex-direction: column;
+}
+
+.split-pane-child {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.split-pane-resizer {
+  flex: 0 0 8px;
+  background: transparent;
+  position: relative;
+  z-index: 2;
+}
+
+.split-pane-resizer::after {
+  position: absolute;
+  content: '';
+  background: var(--border-light);
+  transition:
+    background 0.16s ease,
+    box-shadow 0.16s ease;
+}
+
+.split-pane-resizer:hover,
+.split-pane-resizer:active {
+  z-index: 3;
+}
+
+.split-pane-resizer:hover::after,
+.split-pane-resizer:active::after {
+  background: var(--accent-primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-primary) 28%, transparent);
+}
+
+.split-pane-resizer--row {
+  cursor: col-resize;
+  width: 8px;
+}
+
+.split-pane-resizer--row::after {
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  transform: translateX(-50%);
+}
+
+.split-pane-resizer--column {
+  cursor: row-resize;
+  height: 8px;
+  width: 100%;
+}
+
+.split-pane-resizer--column::after {
+  top: 50%;
+  right: 0;
+  left: 0;
+  height: 1px;
+  transform: translateY(-50%);
+}
+
+.split-pane-leaf {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  background: var(--terminal-bg);
+  box-shadow: inset 0 0 0 1px transparent;
+}
+
+.split-pane-leaf--active {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-primary) 72%, transparent);
+}
+
+.split-pane-leaf-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 8;
+  opacity: 0;
+  pointer-events: none;
+  background: color-mix(in srgb, var(--bg-card) 82%, transparent);
+  box-shadow: var(--shadow-sm);
+  transition: opacity 0.16s ease;
+}
+
+.split-pane-leaf:hover .split-pane-leaf-close,
+.split-pane-leaf:focus-within .split-pane-leaf-close {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.split-pane-terminal {
+  flex: 1 1 auto;
+  min-height: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.split-pane-terminal .terminal-host,
+.split-pane-terminal .terminal-host > div,
+.split-pane-terminal .xterm {
+  width: 100%;
+  height: 100%;
 }

--- a/apps/tauri/src/renderer/styles/features/shell.css
+++ b/apps/tauri/src/renderer/styles/features/shell.css
@@ -569,14 +569,28 @@
   stroke-width: 1.9;
 }
 
-.process-table {
+.process-scroll-region {
+  position: relative;
   height: 96px;
   min-height: 96px;
   max-height: 96px;
-  border: 1px solid var(--border-light);
-  border-top: 0;
+  margin: 0 -12px;
   min-width: 0;
-  overflow: hidden auto;
+  overflow: hidden;
+}
+
+.process-table {
+  height: 100%;
+  min-height: 0;
+  max-height: none;
+  min-width: 0;
+  overflow: auto;
+  scrollbar-width: none;
+}
+
+.process-table::-webkit-scrollbar {
+  width: 0;
+  height: 0;
 }
 
 .process-row {
@@ -589,10 +603,14 @@
 }
 
 .process-row span {
-  padding: 2px 8px;
+  padding: 2px 6px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.process-row span:last-child {
+  padding-right: 0;
 }
 
 .process-empty {

--- a/apps/tauri/src/renderer/styles/features/workstation-skin.css
+++ b/apps/tauri/src/renderer/styles/features/workstation-skin.css
@@ -576,13 +576,26 @@ textarea:focus-visible,
     color 0.18s ease;
 }
 
-.process-table {
+.process-scroll-region {
   height: 96px;
   min-height: 96px;
   max-height: 96px;
   margin: 0 -12px;
-  border: 0;
-  overflow: hidden auto;
+  overflow: hidden;
+}
+
+.process-table {
+  height: 100%;
+  min-height: 0;
+  max-height: none;
+  margin: 0;
+  overflow: auto;
+  scrollbar-width: none;
+}
+
+.process-table::-webkit-scrollbar {
+  width: 0;
+  height: 0;
 }
 
 .process-row {
@@ -596,6 +609,10 @@ textarea:focus-visible,
   padding: 2px 6px;
   font-variant-numeric: tabular-nums;
   text-align: center;
+}
+
+.process-row span:last-child {
+  padding-right: 0;
 }
 
 .process-row span:nth-child(2) {

--- a/apps/tauri/src/renderer/styles/themes/default-dark.css
+++ b/apps/tauri/src/renderer/styles/themes/default-dark.css
@@ -11,6 +11,9 @@
   --bg-active: #3a3d42;
   --manager-head-bg: #242424;
   --input-bg: #1a1a1a;
+  --command-history-head-bg: #161616;
+  --surface-panel: var(--bg-card);
+  --border-subtle: var(--border-light);
 
   --border-light: rgba(255, 255, 255, 0.08);
   --border-dark: rgba(255, 255, 255, 0.16);

--- a/apps/tauri/src/renderer/styles/themes/default-light.css
+++ b/apps/tauri/src/renderer/styles/themes/default-light.css
@@ -9,6 +9,9 @@
   --bg-active: #dde2e8;
   --manager-head-bg: #f3f6fa;
   --input-bg: #f7f8fa;
+  --command-history-head-bg: var(--surface-table-head);
+  --surface-panel: var(--bg-card);
+  --border-subtle: var(--border-light);
 
   --border-light: rgba(15, 23, 42, 0.16);
   --border-dark: rgba(15, 23, 42, 0.28);

--- a/docs/plans/active/split-pane.md
+++ b/docs/plans/active/split-pane.md
@@ -1,0 +1,283 @@
+# 分屏（Split Pane）功能计划
+
+## 目标
+
+在 SSH session 的**终端区域内**支持分屏；系统信息侧栏、顶部 tab、文件面板和命令面板保持单一工作区，不随 pane 复制。每个 pane 是**复用当前 profile 新建的一个独立 session**，不共享 PTY。
+
+## 快捷键
+
+| 操作                | macOS         | Windows / Linux                                   |
+| ------------------- | ------------- | ------------------------------------------------- |
+| 新建标签页          | `Cmd+T`       | `Ctrl+Shift+T`                                    |
+| 垂直分屏（左右）    | `Cmd+D`       | Windows: `Alt+Shift+D`；Linux: `Ctrl+Shift+D`     |
+| 水平分屏（上下）    | `Cmd+Shift+D` | Windows: `Alt+Shift+-`；Linux: `Ctrl+Alt+Shift+D` |
+| 关闭当前 pane / tab | `Cmd+W`       | 平台原生关闭快捷键                                |
+| 切换 pane 焦点      | —             | Windows: `Alt+方向键`                             |
+
+注册位置：Tauri 原生菜单 accelerator（View 菜单），与现有 `Cmd+W` 一致。终端聚焦时前端键盘事件会被 xterm 拦截，原生菜单加速器全局有效。
+
+终端右键菜单也显示“垂直分屏 / 水平分屏”及当前客户端对应的快捷键。菜单通过 Tauri bridge 的平台字段区分 macOS、Windows、Linux；从某个 pane 的右键菜单触发时，始终以该 pane 为 source，不依赖此前的焦点。
+
+## 数据模型
+
+### PaneNode（新增，packages/core）
+
+```ts
+export type SplitDirection = 'row' | 'column'
+
+export type PaneNode =
+  | { kind: 'leaf'; tabId: string }
+  | {
+      kind: 'split'
+      direction: SplitDirection
+      children: PaneNode[]
+      weights: number[] // 每个子节点的占比，和为 1；拖拽时更新
+    }
+```
+
+- `row` = 左右分（垂直分屏）
+- `column` = 上下分（水平分屏）
+- 每个 leaf 引用一个真实 `WorkspaceTab` id
+
+### WorkspaceTab 扩展
+
+`packages/core` 的 `WorkspaceTab` 新增可选字段：
+
+```ts
+export interface WorkspaceTab {
+  id: string
+  sessionType: SessionType
+  profileId: string
+  title: string
+  layout: TabLayout
+  status: TabStatus
+  paneRoot?: PaneNode // 分屏树根节点；普通 tab 无此字段
+  paneRootTabId?: string // leaf 所属 root；leaf 永不显示为顶部 tab
+}
+```
+
+只有「分屏的根 tab」才持有 `paneRoot`，被引用的 leaf tab 自己不持 `paneRoot`。
+
+### 活跃 pane
+
+`WorkspaceSnapshot` 新增：
+
+```ts
+export interface WorkspaceSnapshot {
+  // ...
+  activePaneTabIdByRoot: Record<string, string> // rootTabId -> 当前活跃 leaf tabId
+}
+```
+
+用于终端输入、文件操作、命令发送的目标定位。
+
+### 工作区辅助面板归属
+
+- **终端本身与终端命令栏**跟随当前活跃 pane。
+- **系统信息侧栏、远端文件面板、文件编辑器与传输中心**固定绑定顶级 root tab 的原始 session，不随 pane 焦点切换。
+- 新建 split pane 会启动独立 shell；系统信息和文件面板仍只绑定当前 root。分屏 session 保留资源监控能力，这样原始 root 被关闭并提升其他 pane 时，新的 root 可以继续提供实时系统信息。
+
+## 后端改动
+
+### 新增 command: `app_split_tab`
+
+```rust
+#[tauri::command]
+pub async fn app_split_tab(
+    app: AppHandle,
+    source_tab_id: String,
+    direction: String,  // "row" | "column"
+) -> Result<serde_json::Value, AppError>
+```
+
+流程：
+
+1. 读 source tab，拿到 `profile_id`
+2. 读 profiles.json，找到 profile
+3. 生成新 tab_id，构造 `WorkspaceTab`（layout 同 source）
+4. 创建新 session snapshot、worker、terminal input、cancel token（复用 `app_open_profile` 的核心逻辑，抽取 `spawn_session_for_profile` helper）
+5. 更新 `paneRoot`：
+   - 若 source tab 有 `paneRoot`：把 source 作为 leaf，和新 leaf 组成 split，挂回 source root
+   - 若 source tab 无 `paneRoot`：source 变成 root，`paneRoot` = split(source_leaf, new_leaf)
+   - **注意**：被分屏的 source tab 本身可能就是某个 root 的 leaf。这时 split 发生在 source 所在的 pane 位置，需要在 pane tree 里替换该 leaf 为 split(source_leaf, new_leaf)
+6. 保持 `active_tab_id` 为分屏 root tab，并设置 `activePaneTabIdByRoot[root]` 为新 pane
+7. `get_workspace_snapshot_and_emit`
+
+### 新增 command: `app_close_pane`
+
+```rust
+#[tauri::command]
+pub async fn app_close_pane(
+    app: AppHandle,
+    root_tab_id: String,
+    pane_tab_id: String,
+) -> Result<serde_json::Value, AppError>
+```
+
+流程：
+
+1. 在 `paneRoot` 树中找到 `pane_tab_id`，移除该 leaf
+2. 清理 session worker、tabs、sessions（复用 `stop_session_worker`）
+3. 规整 pane tree：
+   - split 只剩一个子节点时，用唯一子节点替换该 split
+   - 若 root 的 paneRoot 只剩一个 leaf，清掉 `paneRoot`，退化回普通 tab
+   - 若关闭的是原 root 对应的 leaf，提升一个存活 leaf 为新 root，并重新绑定其余 leaf；绝不保留指向已关闭终端的 root
+4. 更新 `activePaneTabIdByRoot`
+5. `get_workspace_snapshot_and_emit`
+
+### 新增 command: `app_set_active_pane`
+
+```rust
+#[tauri::command]
+pub async fn app_set_active_pane(
+    app: AppHandle,
+    root_tab_id: String,
+    pane_tab_id: String,
+) -> Result<serde_json::Value, AppError>
+```
+
+只更新 `activePaneTabIdByRoot[root] = pane_tab_id`。
+
+### 新增 command: `app_set_pane_weights`
+
+```rust
+#[tauri::command]
+pub async fn app_set_pane_weights(
+    app: AppHandle,
+    root_tab_id: String,
+    pane_path: Vec<usize>,
+    weights: Vec<f32>,
+) -> Result<serde_json::Value, AppError>
+```
+
+拖拽 resize 结束时持久化 weights。`pane_path` 是从根 split 到目标 split 的 child index 路径，避免嵌套的两个二分 split 互相覆盖权重。
+
+### 关闭 tab 链路调整
+
+`app_close_tab` 关闭的若是分屏 root，需要关闭整个 pane tree 的所有 leaf；若是 leaf，等价于 `app_close_pane`。
+
+### snapshot 输出
+
+`get_workspace_snapshot_unlocked` 增加 `activePaneTabIdByRoot` 字段。
+
+## Bridge 改动
+
+`apps/tauri/src/bridge/tauri-api.ts` 新增：
+
+```ts
+splitTab: (sourceTabId: string, direction: 'row' | 'column') =>
+  invoke<WorkspaceSnapshot>('app_split_tab', { sourceTabId, direction }),
+closePane: (rootTabId: string, paneTabId: string) =>
+  invoke<WorkspaceSnapshot>('app_close_pane', { rootTabId, paneTabId }),
+setActivePane: (rootTabId: string, paneTabId: string) =>
+  invoke<WorkspaceSnapshot>('app_set_active_pane', { rootTabId, paneTabId }),
+setPaneWeights: (rootTabId: string, panePath: number[], weights: number[]) =>
+  invoke<WorkspaceSnapshot>('app_set_pane_weights', { rootTabId, panePath, weights }),
+```
+
+`FileTermDesktopApi` 接口同步补齐。
+
+## Renderer 改动
+
+### 新增组件 `SplitPaneLayout.tsx`
+
+位置：`apps/tauri/src/renderer/features/workspace/SplitPaneLayout.tsx`
+
+- 递归渲染 `PaneNode`
+- `SessionWorkspace` 保留为共享外壳；leaf 只渲染 `TerminalView`
+- split 渲染两个子容器 + 一个 resizer div（复用现有 `session-split-resizer` 样式思路）
+- 拖拽 resizer 时只改前端 state，drag end 调 `setPaneWeights`
+
+### WorkspaceStage / SessionWorkspace 改造
+
+```tsx
+<SessionWorkspace
+  splitRootTab={activeTab?.paneRoot ? activeTab : undefined}
+  activeTab={activePaneTab}
+  ...
+/>
+```
+
+`SplitPaneLayout` 仅挂在 `SessionWorkspace` 的 terminal area；根 tab 仍显示在顶部 TabBar，分屏产生的 leaf tab 不单独显示为顶部标签。
+
+### useWorkspaceTabs 扩展
+
+新增 `splitCurrentPane(direction)`、`closePane(tabId)`、`activatePane(tabId)`，调用 bridge。
+
+### 活跃 pane 焦点
+
+- 点击 pane 内任意区域时调 `setActivePane`
+- 终端 `TerminalView` 聚焦时也触发 `setActivePane`
+- `Cmd+W`：分屏仍有多个 pane 时直接关闭当前活跃 pane，并把焦点交给下一个 pane；只剩一个 pane 时才走顶级 tab 的既有二次确认流程
+
+## 快捷键菜单项
+
+在 `apps/tauri/src-tauri/src/lib.rs` 的 View 菜单加：
+
+```rust
+let split_vertical = MenuItemBuilder::with_id(
+    "view-split-vertical",
+    localized(is_english, "Split Vertically", "垂直分屏"),
+)
+.accelerator(if cfg!(target_os = "macos") { "Cmd+D" } else { "Ctrl+Shift+D" })
+.build(app)?;
+
+let split_horizontal = MenuItemBuilder::with_id(
+    "view-split-horizontal",
+    localized(is_english, "Split Horizontally", "水平分屏"),
+)
+.accelerator(if cfg!(target_os = "macos") { "Cmd+Shift+D" } else { "Ctrl+Alt+Shift+D" })
+.build(app)?;
+```
+
+`on_menu_event` 分发：
+
+```rust
+"view-split-vertical" => {
+    if let Some(window) = focused_webview_window(app) {
+        let _ = window.emit("app:split-pane-request", "row");
+    }
+}
+"view-split-horizontal" => {
+    if let Some(window) = focused_webview_window(app) {
+        let _ = window.emit("app:split-pane-request", "column");
+    }
+}
+```
+
+bridge 暴露 `onSplitPaneRequest`，renderer 收到后调 `splitCurrentPane(direction)`。
+
+## 边界约束
+
+1. **FTP tab 不支持分屏**：FTP 无终端，快捷键对 `file-only` layout 不响应。
+2. **首页 tab / system info tab 不支持分屏**：这些不是 session tab。
+3. **tab 标题**：分屏 root 的 tab 标题显示第一个 leaf 的 session 标题。
+4. **MaxSessions**：同一 SSH host 多 session 可能触发 MaxSessions 限制，新 session 创建失败时要在 pane 里展示错误，不影响已有 pane。
+5. **关闭确认**：关闭分屏中的非最后一个 leaf 不弹窗；关闭最后一个 pane（即关闭顶级 tab）才走 `shortcutCloseConfirm`（如果有活跃连接）。
+6. **拖拽 resize**：参考现有 `session-split-resizer` 实现，不引入 `react-resizable-panels`（architecture.md 已决定不引入）。
+
+## 实施阶段
+
+1. **Phase 1**：`packages/core` 加 `PaneNode`、`SplitDirection` 类型，扩展 `WorkspaceTab`、`WorkspaceSnapshot`。
+2. **Phase 2**：Rust 后端加 `PaneNode`/`PaneLayout` 镜像类型、`app_split_tab`/`app_close_pane`/`app_set_active_pane`/`app_set_pane_weights` 命令、snapshot 输出扩展。
+3. **Phase 3**：bridge 暴露 4 个新 API + `onSplitPaneRequest` 事件。
+4. **Phase 4**：renderer `SplitPaneLayout` 组件、`WorkspaceStage` 改造、`useWorkspaceTabs` 扩展。
+5. **Phase 5**：拖拽 resize + weights 持久化。
+6. **Phase 6**：快捷键菜单项 + i18n。
+
+## 质量门禁
+
+```bash
+npm run typecheck -w @fileterm/tauri
+npm run lint
+npx prettier --check apps/tauri packages/core packages/shared packages/storage
+npm run test:tauri
+cargo clippy --locked --all-targets --all-features -- -D warnings
+```
+
+## 不做的事
+
+- 不引入 `react-resizable-panels` 或 Zustand。
+- 不做「同一 session 多视图」（共享 PTY），那个方向输入/光标会互相干扰。
+- 不做 pane 之间拖拽重排（后续可加）。
+- 不做 FTP / Telnet / Serial 的分屏（先只 SSH）。

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,23 @@ export type FtpSecurityMode = 'none' | 'explicit' | 'implicit'
 
 export type TabLayout = 'terminal-file' | 'file-only' | 'terminal-only'
 
+/** 分屏方向：row = 左右分（垂直分屏），column = 上下分（水平分屏） */
+export type SplitDirection = 'row' | 'column'
+
+/** 在分屏树中移动焦点的方向。 */
+export type PaneFocusDirection = 'left' | 'right' | 'up' | 'down'
+
+/** 分屏树节点。leaf 引用一个真实 WorkspaceTab id；split 递归持有子节点。 */
+export type PaneNode =
+  | { kind: 'leaf'; tabId: string }
+  | {
+      kind: 'split'
+      direction: SplitDirection
+      children: PaneNode[]
+      /** 每个子节点占比，长度与 children 一致，和为 1。拖拽 resize 时更新。 */
+      weights: number[]
+    }
+
 export type TabStatus = 'idle' | 'connecting' | 'connected' | 'error' | 'closed'
 
 export interface BaseEntity {
@@ -116,6 +133,8 @@ export interface SshProfile extends NetworkProfile {
   jumpProfileId?: string
   forwards?: SshForwardRule[]
   disableShellIntegration?: boolean
+  /** 兼容老服务器：追加 SHA-1 类 MAC/KEX 算法到偏好列表末尾（SHA-2 仍优先） */
+  legacyAlgorithms?: boolean
 }
 
 export interface FtpProfile extends NetworkProfile {
@@ -187,6 +206,10 @@ export interface WorkspaceTab {
   title: string
   layout: TabLayout
   status: TabStatus
+  /** 分屏树根节点；普通 tab 无此字段。只有分屏的根 tab 持有。 */
+  paneRoot?: PaneNode
+  /** 分屏 leaf 所属的顶层 workspace tab；leaf 永不显示在顶栏。 */
+  paneRootTabId?: string
 }
 
 export type WorkspaceSessionTabEvent =
@@ -344,6 +367,8 @@ export interface DirectorySnapshot<TItem> {
 }
 
 export interface SidebarProcessItem {
+  pid: number
+  user: string
   memory: string
   cpu: string
   command: string
@@ -537,6 +562,8 @@ export interface WorkspaceSnapshot {
   activeTabId: string | null
   transfers: TransferTask[]
   sessions: Record<string, SessionSnapshot>
+  /** 分屏 root tabId -> 当前活跃 leaf tabId。用于终端输入/文件操作/命令发送定位。 */
+  activePaneTabIdByRoot?: Record<string, string>
 }
 
 export interface SessionMetricsUpdate {
@@ -687,6 +714,8 @@ export interface CreateProfileInput {
   jumpProfileId?: string
   forwards?: SshForwardRule[]
   disableShellIntegration?: boolean
+  /** 兼容老服务器：追加 SHA-1 类 MAC/KEX 算法到偏好列表末尾（SHA-2 仍优先） */
+  legacyAlgorithms?: boolean
   devicePath?: string
   baudRate?: number
   dataBits?: 5 | 6 | 7 | 8
@@ -954,6 +983,10 @@ export interface FileTermDesktopApi {
   reconnectTab(tabId: string): Promise<WorkspaceSnapshot>
   disconnectTab(tabId: string): Promise<WorkspaceSnapshot>
   closeTab(tabId: string): Promise<WorkspaceSnapshot>
+  splitTab(sourceTabId: string, direction: 'row' | 'column'): Promise<WorkspaceSnapshot>
+  closePane(rootTabId: string, paneTabId: string): Promise<WorkspaceSnapshot>
+  setActivePane(rootTabId: string, paneTabId: string): Promise<WorkspaceSnapshot>
+  setPaneWeights(rootTabId: string, panePath: number[], weights: number[]): Promise<WorkspaceSnapshot>
   listLocalDirectory(dirPath?: string): Promise<DirectorySnapshot<LocalFileItem>>
   connectLocalNetworkShare?(
     path: string,
@@ -1034,6 +1067,9 @@ export interface FileTermDesktopApi {
   onSshInteraction(listener: (request: SshInteractionRequest) => void): () => void
   onWindowCloseRequest(listener: (event: { isQuit: boolean }) => void): () => void
   onRequestCloseActiveWorkspaceItem(listener: () => void): () => void
+  onNewTabRequest(listener: () => void): () => void
+  onSplitPaneRequest(listener: (direction: 'row' | 'column') => void): () => void
+  onFocusPaneRequest(listener: (direction: PaneFocusDirection) => void): () => void
   confirmCloseWindow(action: 'quit' | 'hide' | 'cancel'): Promise<void>
 }
 


### PR DESCRIPTION
## 改动内容

- 在单个顶层工作区内加入终端左右/上下分屏、pane 激活、关闭、调整大小和快捷键支持。
- 让侧栏系统信息、文件区、文件编辑和传输中心保持顶层工作区单例绑定；关闭原始 root pane 时自动提升存活 pane。
- 修复主题、语言和 UI 状态持久化，并补齐白色主题和暗色主题的组件样式。
- 补充 Tauri bridge、核心类型、Rust worker、renderer hooks 和分屏文档。

## 修复原因

此前分屏会误表现为多个顶层 tab，关闭原始 pane 后辅助区域失去连接；进程表还因渲染字段数量与 CSS 列数不一致而出现两行错位。现在分屏只作用于终端区域，辅助区域始终跟随顶层工作区。

## 验证

- `npm run typecheck`
- `npm run lint`
- `npx prettier --check`
- `npm run test:tauri`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
