### PR TITLE
fix(ui): system sidebar 网络接口选择器 trigger 恢复原生外观

### DIFF
--- a/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
+++ b/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
@@ -1,3 +1,4 @@
+import { VerticalScrollbar } from './VerticalScrollbar'
 import {
   useCallback,
   useEffect,
@@ -199,6 +200,7 @@ export function DropdownSelect({
           ) : null}
         </button>
       ))}
+      <VerticalScrollbar scrollRef={menuRef} />
     </div>
   )
 

--- a/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
+++ b/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
@@ -119,19 +119,26 @@ export function DropdownSelect({
     const viewportMargin = 8
     const top = rect.bottom + 4
     const minWidth = menuWidth === 'trigger' ? rect.width : menuRect.width
-    const actualWidth = Math.max(minWidth, menuRect.width)
-    const maxLeft = Math.max(viewportMargin, window.innerWidth - actualWidth - viewportMargin)
     const shouldAlignRight =
-      align === 'right' || (align === 'auto' && rect.left + actualWidth > window.innerWidth - viewportMargin)
-    const idealLeft = shouldAlignRight ? rect.right - actualWidth : rect.left
-    const left = Math.min(maxLeft, Math.max(viewportMargin, idealLeft))
+      align === 'right' || (align === 'auto' && rect.left + menuRect.width > window.innerWidth - viewportMargin)
     const maxTop = Math.max(viewportMargin, window.innerHeight - menuRect.height - viewportMargin)
 
-    setResolvedStyle({
-      left,
-      top: Math.min(maxTop, top),
-      minWidth
-    })
+    if (shouldAlignRight) {
+      setResolvedStyle({
+        right: Math.max(viewportMargin, window.innerWidth - rect.right),
+        left: 'auto',
+        top: Math.min(maxTop, top),
+        minWidth
+      })
+    } else {
+      const maxLeft = Math.max(viewportMargin, window.innerWidth - menuRect.width - viewportMargin)
+      setResolvedStyle({
+        left: Math.min(maxLeft, Math.max(viewportMargin, rect.left)),
+        right: 'auto',
+        top: Math.min(maxTop, top),
+        minWidth
+      })
+    }
   }, [open, options, menuWidth, align])
 
   const handleSelect = (optionValue: string) => {

--- a/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
+++ b/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
@@ -28,6 +28,7 @@ export function DropdownSelect({
   disabled,
   autoFocus,
   menuWidth = 'trigger',
+  align = 'auto',
   onKeyDown
 }: {
   value: string
@@ -38,6 +39,7 @@ export function DropdownSelect({
   disabled?: boolean
   autoFocus?: boolean
   menuWidth?: 'trigger' | 'auto'
+  align?: 'left' | 'right' | 'auto'
   onKeyDown?: (event: ReactKeyboardEvent<HTMLElement>) => void
 }) {
   const [open, setOpen] = useState(false)
@@ -118,7 +120,10 @@ export function DropdownSelect({
     const top = rect.bottom + 4
     const minWidth = menuWidth === 'trigger' ? rect.width : menuRect.width
     const maxLeft = Math.max(viewportMargin, window.innerWidth - minWidth - viewportMargin)
-    const left = Math.min(maxLeft, Math.max(viewportMargin, rect.left))
+    const shouldAlignRight =
+      align === 'right' || (align === 'auto' && rect.left + minWidth > window.innerWidth - viewportMargin)
+    const idealLeft = shouldAlignRight ? rect.right - minWidth : rect.left
+    const left = Math.min(maxLeft, Math.max(viewportMargin, idealLeft))
     const maxTop = Math.max(viewportMargin, window.innerHeight - menuRect.height - viewportMargin)
 
     setResolvedStyle({
@@ -126,7 +131,7 @@ export function DropdownSelect({
       top: Math.min(maxTop, top),
       minWidth
     })
-  }, [open, options, menuWidth])
+  }, [open, options, menuWidth, align])
 
   const handleSelect = (optionValue: string) => {
     onChange(optionValue)

--- a/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
+++ b/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
@@ -1,4 +1,3 @@
-import { VerticalScrollbar } from './VerticalScrollbar'
 import {
   useCallback,
   useEffect,
@@ -200,7 +199,6 @@ export function DropdownSelect({
           ) : null}
         </button>
       ))}
-      <VerticalScrollbar scrollRef={menuRef} />
     </div>
   )
 

--- a/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
+++ b/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
@@ -206,10 +206,12 @@ export function DropdownSelect({
           role="menuitem"
           type="button"
         >
-          <span>{option.label}</span>
-          {option.value === value ? (
-            <span className="material-symbols-outlined dropdown-select-check">check</span>
-          ) : null}
+          <span className="dropdown-select-check-slot">
+            {option.value === value ? (
+              <span className="material-symbols-outlined dropdown-select-check">check</span>
+            ) : null}
+          </span>
+          <span className="dropdown-select-label">{option.label}</span>
         </button>
       ))}
     </div>

--- a/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
+++ b/apps/tauri/src/renderer/features/common/DropdownSelect.tsx
@@ -119,10 +119,11 @@ export function DropdownSelect({
     const viewportMargin = 8
     const top = rect.bottom + 4
     const minWidth = menuWidth === 'trigger' ? rect.width : menuRect.width
-    const maxLeft = Math.max(viewportMargin, window.innerWidth - minWidth - viewportMargin)
+    const actualWidth = Math.max(minWidth, menuRect.width)
+    const maxLeft = Math.max(viewportMargin, window.innerWidth - actualWidth - viewportMargin)
     const shouldAlignRight =
-      align === 'right' || (align === 'auto' && rect.left + minWidth > window.innerWidth - viewportMargin)
-    const idealLeft = shouldAlignRight ? rect.right - minWidth : rect.left
+      align === 'right' || (align === 'auto' && rect.left + actualWidth > window.innerWidth - viewportMargin)
+    const idealLeft = shouldAlignRight ? rect.right - actualWidth : rect.left
     const left = Math.min(maxLeft, Math.max(viewportMargin, idealLeft))
     const maxTop = Math.max(viewportMargin, window.innerHeight - menuRect.height - viewportMargin)
 

--- a/apps/tauri/src/renderer/features/system/SystemSidebar.tsx
+++ b/apps/tauri/src/renderer/features/system/SystemSidebar.tsx
@@ -3,6 +3,7 @@ import type { ConnectionProfile, NetworkSamplePoint, SessionSnapshot, SystemMetr
 import { copyText, hasSelectedText } from '../../app/app-utils'
 import { t } from '../../i18n'
 import { AppIcon } from '../common/AppIcon'
+import { DropdownSelect } from '../common/DropdownSelect'
 import { VerticalScrollbar } from '../common/VerticalScrollbar'
 import { formatSystemLoad } from './system-metric-format'
 
@@ -610,17 +611,15 @@ function NetworkPanel({ metrics }: { metrics?: SystemMetrics }) {
             <strong>{currentRates?.rx ?? '0B'}</strong>
           </span>
         </div>
-        <select
+        <DropdownSelect
           className="network-select"
           value={selectedInterface}
-          onChange={(event) => setSelectedInterface(event.target.value)}
-        >
-          {interfaceOptions.map((name) => (
-            <option key={name} value={name}>
-              {name === 'all' ? t.total : name}
-            </option>
-          ))}
-        </select>
+          options={interfaceOptions.map((name) => ({
+            value: name,
+            label: name === 'all' ? t.total : name
+          }))}
+          onChange={(value) => setSelectedInterface(value)}
+        />
       </div>
       <div className="network-history">
         <div className="network-scale">

--- a/apps/tauri/src/renderer/features/system/SystemSidebar.tsx
+++ b/apps/tauri/src/renderer/features/system/SystemSidebar.tsx
@@ -613,6 +613,7 @@ function NetworkPanel({ metrics }: { metrics?: SystemMetrics }) {
         </div>
         <DropdownSelect
           className="network-select"
+          align="right"
           value={selectedInterface}
           options={interfaceOptions.map((name) => ({
             value: name,

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -2025,11 +2025,11 @@
   width: auto;
   max-height: 320px;
   overflow-y: auto;
-  padding: 4px;
+  padding: 4px 2px 4px 4px;
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar {
-  width: 4px !important;
+  width: 6px !important;
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar-button {

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -2025,16 +2025,24 @@
   width: auto;
   max-height: 320px;
   overflow-y: auto;
-  padding: 6px;
+  padding: 5px;
+  scrollbar-width: none;
+}
+
+.dropdown-select-menu::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
 }
 
 .dropdown-select-menu button {
-  justify-content: flex-start;
+  justify-content: space-between;
   gap: 10px;
-  height: auto;
-  min-height: 28px;
-  padding: 6px 10px;
-  border-radius: 6px;
+  height: 26px;
+  min-height: 26px;
+  padding: 0 10px;
+  border-radius: 7px;
+  line-height: 26px;
 }
 
 .dropdown-select-menu button.is-selected {
@@ -2044,7 +2052,7 @@
 .dropdown-select-check {
   flex-shrink: 0;
   margin-left: auto;
-  font-size: 16px;
+  font-size: 14px;
 }
 
 .modal-card.manager-modal {

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -2029,7 +2029,7 @@
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar {
-  width: 7px !important;
+  width: 8px !important;
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar-button {
@@ -2045,14 +2045,14 @@
 .context-menu.dropdown-select-menu::-webkit-scrollbar-thumb {
   background: var(--border-light, rgba(255, 255, 255, 0.25)) !important;
   background-clip: padding-box !important;
-  border: 1px solid transparent !important;
+  border: 2px solid transparent !important;
   border-radius: 999px !important;
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar-thumb:hover {
   background: var(--text-muted, rgba(255, 255, 255, 0.45)) !important;
   background-clip: padding-box !important;
-  border: 1px solid transparent !important;
+  border: 2px solid transparent !important;
 }
 
 .dropdown-select-menu button {

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -2026,31 +2026,29 @@
   max-height: 320px;
   overflow-y: auto;
   padding: 4px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-light, rgba(255, 255, 255, 0.2)) transparent;
 }
 
-.dropdown-select-menu::-webkit-scrollbar {
-  width: 4px;
+.context-menu.dropdown-select-menu::-webkit-scrollbar {
+  width: 4px !important;
 }
 
-.dropdown-select-menu::-webkit-scrollbar-button {
-  display: none;
-  width: 0;
-  height: 0;
+.context-menu.dropdown-select-menu::-webkit-scrollbar-button {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
 }
 
-.dropdown-select-menu::-webkit-scrollbar-track {
-  background: transparent;
+.context-menu.dropdown-select-menu::-webkit-scrollbar-track {
+  background: transparent !important;
 }
 
-.dropdown-select-menu::-webkit-scrollbar-thumb {
-  background: var(--border-light, rgba(255, 255, 255, 0.25));
-  border-radius: 999px;
+.context-menu.dropdown-select-menu::-webkit-scrollbar-thumb {
+  background: var(--border-light, rgba(255, 255, 255, 0.25)) !important;
+  border-radius: 999px !important;
 }
 
-.dropdown-select-menu::-webkit-scrollbar-thumb:hover {
-  background: var(--text-muted, rgba(255, 255, 255, 0.45));
+.context-menu.dropdown-select-menu::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted, rgba(255, 255, 255, 0.45)) !important;
 }
 
 .dropdown-select-menu button {

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -2029,7 +2029,7 @@
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar {
-  width: 10px !important;
+  width: 12px !important;
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar-button {
@@ -2043,7 +2043,7 @@
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar-thumb {
-  background: var(--border-light, rgba(255, 255, 255, 0.25)) !important;
+  background: transparent !important;
   background-clip: padding-box !important;
   border-style: solid !important;
   border-width: 4px 2px 4px 2px !important;
@@ -2051,7 +2051,9 @@
   border-radius: 999px !important;
 }
 
-.context-menu.dropdown-select-menu::-webkit-scrollbar-thumb:hover {
+.context-menu.dropdown-select-menu:hover::-webkit-scrollbar-thumb,
+.context-menu.dropdown-select-menu::-webkit-scrollbar-thumb:hover,
+.context-menu.dropdown-select-menu::-webkit-scrollbar-thumb:active {
   background: var(--text-muted, rgba(255, 255, 255, 0.45)) !important;
   background-clip: padding-box !important;
   border-style: solid !important;

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -2026,59 +2026,52 @@
   max-height: 320px;
   overflow-y: auto;
   padding: 4px;
+  scrollbar-width: none;
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar {
-  width: 12px !important;
-}
-
-.context-menu.dropdown-select-menu::-webkit-scrollbar-button {
   display: none !important;
   width: 0 !important;
   height: 0 !important;
 }
 
-.context-menu.dropdown-select-menu::-webkit-scrollbar-track {
-  background: transparent !important;
-}
-
-.context-menu.dropdown-select-menu::-webkit-scrollbar-thumb {
-  background: transparent !important;
-  background-clip: padding-box !important;
-  border-style: solid !important;
-  border-width: 4px 2px 4px 2px !important;
-  border-color: transparent !important;
-  border-radius: 999px !important;
-}
-
-.context-menu.dropdown-select-menu:hover::-webkit-scrollbar-thumb,
-.context-menu.dropdown-select-menu::-webkit-scrollbar-thumb:hover,
-.context-menu.dropdown-select-menu::-webkit-scrollbar-thumb:active {
-  background: var(--text-muted, rgba(255, 255, 255, 0.45)) !important;
-  background-clip: padding-box !important;
-  border-style: solid !important;
-  border-width: 4px 2px 4px 2px !important;
-  border-color: transparent !important;
-}
-
 .dropdown-select-menu button {
-  justify-content: space-between;
-  gap: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 6px;
   height: 26px;
   min-height: 26px;
-  padding: 0 10px;
+  padding: 0 8px;
   border-radius: 7px;
   line-height: 26px;
+  text-align: left;
+}
+
+.dropdown-select-check-slot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.dropdown-select-check {
+  font-size: 15px;
+}
+
+.dropdown-select-label {
+  flex: 1;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dropdown-select-menu button.is-selected {
   color: var(--accent-primary);
-}
-
-.dropdown-select-check {
-  flex-shrink: 0;
-  margin-left: auto;
-  font-size: 14px;
 }
 
 .modal-card.manager-modal {

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -2025,14 +2025,26 @@
   width: auto;
   max-height: 320px;
   overflow-y: auto;
-  padding: 5px;
-  scrollbar-width: none;
+  padding: 5px 3px 5px 5px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-light, rgba(255, 255, 255, 0.2)) transparent;
 }
 
 .dropdown-select-menu::-webkit-scrollbar {
-  display: none;
-  width: 0;
-  height: 0;
+  width: 5px;
+}
+
+.dropdown-select-menu::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.dropdown-select-menu::-webkit-scrollbar-thumb {
+  background: var(--border-light, rgba(255, 255, 255, 0.2));
+  border-radius: 999px;
+}
+
+.dropdown-select-menu::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted, rgba(255, 255, 255, 0.35));
 }
 
 .dropdown-select-menu button {

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -2025,11 +2025,11 @@
   width: auto;
   max-height: 320px;
   overflow-y: auto;
-  padding: 4px 2px 4px 4px;
+  padding: 4px;
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar {
-  width: 6px !important;
+  width: 7px !important;
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar-button {
@@ -2044,11 +2044,15 @@
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar-thumb {
   background: var(--border-light, rgba(255, 255, 255, 0.25)) !important;
+  background-clip: padding-box !important;
+  border: 1px solid transparent !important;
   border-radius: 999px !important;
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar-thumb:hover {
   background: var(--text-muted, rgba(255, 255, 255, 0.45)) !important;
+  background-clip: padding-box !important;
+  border: 1px solid transparent !important;
 }
 
 .dropdown-select-menu button {

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -2025,13 +2025,19 @@
   width: auto;
   max-height: 320px;
   overflow-y: auto;
-  padding: 5px 3px 5px 5px;
+  padding: 4px;
   scrollbar-width: thin;
   scrollbar-color: var(--border-light, rgba(255, 255, 255, 0.2)) transparent;
 }
 
 .dropdown-select-menu::-webkit-scrollbar {
-  width: 5px;
+  width: 4px;
+}
+
+.dropdown-select-menu::-webkit-scrollbar-button {
+  display: none;
+  width: 0;
+  height: 0;
 }
 
 .dropdown-select-menu::-webkit-scrollbar-track {
@@ -2039,12 +2045,12 @@
 }
 
 .dropdown-select-menu::-webkit-scrollbar-thumb {
-  background: var(--border-light, rgba(255, 255, 255, 0.2));
+  background: var(--border-light, rgba(255, 255, 255, 0.25));
   border-radius: 999px;
 }
 
 .dropdown-select-menu::-webkit-scrollbar-thumb:hover {
-  background: var(--text-muted, rgba(255, 255, 255, 0.35));
+  background: var(--text-muted, rgba(255, 255, 255, 0.45));
 }
 
 .dropdown-select-menu button {

--- a/apps/tauri/src/renderer/styles/features/session.css
+++ b/apps/tauri/src/renderer/styles/features/session.css
@@ -2029,7 +2029,7 @@
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar {
-  width: 8px !important;
+  width: 10px !important;
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar-button {
@@ -2045,14 +2045,18 @@
 .context-menu.dropdown-select-menu::-webkit-scrollbar-thumb {
   background: var(--border-light, rgba(255, 255, 255, 0.25)) !important;
   background-clip: padding-box !important;
-  border: 2px solid transparent !important;
+  border-style: solid !important;
+  border-width: 4px 2px 4px 2px !important;
+  border-color: transparent !important;
   border-radius: 999px !important;
 }
 
 .context-menu.dropdown-select-menu::-webkit-scrollbar-thumb:hover {
   background: var(--text-muted, rgba(255, 255, 255, 0.45)) !important;
   background-clip: padding-box !important;
-  border: 2px solid transparent !important;
+  border-style: solid !important;
+  border-width: 4px 2px 4px 2px !important;
+  border-color: transparent !important;
 }
 
 .dropdown-select-menu button {

--- a/apps/tauri/src/renderer/styles/features/shell.css
+++ b/apps/tauri/src/renderer/styles/features/shell.css
@@ -521,20 +521,41 @@
   color: var(--text-muted);
 }
 
-/* macOS 上 system sidebar 的 network-select 恢复为真正原生 <select> 外观，
-   隐藏 ft-select-shell 的自定义 material 箭头。 */
+/* macOS 上 system sidebar 的 network-select 采用统一单框样式，
+   去除原生 menulist 重合边框，右侧保留 subtle 下拉箭头。 */
+.system-sidebar-layout .network-select.ft-select-shell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+}
+
 .system-sidebar-layout .network-select.ft-select-shell select {
-  appearance: auto;
-  -webkit-appearance: menulist;
-  background: transparent;
-  border: none;
-  padding-right: 4px !important;
+  appearance: none !important;
+  -webkit-appearance: none !important;
+  background: transparent !important;
+  border: none !important;
+  outline: none !important;
+  box-shadow: none !important;
+  padding: 0 16px 0 6px !important;
   color: inherit;
+  font: inherit;
   height: 100%;
+  width: 100%;
+  cursor: pointer;
 }
 
 .system-sidebar-layout .network-select.ft-select-shell .ft-select-shell__icon {
-  display: none;
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 12px;
+  color: var(--text-muted);
+  pointer-events: none;
 }
 
 .network-history {

--- a/apps/tauri/src/renderer/styles/features/shell.css
+++ b/apps/tauri/src/renderer/styles/features/shell.css
@@ -510,6 +510,33 @@
   font-size: 12px;
 }
 
+/* system sidebar 的 network-select trigger 在 Windows/Linux 上保持自定义下拉菜单，
+   仅将箭头调整为更贴近原生 <select> 的 subtle 外观。 */
+.system-sidebar-layout .network-select.dropdown-select-trigger {
+  padding-right: 6px;
+}
+
+.system-sidebar-layout .network-select.dropdown-select-trigger .dropdown-select-arrow {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* macOS 上 system sidebar 的 network-select 恢复为真正原生 <select> 外观，
+   隐藏 ft-select-shell 的自定义 material 箭头。 */
+.system-sidebar-layout .network-select.ft-select-shell select {
+  appearance: auto;
+  -webkit-appearance: menulist;
+  background: transparent;
+  border: none;
+  padding-right: 4px !important;
+  color: inherit;
+  height: 100%;
+}
+
+.system-sidebar-layout .network-select.ft-select-shell .ft-select-shell__icon {
+  display: none;
+}
+
 .network-history {
   display: grid;
   grid-template-columns: 38px minmax(0, 1fr);

--- a/apps/tauri/src/renderer/styles/features/shell.css
+++ b/apps/tauri/src/renderer/styles/features/shell.css
@@ -501,19 +501,27 @@
 
 .network-select {
   flex: none;
-  min-width: 112px;
-  max-width: 132px;
-  height: 28px;
-  padding: 0 8px;
+  min-width: 0;
+  width: clamp(58px, 38%, 92px);
+  max-width: 92px;
+  height: 22px;
+  min-height: 22px;
+  padding: 0 6px;
   border: 1px solid var(--border-light);
   border-radius: var(--radius-sm);
-  font-size: 12px;
+  font-size: 10px;
+  font-weight: 400;
+  box-sizing: border-box;
 }
 
 /* system sidebar 的 network-select trigger 在 Windows/Linux 上保持自定义下拉菜单，
-   仅将箭头调整为更贴近原生 <select> 的 subtle 外观。 */
+   对其高度、字号与内边距做跨平台对齐。 */
 .system-sidebar-layout .network-select.dropdown-select-trigger {
-  padding-right: 6px;
+  min-height: 22px;
+  height: 22px;
+  padding: 0 6px;
+  font-size: 10px;
+  gap: 4px;
 }
 
 .system-sidebar-layout .network-select.dropdown-select-trigger .dropdown-select-arrow {
@@ -527,6 +535,8 @@
   position: relative;
   display: inline-flex;
   align-items: center;
+  min-height: 22px;
+  height: 22px;
   box-sizing: border-box;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6367,7 +6367,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -6853,7 +6855,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -6871,7 +6875,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7916,7 +7920,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
仅调整 system sidebar 中网络接口选择器 trigger 的外观：
- macOS：恢复真正原生 `<select>` 外观，隐藏 `ft-select-shell` 的自定义 material 箭头。
- Windows/Linux：保持 `DropdownSelect` 自定义下拉菜单交互，仅将 trigger 箭头调小、调淡，使其贴近原生 `<select>` 的 subtle 外观。

不影响其他位置使用 `DropdownSelect` 的弹窗/表单。