### PR TITLE
feat: add terminal split shortcuts, refine light theme styling and memory popover hover area

### DIFF
--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -560,7 +560,7 @@ fn workspace_new_tab_accelerator(platform: &str) -> &'static str {
 fn split_pane_accelerators(platform: &str) -> (&'static str, &'static str) {
     match platform {
         "macos" => ("Cmd+D", "Cmd+Shift+D"),
-        "windows" => ("Alt+Shift++", "Alt+Shift+-"),
+        "windows" => ("Alt+Shift+Plus", "Alt+Shift+-"),
         _ => ("Ctrl+Shift+D", "Ctrl+Alt+Shift+D"),
     }
 }
@@ -1670,7 +1670,7 @@ mod tests {
         assert_eq!(split_pane_accelerators("macos"), ("Cmd+D", "Cmd+Shift+D"));
         assert_eq!(
             split_pane_accelerators("windows"),
-            ("Alt+Shift++", "Alt+Shift+-")
+            ("Alt+Shift+Plus", "Alt+Shift+-")
         );
         assert_eq!(
             split_pane_accelerators("linux"),

--- a/apps/tauri/src/renderer/App.tsx
+++ b/apps/tauri/src/renderer/App.tsx
@@ -269,6 +269,7 @@ export function App({ initialUiPreferences }: { initialUiPreferences?: InitialUi
     openSystemInfo,
     splitPane,
     closePane,
+    closeActiveWorkspaceItem,
     activatePane,
     setPaneWeights
   } = useWorkspaceTabs({
@@ -1406,6 +1407,7 @@ export function App({ initialUiPreferences }: { initialUiPreferences?: InitialUi
                 sessions={workspace.sessions}
                 activePaneTabId={activePaneTab?.id}
                 onClosePane={closePane}
+                onCloseTab={closeActiveWorkspaceItem}
                 onSplitPane={splitPane}
                 onActivatePane={activatePane}
                 onSetPaneWeights={setPaneWeights}

--- a/apps/tauri/src/renderer/components/TerminalView.tsx
+++ b/apps/tauri/src/renderer/components/TerminalView.tsx
@@ -128,22 +128,26 @@ export const TerminalView = memo(function TerminalView({
   bootText,
   connected = false,
   connecting = false,
+  isActive = true,
   onStatus,
   onReconnect,
   onActivate,
   onSplitPane,
   onClosePane,
+  onCloseTab,
   canClosePane = false
 }: {
   tabId: string
   bootText: string
   connected?: boolean
   connecting?: boolean
+  isActive?: boolean
   onStatus?(message: string | null): void
   onReconnect?(): void | Promise<void>
   onActivate?(): void
   onSplitPane?(direction: SplitPaneDirection): void
   onClosePane?(): void
+  onCloseTab?(): void
   canClosePane?: boolean
 }) {
   const hostRef = useRef<HTMLDivElement | null>(null)
@@ -180,6 +184,10 @@ export const TerminalView = memo(function TerminalView({
   const tabIdRef = useRef(tabId)
   const onStatusRef = useRef(onStatus)
   const onReconnectRef = useRef(onReconnect)
+  const onSplitPaneRef = useRef(onSplitPane)
+  const onClosePaneRef = useRef(onClosePane)
+  const onCloseTabRef = useRef(onCloseTab)
+  const canClosePaneRef = useRef(canClosePane)
   const isReconnectingRef = useRef(false)
   const activeTerminalTabIdRef = useRef<string | null>(null)
   tabIdRef.current = tabId
@@ -187,6 +195,10 @@ export const TerminalView = memo(function TerminalView({
   connectingRef.current = Boolean(connecting)
   onStatusRef.current = onStatus
   onReconnectRef.current = onReconnect
+  onSplitPaneRef.current = onSplitPane
+  onClosePaneRef.current = onClosePane
+  onCloseTabRef.current = onCloseTab
+  canClosePaneRef.current = canClosePane
   const [hasSelection, setHasSelection] = useState(false)
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
   const [findOpen, setFindOpen] = useState(false)
@@ -201,6 +213,7 @@ export const TerminalView = memo(function TerminalView({
   const [findCaseSensitive, setFindCaseSensitive] = useState(false)
   const [findRegex, setFindRegex] = useState(false)
   const isMac = window.fileterm?.platform === 'darwin'
+  const isWin = window.fileterm?.platform === 'win32'
 
   const shortcuts = {
     copy: isMac ? '⌘C' : 'Ctrl+Shift+C',
@@ -215,7 +228,8 @@ export const TerminalView = memo(function TerminalView({
   const buildTerminalTheme = () => ({
     background: readColor('--terminal-bg', '#1e1e1e'),
     foreground: readColor('--terminal-text', '#e0e0e0'),
-    cursor: readColor('--terminal-text', '#e0e0e0'),
+    cursor: readColor('--terminal-cursor', readColor('--accent-primary', '#3b82f6')),
+    cursorAccent: readColor('--terminal-cursor-accent', readColor('--terminal-bg', '#ffffff')),
     green: readColor('--success', '#39d98a'),
     brightGreen: readColor('--success', '#52f2a0'),
     blue: readColor('--accent-text', '#c8d0da'),
@@ -387,11 +401,15 @@ export const TerminalView = memo(function TerminalView({
   }
 
   const runSplitPane = (direction: SplitPaneDirection) => {
-    onSplitPane?.(direction)
+    onSplitPaneRef.current?.(direction)
   }
 
   const runClosePane = () => {
-    onClosePane?.()
+    onClosePaneRef.current?.()
+  }
+
+  const runCloseTab = () => {
+    onCloseTabRef.current?.()
   }
 
   const flushPendingWrite = () => {
@@ -585,6 +603,8 @@ export const TerminalView = memo(function TerminalView({
       fontSize: 12,
       lineHeight: 1.05,
       cursorBlink: true,
+      cursorStyle: 'bar',
+      cursorWidth: 2,
       allowProposedApi: true,
       allowTransparency: true,
       reflowCursorLine: false,
@@ -695,6 +715,53 @@ export const TerminalView = memo(function TerminalView({
         } else {
           openFind()
         }
+        return false
+      }
+
+      const matchesClose = isMac
+        ? event.metaKey && !event.shiftKey && event.key.toLowerCase() === 'w'
+        : event.ctrlKey && event.shiftKey && event.key.toLowerCase() === 'w'
+
+      if (matchesClose) {
+        event.preventDefault()
+        event.stopPropagation()
+        if (canClosePaneRef.current) {
+          runClosePane()
+        } else {
+          runCloseTab()
+        }
+        return false
+      }
+
+      const matchesSplitVertical = isMac
+        ? event.metaKey && !event.shiftKey && event.key.toLowerCase() === 'd'
+        : isWin
+          ? (event.altKey &&
+              event.shiftKey &&
+              (event.key === '+' || event.key === '=' || event.code === 'Equal' || event.code === 'NumpadAdd')) ||
+            (event.ctrlKey && event.shiftKey && event.key.toLowerCase() === 'd')
+          : event.ctrlKey && event.shiftKey && event.key.toLowerCase() === 'd'
+
+      const matchesSplitHorizontal = isMac
+        ? event.metaKey && event.shiftKey && event.key.toLowerCase() === 'd'
+        : isWin
+          ? (event.altKey &&
+              event.shiftKey &&
+              (event.key === '-' || event.key === '_' || event.code === 'Minus' || event.code === 'NumpadSubtract')) ||
+            (event.ctrlKey && event.altKey && event.shiftKey && event.key.toLowerCase() === 'd')
+          : event.ctrlKey && event.altKey && event.shiftKey && event.key.toLowerCase() === 'd'
+
+      if (matchesSplitVertical) {
+        event.preventDefault()
+        event.stopPropagation()
+        runSplitPane('row')
+        return false
+      }
+
+      if (matchesSplitHorizontal) {
+        event.preventDefault()
+        event.stopPropagation()
+        runSplitPane('column')
         return false
       }
 
@@ -1092,6 +1159,14 @@ export const TerminalView = memo(function TerminalView({
       terminal.dispose()
     }
   }, [isMac])
+
+  useEffect(() => {
+    if (isActive) {
+      window.requestAnimationFrame(() => {
+        terminalRef.current?.focus()
+      })
+    }
+  }, [isActive])
 
   useEffect(() => {
     bootTextRef.current = bootText

--- a/apps/tauri/src/renderer/features/terminal/TerminalDock.tsx
+++ b/apps/tauri/src/renderer/features/terminal/TerminalDock.tsx
@@ -216,18 +216,6 @@ export function TerminalDock({
         return
       }
 
-      if (event.key === 'Alt' && !event.ctrlKey && !event.metaKey && !event.shiftKey && !event.repeat) {
-        event.preventDefault()
-        setPanel((prev) => {
-          const next = prev === 'history' ? null : 'history'
-          if (next !== 'history') {
-            focusTerminal()
-          }
-          return next
-        })
-        return
-      }
-
       if (panel === 'history') {
         if (event.key === 'Escape') {
           event.preventDefault()

--- a/apps/tauri/src/renderer/features/workspace/SessionWorkspace.tsx
+++ b/apps/tauri/src/renderer/features/workspace/SessionWorkspace.tsx
@@ -34,6 +34,7 @@ export function SessionWorkspace({
   splitPaneSessions,
   activePaneTabId,
   onClosePane,
+  onCloseTab,
   onSplitPane,
   onActivatePane,
   onSetPaneWeights,
@@ -103,6 +104,7 @@ export function SessionWorkspace({
   splitPaneSessions: Record<string, SessionSnapshot>
   activePaneTabId?: string
   onClosePane(paneTabId: string): void
+  onCloseTab(): void
   onSplitPane(paneTabId: string, direction: 'row' | 'column'): void
   onActivatePane(paneTabId: string): void
   onSetPaneWeights(panePath: number[], weights: number[]): void
@@ -426,6 +428,7 @@ export function SessionWorkspace({
               sessions={splitPaneSessions}
               activePaneTabId={activePaneTabId}
               onClosePane={onClosePane}
+              onCloseTab={onCloseTab}
               onSplitPane={onSplitPane}
               onActivatePane={onActivatePane}
               onResizeEnd={onSetPaneWeights}
@@ -438,6 +441,7 @@ export function SessionWorkspace({
               connecting={terminalActiveTab.status === 'connecting'}
               onReconnect={reconnectOnEnter}
               onSplitPane={canSplitTerminal ? (direction) => onSplitPane(terminalActiveTab.id, direction) : undefined}
+              onCloseTab={onCloseTab}
             />
           )}
           <TerminalDock

--- a/apps/tauri/src/renderer/features/workspace/SplitPaneLayout.tsx
+++ b/apps/tauri/src/renderer/features/workspace/SplitPaneLayout.tsx
@@ -9,6 +9,7 @@ interface SplitPaneLayoutProps {
   sessions: Record<string, SessionSnapshot>
   activePaneTabId?: string
   onClosePane(paneTabId: string): void
+  onCloseTab(): void
   onSplitPane(paneTabId: string, direction: 'row' | 'column'): void
   onActivatePane(paneTabId: string): void
   onResizeEnd(panePath: number[], weights: number[]): void
@@ -26,6 +27,7 @@ export function SplitPaneLayout({
   sessions,
   activePaneTabId,
   onClosePane,
+  onCloseTab,
   onSplitPane,
   onActivatePane,
   onResizeEnd
@@ -47,6 +49,7 @@ export function SplitPaneLayout({
         panePath={[]}
         activePaneTabId={activePaneTabId}
         onClosePane={onClosePane}
+        onCloseTab={onCloseTab}
         canClosePane={canClosePane}
         onSplitPane={onSplitPane}
         onActivatePane={onActivatePane}
@@ -70,6 +73,7 @@ interface PaneRendererProps {
   panePath: number[]
   activePaneTabId?: string
   onClosePane(paneTabId: string): void
+  onCloseTab(): void
   canClosePane: boolean
   onSplitPane(paneTabId: string, direction: 'row' | 'column'): void
   onActivatePane(paneTabId: string): void
@@ -83,6 +87,7 @@ function PaneRenderer({
   panePath,
   activePaneTabId,
   onClosePane,
+  onCloseTab,
   canClosePane,
   onSplitPane,
   onActivatePane,
@@ -99,8 +104,10 @@ function PaneRenderer({
             bootText={session?.terminalTranscript ?? ''}
             connected={session?.connected ?? false}
             connecting={session?.connected === false}
+            isActive={isActive}
             onSplitPane={(direction) => onSplitPane(node.tabId, direction)}
             onClosePane={() => onClosePane(node.tabId)}
+            onCloseTab={onCloseTab}
             canClosePane={canClosePane}
             onActivate={() => {
               if (!isActive) {
@@ -135,6 +142,7 @@ function PaneRenderer({
       panePath={panePath}
       activePaneTabId={activePaneTabId}
       onClosePane={onClosePane}
+      onCloseTab={onCloseTab}
       canClosePane={canClosePane}
       onSplitPane={onSplitPane}
       onActivatePane={onActivatePane}
@@ -152,6 +160,7 @@ interface SplitContainerProps {
   panePath: number[]
   activePaneTabId?: string
   onClosePane(paneTabId: string): void
+  onCloseTab(): void
   canClosePane: boolean
   onSplitPane(paneTabId: string, direction: 'row' | 'column'): void
   onActivatePane(paneTabId: string): void
@@ -167,6 +176,7 @@ function SplitContainer({
   panePath,
   activePaneTabId,
   onClosePane,
+  onCloseTab,
   canClosePane,
   onSplitPane,
   onActivatePane,
@@ -236,6 +246,7 @@ function SplitContainer({
           panePath={[...panePath, idx]}
           activePaneTabId={activePaneTabId}
           onClosePane={onClosePane}
+          onCloseTab={onCloseTab}
           canClosePane={canClosePane}
           onSplitPane={onSplitPane}
           onActivatePane={onActivatePane}

--- a/apps/tauri/src/renderer/features/workspace/WorkspaceStage.tsx
+++ b/apps/tauri/src/renderer/features/workspace/WorkspaceStage.tsx
@@ -118,6 +118,7 @@ export function WorkspaceStage({
   sessions,
   activePaneTabId,
   onClosePane,
+  onCloseTab,
   onSplitPane,
   onActivatePane,
   onSetPaneWeights
@@ -228,6 +229,7 @@ export function WorkspaceStage({
   sessions: Record<string, SessionSnapshot>
   activePaneTabId?: string
   onClosePane(paneTabId: string): void
+  onCloseTab(): void
   onSplitPane(paneTabId: string, direction: 'row' | 'column'): void
   onActivatePane(paneTabId: string): void
   onSetPaneWeights(panePath: number[], weights: number[]): void
@@ -253,6 +255,7 @@ export function WorkspaceStage({
         splitPaneSessions={sessions}
         activePaneTabId={activePaneTabId}
         onClosePane={onClosePane}
+        onCloseTab={onCloseTab}
         onSplitPane={onSplitPane}
         onActivatePane={onActivatePane}
         onSetPaneWeights={onSetPaneWeights}

--- a/apps/tauri/src/renderer/hooks/useWorkspaceTabs.ts
+++ b/apps/tauri/src/renderer/hooks/useWorkspaceTabs.ts
@@ -1036,6 +1036,13 @@ export function useWorkspaceTabs({
       onBusyChange(true)
       const snapshot = await desktopApi.splitTab(sourceTabId, direction)
       onSnapshot(snapshot)
+      const rootTabId = workspace.activeTabId
+      const newActivePaneId = (rootTabId && snapshot.activePaneTabIdByRoot?.[rootTabId]) ?? snapshot.activeTabId
+      if (newActivePaneId) {
+        window.requestAnimationFrame(() => {
+          window.dispatchEvent(new CustomEvent('fileterm:focus-terminal', { detail: newActivePaneId }))
+        })
+      }
     } catch (error) {
       onError('splitPane', error)
     } finally {
@@ -1121,6 +1128,9 @@ export function useWorkspaceTabs({
     try {
       const snapshot = await desktopApi.setActivePane(rootTabId, paneTabId)
       onSnapshot(snapshot)
+      window.requestAnimationFrame(() => {
+        window.dispatchEvent(new CustomEvent('fileterm:focus-terminal', { detail: paneTabId }))
+      })
     } catch (error) {
       onError('activatePane', error)
     }

--- a/apps/tauri/src/renderer/i18n.ts
+++ b/apps/tauri/src/renderer/i18n.ts
@@ -452,8 +452,8 @@ const zhCN = {
   terminalDockHistoryInsertHint: '按左右方向键选择字段，Enter 插入',
   terminalDockClearList: '清空列表',
   terminalDockHistorySearchPlaceholder: '搜索历史命令...',
-  terminalDockPlaceholderMac: '命令输入（Enter 发送，Shift+Enter 换行，⌥ 打开历史，双击 Cmd 切换）',
-  terminalDockPlaceholderWin: '命令输入（Enter 发送，Shift+Enter 换行，Alt 打开历史，双击 Ctrl 切换）',
+  terminalDockPlaceholderMac: '命令输入（Enter 发送，Shift+Enter 换行，双击 Cmd 切换）',
+  terminalDockPlaceholderWin: '命令输入（Enter 发送，Shift+Enter 换行，双击 Ctrl 切换）',
   terminalDockDisconnect: '断开连接',
   terminalDockReconnect: '重新连接',
   terminalDockShowFilePanel: '显示文件面板',
@@ -1166,10 +1166,8 @@ const enUS: typeof zhCN = {
   terminalDockHistoryInsertHint: 'Use left/right to select a token, press Enter to insert',
   terminalDockClearList: 'Clear list',
   terminalDockHistorySearchPlaceholder: 'Search command history...',
-  terminalDockPlaceholderMac:
-    'Command input (Enter sends, Shift+Enter adds a line, ⌥ opens history, double Cmd toggles)',
-  terminalDockPlaceholderWin:
-    'Command input (Enter sends, Shift+Enter adds a line, Alt opens history, double Ctrl toggles)',
+  terminalDockPlaceholderMac: 'Command input (Enter sends, Shift+Enter adds a line, double Cmd toggles)',
+  terminalDockPlaceholderWin: 'Command input (Enter sends, Shift+Enter adds a line, double Ctrl toggles)',
   terminalDockDisconnect: 'Disconnect',
   terminalDockReconnect: 'Reconnect',
   terminalDockShowFilePanel: 'Show file panel',

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -3292,11 +3292,18 @@
   min-width: 0;
   min-height: 0;
   background: var(--terminal-bg);
-  box-shadow: inset 0 0 0 1px transparent;
 }
 
-.split-pane-leaf--active {
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-primary) 72%, transparent);
+.split-pane-leaf--active::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border: 2px solid var(--accent-primary);
+  pointer-events: none;
+  z-index: 10;
 }
 
 .split-pane-leaf-close {

--- a/apps/tauri/src/renderer/styles/features/shell.css
+++ b/apps/tauri/src/renderer/styles/features/shell.css
@@ -177,6 +177,7 @@
   grid-template-rows: auto 1fr;
   min-height: 0;
   height: 100%;
+  background: var(--bg-sidebar);
 }
 
 .system-sidebar-layout.is-collapsed {

--- a/apps/tauri/src/renderer/styles/features/workstation-skin.css
+++ b/apps/tauri/src/renderer/styles/features/workstation-skin.css
@@ -536,7 +536,12 @@ textarea:focus-visible,
   box-shadow: var(--popover-shadow);
 }
 
-.memory-meter-group .meter-track:hover .memory-hover-popover {
+.memory-meter-group {
+  position: relative;
+  cursor: pointer;
+}
+
+.memory-meter-group:hover .memory-hover-popover {
   display: flex;
 }
 

--- a/apps/tauri/src/renderer/styles/themes/default-dark.css
+++ b/apps/tauri/src/renderer/styles/themes/default-dark.css
@@ -122,6 +122,8 @@
 
   --terminal-bg: #181818;
   --terminal-text: #e0e0e0;
+  --terminal-cursor: #ffffff;
+  --terminal-cursor-accent: #181818;
   --terminal-cmd-bg: rgba(148, 163, 184, 0.16);
   --terminal-search-match-bg: #4b5563;
   --terminal-search-match-ruler: #9ca3af;

--- a/apps/tauri/src/renderer/styles/themes/default-light.css
+++ b/apps/tauri/src/renderer/styles/themes/default-light.css
@@ -1,79 +1,79 @@
 :root[data-theme='default-light'] {
   color-scheme: light;
 
-  --bg-main: #f4f5f7;
-  --bg-sidebar: #ffffff;
+  --bg-main: #ffffff;
+  --bg-sidebar: #f4f4f6;
   --bg-card: #ffffff;
   --bg-elevated: #ffffff;
-  --bg-hover: #eceff3;
-  --bg-active: #dde2e8;
-  --manager-head-bg: #f3f6fa;
-  --input-bg: #f7f8fa;
+  --bg-hover: #e8e8ec;
+  --bg-active: #dddde3;
+  --manager-head-bg: #f4f4f6;
+  --input-bg: #ffffff;
   --command-history-head-bg: var(--surface-table-head);
   --surface-panel: var(--bg-card);
   --border-subtle: var(--border-light);
 
-  --border-light: rgba(15, 23, 42, 0.16);
-  --border-dark: rgba(15, 23, 42, 0.28);
+  --border-light: rgba(0, 0, 0, 0.08);
+  --border-dark: rgba(0, 0, 0, 0.16);
   --border: var(--border-light);
 
-  --text-main: #1f2933;
-  --text-muted: #66717f;
-  --text-soft: #7b8794;
+  --text-main: #18181b;
+  --text-muted: #52525b;
+  --text-soft: #71717a;
   --text-primary: var(--text-main);
   --text-secondary: var(--text-muted);
 
-  --primary: #4f7cff;
-  --primary-hover: #3d69ea;
+  --primary: #3b82f6;
+  --primary-hover: #2563eb;
   --accent-primary: var(--primary);
-  --accent-text: #3f4b59;
+  --accent-text: #27272a;
   --sidebar-active-accent: var(--text-main);
-  --selection-bg: #dfe5ec;
-  --danger: #c93d3d;
-  --success: #168a53;
-  --warning: #b77900;
+  --selection-bg: #e4e4e7;
+  --danger: #dc2626;
+  --success: #16a34a;
+  --warning: #d97706;
 
-  /* 状态语义色:面/边/文本,统一替代散落的红蓝硬编码 */
-  --danger-text: #b93838;
-  --danger-surface: rgba(201, 61, 61, 0.08);
-  --danger-border: rgba(201, 61, 61, 0.26);
+  /* 状态语义色:面/边/文本 */
+  --danger-text: #dc2626;
+  --danger-surface: rgba(220, 38, 38, 0.08);
+  --danger-border: rgba(220, 38, 38, 0.2);
   --info: var(--primary);
-  --info-text: #2f5fef;
-  --info-surface: rgba(79, 124, 255, 0.1);
-  --info-border: rgba(79, 124, 255, 0.28);
-  --input-focus-ring: rgba(79, 124, 255, 0.18);
+  --info-text: #2563eb;
+  --info-surface: rgba(59, 130, 246, 0.08);
+  --info-border: rgba(59, 130, 246, 0.2);
+  --input-focus-ring: rgba(59, 130, 246, 0.18);
 
-  /* accent 色阶(交互高亮)与 success 面/边/文本 */
-  --accent-tint-weak: rgba(79, 124, 255, 0.1);
-  --accent-tint: rgba(79, 124, 255, 0.16);
-  --accent-focus-ring: rgba(79, 124, 255, 0.28);
-  --success-text: #168a53;
-  --success-surface: rgba(22, 138, 83, 0.12);
-  --success-border: rgba(22, 138, 83, 0.28);
+  /* accent 色阶 */
+  --accent-tint-weak: rgba(59, 130, 246, 0.08);
+  --accent-tint: rgba(59, 130, 246, 0.14);
+  --accent-focus-ring: rgba(59, 130, 246, 0.24);
+  --success-text: #16a34a;
+  --success-surface: rgba(22, 163, 74, 0.08);
+  --success-border: rgba(22, 163, 74, 0.2);
 
-  /* 中性叠层(暗色用白色微透,亮色用深色微透) */
-  --surface-hover: rgba(15, 23, 42, 0.05);
-  --surface-chip: rgba(15, 23, 42, 0.08);
-  --surface-inset: rgba(15, 23, 42, 0.03);
-  --surface-inset-border: rgba(15, 23, 42, 0.1);
-  --surface-table-head: rgba(15, 23, 42, 0.04);
-  --surface-nested: rgba(15, 23, 42, 0.035);
-  --floating-drawer-expanded-bg: rgba(255, 255, 255, 0.9);
-  --floating-drawer-expanded-border: rgba(15, 23, 42, 0.16);
-  --floating-drawer-shadow: 0 10px 26px rgba(15, 23, 42, 0.14), 0 1px 2px rgba(15, 23, 42, 0.1);
-  --floating-drawer-trigger-hover-bg: rgba(15, 23, 42, 0.06);
-  --modal-backdrop-bg: rgba(15, 23, 42, 0.28);
-  --modal-card-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
-  --control-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
-  --control-focus-shadow: 0 0 0 2px var(--accent-tint), 0 1px 2px rgba(15, 23, 42, 0.08);
-  --control-inset-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
-  --terminal-dock-shadow: 0 16px 36px rgba(15, 23, 42, 0.16);
-  --terminal-dock-header-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
-  --system-sidebar-toggle-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
-  --system-sidebar-toggle-hover-shadow: 0 10px 22px rgba(15, 23, 42, 0.16);
-  --system-sidebar-frame: rgba(15, 23, 42, 0.32);
-  --system-sidebar-control-border: rgba(15, 23, 42, 0.26);
-  --system-sidebar-divider: rgba(15, 23, 42, 0.18);
+  /* 中性叠层 */
+  --surface-hover: rgba(0, 0, 0, 0.04);
+  --surface-chip: rgba(0, 0, 0, 0.06);
+  --surface-inset: rgba(0, 0, 0, 0.02);
+  --surface-inset-border: rgba(0, 0, 0, 0.08);
+  --surface-table-head: rgba(0, 0, 0, 0.03);
+  --surface-nested: rgba(0, 0, 0, 0.025);
+  --floating-drawer-expanded-bg: rgba(255, 255, 255, 0.94);
+  --floating-drawer-expanded-border: rgba(0, 0, 0, 0.08);
+  --floating-drawer-shadow: 0 10px 26px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06);
+  --floating-drawer-trigger-hover-bg: rgba(0, 0, 0, 0.05);
+  --modal-backdrop-bg: rgba(0, 0, 0, 0.32);
+  --modal-card-shadow: 0 20px 50px rgba(0, 0, 0, 0.12);
+  --control-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --control-focus-shadow: 0 0 0 2px var(--accent-tint), 0 1px 2px rgba(0, 0, 0, 0.05);
+  --control-inset-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
+  --terminal-dock-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
+  --terminal-dock-header-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+  --system-sidebar-toggle-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --system-sidebar-toggle-hover-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  --system-sidebar-frame: rgba(0, 0, 0, 0.08);
+  --system-sidebar-control-border: rgba(0, 0, 0, 0.1);
+  --system-sidebar-divider: rgba(0, 0, 0, 0.06);
   --overview-hero-highlight: rgba(255, 255, 255, 0.02);
   --brand-title-shadow: none;
   --traffic-close: #ff5f57;
@@ -160,6 +160,8 @@
 
   --terminal-bg: #ffffff;
   --terminal-text: #111827;
+  --terminal-cursor: #3b82f6;
+  --terminal-cursor-accent: #ffffff;
   --terminal-cmd-bg: rgba(15, 23, 42, 0.08);
   --terminal-search-match-bg: #f6cf57;
   --terminal-search-match-ruler: #d39b16;
@@ -243,6 +245,9 @@
 :root[data-theme='default-light'] .window-menubar,
 :root[data-theme='default-light'] .standalone-window-titlebar,
 :root[data-theme='default-light'] .file-tabs,
+:root[data-theme='default-light'] .pane-title,
+:root[data-theme='default-light'] .pane-path-bar,
+:root[data-theme='default-light'] .fs-file-table th,
 :root[data-theme='default-light'] .disk-head,
 :root[data-theme='default-light'] .transfer-strip {
   background: var(--bg-sidebar);
@@ -324,15 +329,57 @@
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08) !important;
 }
 
-/* Remove Process Table Outer Border */
-:root[data-theme='default-light'] .system-sidebar-layout .process-table {
-  border: none !important;
+:root[data-theme='default-light'] .system-sidebar-layout,
+:root[data-theme='default-light'] .system-sidebar-layout .sys-card,
+:root[data-theme='default-light'] .system-sidebar-layout .disk-table,
+:root[data-theme='default-light'] .system-sidebar-layout .process-table,
+:root[data-theme='default-light'] .system-sidebar-layout .disk-scroll-region,
+:root[data-theme='default-light'] .system-sidebar-layout .disk-body {
+  background: var(--bg-sidebar);
 }
 
 :root[data-theme='default-light'] .system-sidebar-layout .process-row,
-:root[data-theme='default-light'] .system-sidebar-layout .disk-head,
 :root[data-theme='default-light'] .system-sidebar-layout .disk-row {
   border-bottom-color: var(--system-sidebar-divider);
+}
+
+:root[data-theme='default-light'] .system-sidebar-layout .disk-head {
+  border-top: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--border-light);
+}
+
+/* Light Theme Sidebar Typography Optimization */
+:root[data-theme='default-light'] .system-sidebar-layout,
+:root[data-theme='default-light'] .fs-sidebar {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Microsoft YaHei', sans-serif;
+}
+
+:root[data-theme='default-light'] .system-sidebar-layout .address-line .label,
+:root[data-theme='default-light'] .system-sidebar-layout .metric-line span,
+:root[data-theme='default-light'] .system-sidebar-layout .meter-header span,
+:root[data-theme='default-light'] .system-sidebar-layout .disk-head span {
+  color: #475569;
+  font-weight: 500;
+  font-size: 12px;
+  letter-spacing: 0.01em;
+}
+
+:root[data-theme='default-light'] .system-sidebar-layout .address-line .value,
+:root[data-theme='default-light'] .system-sidebar-layout .metric-line .value,
+:root[data-theme='default-light'] .system-sidebar-layout .metric-chip-summary,
+:root[data-theme='default-light'] .system-sidebar-layout .system-title {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+:root[data-theme='default-light'] .system-sidebar-layout .address-line .value,
+:root[data-theme='default-light'] .system-sidebar-layout .disk-row,
+:root[data-theme='default-light'] .system-sidebar-layout .process-row {
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-variant-numeric: tabular-nums;
 }
 
 :root[data-theme='default-light'] .window-menu-items button:hover,
@@ -359,9 +406,6 @@
   color: var(--window-control-danger-text);
 }
 
-:root[data-theme='default-light'] .sys-card,
-:root[data-theme='default-light'] .disk-table,
-:root[data-theme='default-light'] .process-table,
 :root[data-theme='default-light'] .quick-panel,
 :root[data-theme='default-light'] .modal-card,
 :root[data-theme='default-light'] .manager-table,
@@ -579,11 +623,11 @@
 
 :root[data-theme='default-light'] .network-guide {
   fill: none;
-  stroke: rgba(255, 255, 255, 0.16);
+  stroke: rgba(15, 23, 42, 0.12);
 }
 
 :root[data-theme='default-light'] .network-guide.minor {
-  stroke: rgba(255, 255, 255, 0.08);
+  stroke: rgba(15, 23, 42, 0.05);
 }
 
 :root[data-theme='default-light'] .network-path {
@@ -748,15 +792,22 @@
 }
 
 :root[data-theme='default-light'] .fs-file-table th {
-  background: #f3f6fa;
+  background: var(--manager-head-bg);
   color: var(--text-muted);
+}
+
+:root[data-theme='default-light'] .process-row:nth-child(odd),
+:root[data-theme='default-light'] .disk-row:nth-child(odd),
+:root[data-theme='default-light'] .system-table tbody tr:nth-child(odd),
+:root[data-theme='default-light'] .fs-file-table tbody tr:nth-child(odd) {
+  background: #ffffff;
 }
 
 :root[data-theme='default-light'] .process-row:nth-child(even),
 :root[data-theme='default-light'] .disk-row:nth-child(even),
 :root[data-theme='default-light'] .system-table tbody tr:nth-child(even),
 :root[data-theme='default-light'] .fs-file-table tbody tr:nth-child(even) {
-  background: rgba(148, 163, 184, 0.06);
+  background: #f6f7f9;
 }
 
 :root[data-theme='default-light'] .file-icon,


### PR DESCRIPTION
## Summary of Changes
- **Shortcuts & Hotkeys**: Added Windows split pane shortcuts (\Alt+Shift++\ / \Alt+Shift+-\, \Ctrl+Shift+D\ / \Ctrl+Alt+Shift+D\) and tab/pane close shortcut (\Ctrl+Shift+W\ / \Cmd+W\).
- **Terminal Cursor Modernization**: Upgraded xterm cursor in \TerminalView.tsx\ to 2px bar style (\cursorStyle: 'bar'\), configured light theme cursor (\#3b82f6\) and dark theme cursor (\#ffffff\).
- **Active Split Border**: Added \.split-pane-leaf--active::after\ overlay border to overcome xterm canvas clipping.
- **Light Theme Alignment**: Aligned sidebar color (\#f4f4f6\), workspace background (\#ffffff\), file manager headers, and eliminated zebra striping row color misalignment.
- **Memory Hover Popover**: Expanded hover detection area to \.memory-meter-group:hover\ covering memory labels, status dot, usage values, percentages, and progress tracks.
- **Light Theme Typography**: Refined light theme sidebar typography, font smoothing, and tabular numeric alignment for system metrics.