### PR TITLE
fix: preserve top-level tab position when closing a split pane

### DIFF
--- a/apps/tauri/src-tauri/src/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/mod.rs
@@ -1436,7 +1436,7 @@ fn remove_split_pane_from_tabs(
             AppError::Storage(format!("Promoted pane tab not found: {promoted_root_tab_id}"))
         })?;
 
-    let promoted_tab = &mut tabs[promoted_idx];
+    let mut promoted_tab = tabs.remove(promoted_idx);
     promoted_tab.pane_root_tab_id = None;
     promoted_tab.pane_root = keeps_split.then_some(next_pane_root);
 
@@ -1445,6 +1445,9 @@ fn remove_split_pane_from_tabs(
             tab.pane_root_tab_id = Some(promoted_root_tab_id.clone());
         }
     }
+
+    let insert_idx = root_idx.min(tabs.len());
+    tabs.insert(insert_idx, promoted_tab);
 
     Ok(PaneCloseOutcome {
         root_tab_id: promoted_root_tab_id,

--- a/apps/tauri/src-tauri/src/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/mod.rs
@@ -1433,7 +1433,9 @@ fn remove_split_pane_from_tabs(
         .iter()
         .position(|tab| tab.id == promoted_root_tab_id)
         .ok_or_else(|| {
-            AppError::Storage(format!("Promoted pane tab not found: {promoted_root_tab_id}"))
+            AppError::Storage(format!(
+                "Promoted pane tab not found: {promoted_root_tab_id}"
+            ))
         })?;
 
     let mut promoted_tab = tabs.remove(promoted_idx);

--- a/apps/tauri/src/renderer/hooks/useWorkspaceTabs.ts
+++ b/apps/tauri/src/renderer/hooks/useWorkspaceTabs.ts
@@ -481,6 +481,25 @@ export function useWorkspaceTabs({
         }
       }
 
+      if (missing.length > 0) {
+        const removedKeys = previousOrder.filter((key) => !allKeySet.has(key))
+        if (removedKeys.length > 0) {
+          let missingIdx = 0
+          const replacedOrder: string[] = []
+          for (const key of previousOrder) {
+            if (allKeySet.has(key)) {
+              replacedOrder.push(key)
+            } else if (missingIdx < missing.length) {
+              replacedOrder.push(missing[missingIdx])
+              missingIdx++
+            }
+          }
+          const remainingMissing = missing.slice(missingIdx)
+          const nextOrder = uniqueStrings([...replacedOrder, ...remainingMissing])
+          return areStringArraysEqual(previousOrder, nextOrder) ? previousOrder : nextOrder
+        }
+      }
+
       const nextOrder = [...kept, ...missing]
       return areStringArraysEqual(previousOrder, nextOrder) ? previousOrder : nextOrder
     })


### PR DESCRIPTION
## Summary of Changes
- Rust Backend (commands/mod.rs): Re-insert promoted leaf tab at exact root_idx position in remove_split_pane_from_tabs instead of appending to end.
- Frontend (useWorkspaceTabs.ts): Update setTabOrder in useWorkspaceTabs to inline-replace closed root tab key with promoted leaf key, preserving top-level tab bar position.