### PR TITLE
chore: prepare FileTerm 2.1.0 release

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/electron",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",
@@ -38,9 +38,9 @@
     "release:win": "npm run build && npm run package:win"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.5",
-    "@fileterm/shared": "2.0.5",
-    "@fileterm/storage": "2.0.5",
+    "@fileterm/core": "2.1.0",
+    "@fileterm/shared": "2.1.0",
+    "@fileterm/storage": "2.1.0",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -25,8 +25,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.5",
-    "@fileterm/shared": "2.0.5",
+    "@fileterm/core": "2.1.0",
+    "@fileterm/shared": "2.1.0",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.0.5"
+version = "2.1.0"
 dependencies = [
  "arboard",
  "async-trait",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.0.5"
+version = "2.1.0"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,11 +33,11 @@
     },
     "apps/electron": {
       "name": "@fileterm/electron",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "dependencies": {
-        "@fileterm/core": "2.0.5",
-        "@fileterm/shared": "2.0.5",
-        "@fileterm/storage": "2.0.5",
+        "@fileterm/core": "2.1.0",
+        "@fileterm/shared": "2.1.0",
+        "@fileterm/storage": "2.1.0",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@xterm/addon-fit": "^0.11.0",
@@ -232,10 +232,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "dependencies": {
-        "@fileterm/core": "2.0.5",
-        "@fileterm/shared": "2.0.5",
+        "@fileterm/core": "2.1.0",
+        "@fileterm/shared": "2.1.0",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -8583,17 +8583,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.0.5"
+      "version": "2.1.0"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.0.5"
+      "version": "2.1.0"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "dependencies": {
-        "@fileterm/core": "2.0.5"
+        "@fileterm/core": "2.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.0.5"
+    "@fileterm/core": "2.1.0"
   }
 }


### PR DESCRIPTION
Bump all workspace versions to 2.1.0 via sync:version script.