### PR TITLE
fix(workspace): 退出时清除 home tab 持久化状态并优化 light 主题

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/electron",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",
@@ -38,9 +38,9 @@
     "release:win": "npm run build && npm run package:win"
   },
   "dependencies": {
-    "@fileterm/core": "2.1.0",
-    "@fileterm/shared": "2.1.0",
-    "@fileterm/storage": "2.1.0",
+    "@fileterm/core": "2.1.1",
+    "@fileterm/shared": "2.1.1",
+    "@fileterm/storage": "2.1.1",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -25,8 +25,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.1.0",
-    "@fileterm/shared": "2.1.0",
+    "@fileterm/core": "2.1.1",
+    "@fileterm/shared": "2.1.1",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "arboard",
  "async-trait",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.1.0"
+version = "2.1.1"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/src/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/mod.rs
@@ -839,6 +839,15 @@ pub async fn app_window_action(
                 return Err(error);
             }
             shutdown_session_workers(&app).await;
+            // 清除持久化的 home tab UI 状态，确保下次启动只恢复一个默认新建标签页，
+            // 而不是上一次退出前残留的所有 home tab。失败仅记录警告，不阻断退出。
+            if let Err(error) = app_remove_ui_state_item(app.clone(), "main.tab-ui".to_string()) {
+                crate::services::logging::warn(
+                    &app,
+                    "workspace",
+                    format!("failed to clear home tab ui state on quit: {error}"),
+                );
+            }
             app.exit(0);
         }
         _ => {}

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/apps/tauri/src/renderer/styles/features/overview.css
+++ b/apps/tauri/src/renderer/styles/features/overview.css
@@ -76,7 +76,7 @@
 
 .hero-btn-primary {
   background: var(--text-main);
-  color: var(--bg-main) !important;
+  color: #ffffff !important;
   border-color: var(--text-main);
 }
 

--- a/apps/tauri/src/renderer/styles/themes/default-light.css
+++ b/apps/tauri/src/renderer/styles/themes/default-light.css
@@ -1,8 +1,8 @@
 :root[data-theme='default-light'] {
   color-scheme: light;
 
-  --bg-main: #ffffff;
-  --bg-sidebar: #f4f4f6;
+  --bg-main: #f4f4f6;
+  --bg-sidebar: #ffffff;
   --bg-card: #ffffff;
   --bg-elevated: #ffffff;
   --bg-hover: #e8e8ec;
@@ -158,7 +158,7 @@
     0 0 0 4px color-mix(in srgb, var(--primary) 24%, transparent);
   --dialog-warning-text: var(--danger);
 
-  --terminal-bg: #ffffff;
+  --terminal-bg: #f4f4f6;
   --terminal-text: #111827;
   --terminal-cursor: #3b82f6;
   --terminal-cursor-accent: #ffffff;
@@ -191,8 +191,12 @@
 }
 
 :root[data-theme='default-light'] .terminal-area,
+:root[data-theme='default-light'] .terminal-host,
 :root[data-theme='default-light'] .terminal-area::after {
+  border: none !important;
+  outline: none !important;
   box-shadow: none !important;
+  border-radius: 0 !important;
 }
 
 :root[data-theme='default-light'] .terminal-find {
@@ -243,24 +247,42 @@
 :root[data-theme='default-light'] .titlebar-brand,
 :root[data-theme='default-light'] .tabbar-folder-button,
 :root[data-theme='default-light'] .window-menubar,
-:root[data-theme='default-light'] .standalone-window-titlebar,
+:root[data-theme='default-light'] .standalone-window-titlebar {
+  background: var(--bg-sidebar);
+  border-color: var(--border-light);
+  color: var(--text-main);
+}
+
 :root[data-theme='default-light'] .file-tabs,
 :root[data-theme='default-light'] .pane-title,
 :root[data-theme='default-light'] .pane-path-bar,
 :root[data-theme='default-light'] .fs-file-table th,
 :root[data-theme='default-light'] .disk-head,
 :root[data-theme='default-light'] .transfer-strip {
-  background: var(--bg-sidebar);
+  background: var(--bg-main);
   border-color: var(--border-light);
   color: var(--text-main);
 }
 
 :root[data-theme='default-light'] .fs-sidebar::before {
-  background: var(--border-dark);
+  display: none !important;
 }
 
 :root[data-theme='default-light'] .fs-sidebar {
-  border-right: 1px solid var(--system-sidebar-frame) !important;
+  border-right: 1px solid var(--border-light) !important;
+}
+
+:root[data-theme='default-light'] .sidebar-resizer {
+  right: -1px !important;
+  width: 3px !important;
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+:root[data-theme='default-light'] .sidebar-resizer::after {
+  display: none !important;
 }
 
 :root[data-theme='default-light'] .titlebar-brand {
@@ -269,17 +291,17 @@
 }
 
 :root[data-theme='default-light'] .fs-tabbar {
-  border-bottom: none !important;
+  border-bottom: 1px solid var(--border-light) !important;
+  background: var(--bg-main);
 }
 
 :root[data-theme='default-light'] .fs-tabbar::after {
-  background: var(--border-light) !important;
-  z-index: 20 !important;
-  height: 1px !important;
+  display: none !important;
 }
 
 :root[data-theme='default-light'] .fs-tabs {
   bottom: 0 !important;
+  height: 47px !important;
 }
 
 :root[data-theme='default-light'] .connection-summary {
@@ -439,6 +461,7 @@
   background: #f1f3f6 !important;
   border: none !important;
   color: var(--text-soft) !important;
+  height: 47px !important;
   transition:
     background-color 0.2s,
     color 0.2s;
@@ -454,6 +477,7 @@
   background: transparent !important;
   border: none !important;
   color: var(--text-soft) !important;
+  height: 47px !important;
   transition:
     background-color 0.2s,
     color 0.2s;
@@ -491,6 +515,7 @@
   background: #ffffff !important;
   color: var(--text-main) !important;
   box-shadow: inset 0 3px 0 0 var(--primary) !important;
+  height: 47px !important;
 }
 
 :root[data-theme='default-light'] .context-menu {
@@ -657,7 +682,7 @@
 
 :root[data-theme='default-light'] .file-manager,
 :root[data-theme='default-light'] .command-center {
-  background: #fbfcfe;
+  background: #ffffff;
 }
 
 :root[data-theme='default-light'] .file-manager {
@@ -665,7 +690,7 @@
 }
 
 :root[data-theme='default-light'] .file-tabs {
-  background: #f8fafc;
+  background: #f4f4f6;
   border-bottom-color: var(--border-light);
 }
 
@@ -705,7 +730,7 @@
 }
 
 :root[data-theme='default-light'] .file-toolbar {
-  background: linear-gradient(180deg, #ffffff 0%, #f6f8fb 100%);
+  background: #f4f4f6;
   border-bottom-color: var(--border-light);
   color: var(--text-muted);
 }
@@ -725,10 +750,6 @@
 :root[data-theme='default-light'] .remote-pane,
 :root[data-theme='default-light'] .command-pane-preview {
   background: #ffffff;
-}
-
-:root[data-theme='default-light'] .local-pane {
-  background: #fbfcfe;
 }
 
 :root[data-theme='default-light'] .command-pane-list {
@@ -753,7 +774,7 @@
 
 :root[data-theme='default-light'] .pane-title {
   border-bottom-color: var(--border-light);
-  background: linear-gradient(180deg, #fbfcfe 0%, #f3f6fa 100%);
+  background: #ffffff;
   color: var(--text-main);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,11 +33,11 @@
     },
     "apps/electron": {
       "name": "@fileterm/electron",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
-        "@fileterm/core": "2.1.0",
-        "@fileterm/shared": "2.1.0",
-        "@fileterm/storage": "2.1.0",
+        "@fileterm/core": "2.1.1",
+        "@fileterm/shared": "2.1.1",
+        "@fileterm/storage": "2.1.1",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@xterm/addon-fit": "^0.11.0",
@@ -232,10 +232,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
-        "@fileterm/core": "2.1.0",
-        "@fileterm/shared": "2.1.0",
+        "@fileterm/core": "2.1.1",
+        "@fileterm/shared": "2.1.1",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -8583,17 +8583,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.1.0"
+      "version": "2.1.1"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.1.0"
+      "version": "2.1.1"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
-        "@fileterm/core": "2.1.0"
+        "@fileterm/core": "2.1.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.1.0"
+    "@fileterm/core": "2.1.1"
   }
 }


### PR DESCRIPTION
## 修复内容

退出时清除 `ui-state.json` 的 `main.tab-ui` 持久化状态，确保下次启动只恢复默认单 tab。

### 根因
用户反馈：Cmd+Q 大退后再打开，之前未关闭的多个"新建标签页"（home tab）还在，而不是只剩初始化的一个新建标签。

原因是 home tab 状态通过 `ui-state.json` 的 `main.tab-ui` key 持久化，退出时既不清除也不重置，下次启动 hydrate 原样恢复所有 home tabs。

### 解决方案
在 `app_window_action` 的 quit 分支 `app.exit(0)` 之前调用 `app_remove_ui_state_item` 清除 `main.tab-ui` key。清除失败仅记录警告，不阻断退出。

下次启动时 `main.tab-ui` 不存在，走 [useWorkspaceTabs.ts](file:///Users/stoffel/CodeFile/fileterm/apps/tauri/src/renderer/hooks/useWorkspaceTabs.ts#L489-L512) 的兜底逻辑只创建默认 `home-1`。

## 其他改动

- Light 主题优化：互换 bg-main/bg-sidebar、终端背景、标题栏样式等
- 修复 hero-btn-primary 按钮颜色为 #ffffff

## 验证

- 门禁全绿：typecheck / lint / prettier / clippy
- Rust 测试 144 passed（2 个 webdav flaky test 是 main 上预先存在的，与本次改动无关）
- 版本号提升到 2.1.1