### PR TITLE
fix: macOS SMB 本地回退、拖拽稳定性、resizer 样式优化

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/electron",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/main.js",
@@ -38,9 +38,9 @@
     "release:win": "npm run build && npm run package:win"
   },
   "dependencies": {
-    "@fileterm/core": "2.1.1",
-    "@fileterm/shared": "2.1.1",
-    "@fileterm/storage": "2.1.1",
+    "@fileterm/core": "2.1.2",
+    "@fileterm/shared": "2.1.2",
+    "@fileterm/storage": "2.1.2",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -25,8 +25,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.1.1",
-    "@fileterm/shared": "2.1.1",
+    "@fileterm/core": "2.1.2",
+    "@fileterm/shared": "2.1.2",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "arboard",
  "async-trait",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.1.1"
+version = "2.1.2"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/apps/tauri/src/renderer/App.tsx
+++ b/apps/tauri/src/renderer/App.tsx
@@ -557,6 +557,7 @@ export function App({ initialUiPreferences }: { initialUiPreferences?: InitialUi
     openLocalDirectory,
     handleOpenLocalItem,
     handleOpenLocalPath,
+    handleBackToLocalComputer,
     handleOpenRemoteItem,
     handleOpenRemotePath,
     copyItems,
@@ -1354,6 +1355,7 @@ export function App({ initialUiPreferences }: { initialUiPreferences?: InitialUi
                 onDropUpload={handleDropUpload}
                 onOpenLocalItem={handleOpenLocalItem}
                 onOpenLocalPath={handleOpenLocalPath}
+                onBackToLocalComputer={handleBackToLocalComputer}
                 onOpenProfile={openProfile}
                 onOpenRemoteItem={handleOpenRemoteItem}
                 onOpenRemotePath={handleOpenRemotePath}

--- a/apps/tauri/src/renderer/features/files/FileManager.tsx
+++ b/apps/tauri/src/renderer/features/files/FileManager.tsx
@@ -177,6 +177,7 @@ export function FileManager({
   onClearCutState,
   onOpenLocalItem,
   onOpenLocalPath,
+  onBackToLocalComputer,
   onOpenRemoteItem,
   onOpenRemotePath,
   onPasteIntoPane,
@@ -240,6 +241,7 @@ export function FileManager({
   onClearCutState(): void
   onOpenLocalItem(item: LocalFileItem): void
   onOpenLocalPath(path: string): void
+  onBackToLocalComputer(): void
   onOpenRemoteItem(item: RemoteFileItem): void
   onOpenRemotePath(path: string): void
   onPasteIntoPane(pane: 'local' | 'remote'): void
@@ -821,7 +823,7 @@ export function FileManager({
                     type="button"
                     className="pane-path-bar-action"
                     title={t.backToThisPC}
-                    onClick={() => onOpenLocalPath(WINDOWS_DRIVES_PATH)}
+                    onClick={onBackToLocalComputer}
                   >
                     {t.localComputer}
                   </button>

--- a/apps/tauri/src/renderer/features/layout/TabBar.tsx
+++ b/apps/tauri/src/renderer/features/layout/TabBar.tsx
@@ -61,15 +61,21 @@ export function TabBar({
       suppressTabClickRef.current = false
     }, 0)
   }
+  const hoverTargetRef = useRef<string | null>(null)
+
   const startPointerSort = usePointerSortFallback<string>({
     onStart: (tabKey) => {
       suppressTabClickRef.current = true
+      hoverTargetRef.current = null
       onDragStart(tabKey)
     },
-    onTarget: (_source, target) => onDragEnter(target.id),
-    onDrop: (_source, target) => {
-      if (target) {
-        onDragEnter(target.id)
+    onTarget: (_source, target) => {
+      hoverTargetRef.current = target.id
+    },
+    onDrop: (_source, _target) => {
+      const finalTarget = hoverTargetRef.current
+      if (finalTarget) {
+        onDragEnter(finalTarget)
       }
       onDragEnd()
       releaseSuppressedClick()

--- a/apps/tauri/src/renderer/features/workspace/SessionWorkspace.tsx
+++ b/apps/tauri/src/renderer/features/workspace/SessionWorkspace.tsx
@@ -77,6 +77,7 @@ export function SessionWorkspace({
   onOpenCommandManager,
   onOpenLocalItem,
   onOpenLocalPath,
+  onBackToLocalComputer,
   onOpenRemoteItem,
   onOpenRemotePath,
   onPasteIntoPane,
@@ -153,6 +154,7 @@ export function SessionWorkspace({
   onOpenCommandManager(): void
   onOpenLocalItem(item: LocalFileItem): void
   onOpenLocalPath(path: string): void
+  onBackToLocalComputer(): void
   onOpenRemoteItem(item: RemoteFileItem): void
   onOpenRemotePath(path: string): void
   onPasteIntoPane(pane: 'local' | 'remote'): void
@@ -531,6 +533,7 @@ export function SessionWorkspace({
             onOpenCommandManager={onOpenCommandManager}
             onOpenLocalItem={onOpenLocalItem}
             onOpenLocalPath={onOpenLocalPath}
+            onBackToLocalComputer={onBackToLocalComputer}
             onOpenRemoteItem={onOpenRemoteItem}
             onOpenRemotePath={onOpenRemotePath}
             onPasteIntoPane={onPasteIntoPane}

--- a/apps/tauri/src/renderer/features/workspace/WorkspaceStage.tsx
+++ b/apps/tauri/src/renderer/features/workspace/WorkspaceStage.tsx
@@ -75,6 +75,7 @@ export function WorkspaceStage({
   onDropUpload,
   onOpenLocalItem,
   onOpenLocalPath,
+  onBackToLocalComputer,
   onOpenProfile,
   onOpenRemoteItem,
   onOpenRemotePath,
@@ -182,6 +183,7 @@ export function WorkspaceStage({
   onDropUpload(event: DragEvent<HTMLDivElement>): void
   onOpenLocalItem(item: LocalFileItem): void
   onOpenLocalPath(path: string): void
+  onBackToLocalComputer(): void
   onOpenProfile(profileId: string): void
   onOpenRemoteItem(item: RemoteFileItem): void
   onOpenRemotePath(path: string): void
@@ -300,6 +302,7 @@ export function WorkspaceStage({
         onDropUpload={onDropUpload}
         onOpenLocalItem={onOpenLocalItem}
         onOpenLocalPath={onOpenLocalPath}
+        onBackToLocalComputer={onBackToLocalComputer}
         onOpenRemoteItem={onOpenRemoteItem}
         onOpenRemotePath={onOpenRemotePath}
         onPasteIntoPane={onPasteIntoPane}

--- a/apps/tauri/src/renderer/hooks/useFileOperations.ts
+++ b/apps/tauri/src/renderer/hooks/useFileOperations.ts
@@ -471,7 +471,8 @@ export function useFileOperations({
     targetPath: string,
     options?: {
       promptForSmbCredentials?: boolean
-      networkShareSource?: LocalNetworkShareSource
+      networkShareSource?: LocalNetworkShareSource | null
+      clearNetworkShare?: boolean
     }
   ) => {
     if (!desktopApi) {
@@ -480,16 +481,19 @@ export function useFileOperations({
     }
 
     setIsLocalDirectoryLoading(true)
-    const resolvedTargetPath = localNetworkShareSource
-      ? resolveNetworkSharePath(localNetworkShareSource, targetPath)
-      : targetPath
-    const networkShareSource =
-      options?.networkShareSource ??
-      (localNetworkShareSource &&
-      (isLocalPathWithin(localNetworkShareSource.mountPath, resolvedTargetPath) ||
-        isNetworkShareHostPath(localNetworkShareSource, resolvedTargetPath))
-        ? localNetworkShareSource
-        : null)
+    const clearNetworkShare = options?.clearNetworkShare === true
+    const resolvedTargetPath =
+      !clearNetworkShare && localNetworkShareSource
+        ? resolveNetworkSharePath(localNetworkShareSource, targetPath)
+        : targetPath
+    const networkShareSource = clearNetworkShare
+      ? null
+      : (options?.networkShareSource ??
+        (localNetworkShareSource &&
+        (isLocalPathWithin(localNetworkShareSource.mountPath, resolvedTargetPath) ||
+          isNetworkShareHostPath(localNetworkShareSource, resolvedTargetPath))
+          ? localNetworkShareSource
+          : null))
     setLocalNetworkShareSource(networkShareSource)
 
     try {
@@ -606,6 +610,16 @@ export function useFileOperations({
 
   const handleOpenLocalPath = (targetPath: string) => {
     void openLocalDirectory(targetPath).catch((error: unknown) => {
+      reportStatusError('打开本地路径', error, { targetPath })
+    })
+  }
+
+  // macOS 没有 Windows "此电脑" 概念，点"本地"回退到 home 目录并清理
+  // SMB 网络共享状态；Windows 保持 WINDOWS_DRIVES_PATH 列出磁盘。
+  const handleBackToLocalComputer = () => {
+    const isMac = desktopApi?.platform === 'darwin'
+    const targetPath = isMac ? '' : WINDOWS_DRIVES_PATH
+    void openLocalDirectory(targetPath, { clearNetworkShare: true }).catch((error: unknown) => {
       reportStatusError('打开本地路径', error, { targetPath })
     })
   }
@@ -1592,6 +1606,7 @@ export function useFileOperations({
     refreshCurrentPane,
     handleOpenLocalItem,
     handleOpenLocalPath,
+    handleBackToLocalComputer,
     handleOpenRemoteItem,
     handleOpenRemotePath,
     setClipboardItems,

--- a/apps/tauri/src/renderer/styles/features/shell.css
+++ b/apps/tauri/src/renderer/styles/features/shell.css
@@ -144,6 +144,7 @@
   width: 6px;
   min-height: 0;
   cursor: col-resize;
+  transition: background 0.15s ease;
 }
 
 .sidebar-resizer::after {

--- a/apps/tauri/src/renderer/styles/themes/default-dark.css
+++ b/apps/tauri/src/renderer/styles/themes/default-dark.css
@@ -195,13 +195,20 @@
   background: transparent;
 }
 
-:root:not([data-theme]) .sidebar-resizer:hover,
-:root[data-theme='default-dark'] .sidebar-resizer:hover,
-:root[data-theme='default'] .sidebar-resizer:hover,
-:root:not([data-theme]) .sidebar-resizer.is-active,
-:root[data-theme='default-dark'] .sidebar-resizer.is-active,
-:root[data-theme='default'] .sidebar-resizer.is-active {
-  background: transparent;
+:root:not([data-theme]) .sidebar-resizer::after,
+:root[data-theme='default-dark'] .sidebar-resizer::after,
+:root[data-theme='default'] .sidebar-resizer::after {
+  width: 2px;
+  left: 2px;
+}
+
+:root:not([data-theme]) .sidebar-resizer:hover::after,
+:root[data-theme='default-dark'] .sidebar-resizer:hover::after,
+:root[data-theme='default'] .sidebar-resizer:hover::after,
+:root:not([data-theme]) .sidebar-resizer.is-active::after,
+:root[data-theme='default-dark'] .sidebar-resizer.is-active::after,
+:root[data-theme='default'] .sidebar-resizer.is-active::after {
+  background: var(--accent-primary);
 }
 
 :root:not([data-theme]) .sync-dot,

--- a/apps/tauri/src/renderer/styles/themes/default-light.css
+++ b/apps/tauri/src/renderer/styles/themes/default-light.css
@@ -273,8 +273,8 @@
 }
 
 :root[data-theme='default-light'] .sidebar-resizer {
-  right: -1px !important;
-  width: 3px !important;
+  right: -3px !important;
+  width: 6px !important;
   background: transparent !important;
   border: none !important;
   box-shadow: none !important;
@@ -282,7 +282,14 @@
 }
 
 :root[data-theme='default-light'] .sidebar-resizer::after {
-  display: none !important;
+  width: 2px !important;
+  left: 2px !important;
+  background: transparent !important;
+}
+
+:root[data-theme='default-light'] .sidebar-resizer:hover::after,
+:root[data-theme='default-light'] .sidebar-resizer.is-active::after {
+  background: var(--primary) !important;
 }
 
 :root[data-theme='default-light'] .titlebar-brand {
@@ -1051,6 +1058,11 @@
 :root[data-theme='default-light'] .command-folder-tabs button small {
   background: rgba(79, 124, 255, 0.14);
   color: var(--primary);
+}
+
+:root[data-theme='default-light'] .status-message {
+  color: var(--warning);
+  background: rgba(217, 119, 6, 0.1);
 }
 
 :root[data-theme='default-light'] .status-message-close:hover {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,11 +33,11 @@
     },
     "apps/electron": {
       "name": "@fileterm/electron",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dependencies": {
-        "@fileterm/core": "2.1.1",
-        "@fileterm/shared": "2.1.1",
-        "@fileterm/storage": "2.1.1",
+        "@fileterm/core": "2.1.2",
+        "@fileterm/shared": "2.1.2",
+        "@fileterm/storage": "2.1.2",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@xterm/addon-fit": "^0.11.0",
@@ -232,10 +232,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dependencies": {
-        "@fileterm/core": "2.1.1",
-        "@fileterm/shared": "2.1.1",
+        "@fileterm/core": "2.1.2",
+        "@fileterm/shared": "2.1.2",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -8583,17 +8583,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dependencies": {
-        "@fileterm/core": "2.1.1"
+        "@fileterm/core": "2.1.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.1.1"
+    "@fileterm/core": "2.1.2"
   }
 }


### PR DESCRIPTION
## 改动内容

### macOS SMB 连接后点"本地"回退报错
- macOS 点"本地"时清理 SMB 共享状态并回退到 home 目录
- Windows 保持原 "此电脑" 磁盘列表行为

### 新标签拖不到正在连接的 tab 前面
- 根因：拖拽过程中每次 pointermove 都会触发 setTabOrder 导致 re-render
- 正在连接的 tab 因状态变化频繁 re-render，pointer capture 丢失
- 修复：拖拽期间仅记录 hover 目标，drop 时一次性排序

### 侧边栏拖拽区域太细、hover 无颜色
- 宽度恢复 6px（原 light 主题被覆盖为 3px）
- hover 时显示蓝色指示线（与文件区域选中色一致）
- light 主题补 status-message 颜色

## 验证
- typecheck ✅
- lint ✅
- prettier ✅