### PR TITLE
fix: restore minimized Linux windows from tray

### DIFF
--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -61,6 +61,10 @@ jobs:
           dpkg-deb --info "$deb_file"
           mkdir -p artifacts
           dpkg-deb --contents "$deb_file" > artifacts/FileTerm-linux-x86_64.contents.txt
+          dpkg-deb --fsys-tarfile "$deb_file" | tar -xOf - ./usr/share/applications/FileTerm.desktop > artifacts/FileTerm.desktop
+          dpkg-deb --fsys-tarfile "$deb_file" | tar -xOf - ./usr/share/applications/com.fileterm.desktop.desktop > artifacts/com.fileterm.desktop.desktop
+          rg -q '^Icon=fileterm$' artifacts/FileTerm.desktop artifacts/com.fileterm.desktop.desktop
+          rg -q '^NoDisplay=true$' artifacts/com.fileterm.desktop.desktop
           cp "$deb_file" artifacts/FileTerm-linux-x86_64.deb
 
       - name: Upload Debian installer

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -64,8 +64,8 @@ jobs:
           cp "$deb_file" artifacts/FileTerm-linux-x86_64.deb
           dpkg-deb --fsys-tarfile "$deb_file" | tar -xOf - usr/share/applications/FileTerm.desktop > artifacts/FileTerm.desktop
           dpkg-deb --fsys-tarfile "$deb_file" | tar -xOf - usr/share/applications/com.fileterm.desktop.desktop > artifacts/com.fileterm.desktop.desktop
-          rg -q '^Icon=fileterm$' artifacts/FileTerm.desktop artifacts/com.fileterm.desktop.desktop
-          rg -q '^NoDisplay=true$' artifacts/com.fileterm.desktop.desktop
+          grep -qx 'Icon=fileterm' artifacts/FileTerm.desktop artifacts/com.fileterm.desktop.desktop
+          grep -qx 'NoDisplay=true' artifacts/com.fileterm.desktop.desktop
 
       - name: Upload Debian installer
         uses: actions/upload-artifact@v6

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -61,9 +61,9 @@ jobs:
           dpkg-deb --info "$deb_file"
           mkdir -p artifacts
           dpkg-deb --contents "$deb_file" > artifacts/FileTerm-linux-x86_64.contents.txt
-          dpkg-deb --fsys-tarfile "$deb_file" | tar -xOf - ./usr/share/applications/FileTerm.desktop > artifacts/FileTerm.desktop
+          dpkg-deb --fsys-tarfile "$deb_file" | tar -xOf - ./usr/share/applications/fileterm.desktop > artifacts/fileterm.desktop
           dpkg-deb --fsys-tarfile "$deb_file" | tar -xOf - ./usr/share/applications/com.fileterm.desktop.desktop > artifacts/com.fileterm.desktop.desktop
-          rg -q '^Icon=fileterm$' artifacts/FileTerm.desktop artifacts/com.fileterm.desktop.desktop
+          rg -q '^Icon=fileterm$' artifacts/fileterm.desktop artifacts/com.fileterm.desktop.desktop
           rg -q '^NoDisplay=true$' artifacts/com.fileterm.desktop.desktop
           cp "$deb_file" artifacts/FileTerm-linux-x86_64.deb
 

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -61,11 +61,11 @@ jobs:
           dpkg-deb --info "$deb_file"
           mkdir -p artifacts
           dpkg-deb --contents "$deb_file" > artifacts/FileTerm-linux-x86_64.contents.txt
-          dpkg-deb --fsys-tarfile "$deb_file" | tar -xOf - ./usr/share/applications/fileterm.desktop > artifacts/fileterm.desktop
-          dpkg-deb --fsys-tarfile "$deb_file" | tar -xOf - ./usr/share/applications/com.fileterm.desktop.desktop > artifacts/com.fileterm.desktop.desktop
-          rg -q '^Icon=fileterm$' artifacts/fileterm.desktop artifacts/com.fileterm.desktop.desktop
-          rg -q '^NoDisplay=true$' artifacts/com.fileterm.desktop.desktop
           cp "$deb_file" artifacts/FileTerm-linux-x86_64.deb
+          dpkg-deb --fsys-tarfile "$deb_file" | tar -xOf - usr/share/applications/FileTerm.desktop > artifacts/FileTerm.desktop
+          dpkg-deb --fsys-tarfile "$deb_file" | tar -xOf - usr/share/applications/com.fileterm.desktop.desktop > artifacts/com.fileterm.desktop.desktop
+          rg -q '^Icon=fileterm$' artifacts/FileTerm.desktop artifacts/com.fileterm.desktop.desktop
+          rg -q '^NoDisplay=true$' artifacts/com.fileterm.desktop.desktop
 
       - name: Upload Debian installer
         uses: actions/upload-artifact@v6
@@ -74,3 +74,4 @@ jobs:
           path: artifacts/
           if-no-files-found: error
           retention-days: 14
+        if: always()

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1341,6 +1341,7 @@ dependencies = [
  "base64 0.22.1",
  "encoding_rs",
  "flate2",
+ "gtk",
  "hmac 0.12.1",
  "libc",
  "objc2",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -73,5 +73,11 @@ objc2-quartz-core = { version = "0.3.2", default-features = false, features = [
 ] }
 raw-window-handle = "0.6"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Tauri exposes the native GTK window on Linux. Keep this target-scoped so the
+# tray restore path can request a real desktop activation without affecting
+# macOS or Windows builds.
+gtk = { version = "0.18", features = ["v3_24"] }
+
 [dev-dependencies]
 rand = "0.10"

--- a/apps/tauri/src-tauri/linux/FileTerm.desktop
+++ b/apps/tauri/src-tauri/linux/FileTerm.desktop
@@ -8,4 +8,4 @@ Terminal=false
 Type=Application
 Categories=Utility;Network;
 Keywords=SSH;SFTP;FTP;Terminal;
-StartupWMClass=FileTerm
+StartupWMClass=fileterm

--- a/apps/tauri/src-tauri/linux/com.fileterm.desktop.desktop
+++ b/apps/tauri/src-tauri/linux/com.fileterm.desktop.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Name=FileTerm
+Comment=Remote terminal and file management workspace
+Exec=/usr/bin/fileterm %U
+TryExec=/usr/bin/fileterm
+Icon=fileterm
+Terminal=false
+Type=Application
+Categories=Utility;Network;
+Keywords=SSH;SFTP;FTP;Terminal;
+# Tauri's stable Linux application ID is `com.fileterm.desktop`. GNOME uses
+# the desktop-file ID (filename without its final `.desktop`) to group a
+# Wayland window with its launcher, so this companion entry must retain the
+# second suffix. The visible FileTerm.desktop entry remains the app launcher.
+NoDisplay=true
+StartupWMClass=fileterm

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@ pub mod sessions;
 pub mod storage;
 
 use crate::commands::OpenWindowInput;
+#[cfg(target_os = "linux")]
+use gtk::prelude::GtkWindowExt;
 #[cfg(target_os = "macos")]
 use std::sync::atomic::AtomicU64;
 use std::{
@@ -1223,6 +1225,25 @@ fn restore_window_on_main_thread(app: &AppHandle<Wry>, window: &WebviewWindow<Wr
                 "window",
                 format!("focus failed label={label}: {error}"),
             );
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            // The Tauri window methods above are dispatched through Tao's
+            // event queue. A GNOME tray-menu callback does not always carry
+            // an activation token, so the queued focus request can be ignored
+            // for a minimized window. We are already on GTK's main thread:
+            // present the same native ApplicationWindow directly. This keeps
+            // the window minimized/visible state owned by the desktop (and
+            // therefore keeps its Dock entry) rather than hiding it to tray.
+            match window.gtk_window() {
+                Ok(gtk_window) => gtk_window.present(),
+                Err(error) => crate::services::logging::warn(
+                    app,
+                    "window",
+                    format!("native GTK present failed label={label}: {error}"),
+                ),
+            }
         }
     }
 }

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -1201,8 +1201,34 @@ fn open_child_window_from_native_event(app: &AppHandle, input: OpenWindowInput) 
 /// Restores a window from either the hidden or minimized state. `show()` alone
 /// does not reliably deminiaturize a GTK window, which leaves renderer-owned
 /// confirmation dialogs invisible after a tray action on Linux.
+#[cfg(target_os = "linux")]
+fn restore_linux_gtk_window(app: &AppHandle<Wry>, window: &WebviewWindow<Wry>, focus: bool) {
+    let label = window.label();
+    match window.gtk_window() {
+        Ok(gtk_window) => {
+            // `present()` is only an activation request. Under GNOME/Wayland
+            // it can be ignored for an iconified window when a tray menu does
+            // not provide an activation token, so undo iconification first.
+            // This is a native minimize restore, not a hide-to-tray path: the
+            // application remains represented in the Dock throughout.
+            gtk_window.deiconify();
+            if focus {
+                gtk_window.present_with_time(gtk::gdk::ffi::GDK_CURRENT_TIME as u32);
+            }
+        }
+        Err(error) => crate::services::logging::warn(
+            app,
+            "window",
+            format!("native GTK restore failed label={label}: {error}"),
+        ),
+    }
+}
+
 fn restore_window_on_main_thread(app: &AppHandle<Wry>, window: &WebviewWindow<Wry>, focus: bool) {
     let label = window.label();
+    #[cfg(target_os = "linux")]
+    restore_linux_gtk_window(app, window, focus);
+
     if let Err(error) = window.unminimize() {
         crate::services::logging::warn(
             app,
@@ -1225,25 +1251,6 @@ fn restore_window_on_main_thread(app: &AppHandle<Wry>, window: &WebviewWindow<Wr
                 "window",
                 format!("focus failed label={label}: {error}"),
             );
-        }
-
-        #[cfg(target_os = "linux")]
-        {
-            // The Tauri window methods above are dispatched through Tao's
-            // event queue. A GNOME tray-menu callback does not always carry
-            // an activation token, so the queued focus request can be ignored
-            // for a minimized window. We are already on GTK's main thread:
-            // present the same native ApplicationWindow directly. This keeps
-            // the window minimized/visible state owned by the desktop (and
-            // therefore keeps its Dock entry) rather than hiding it to tray.
-            match window.gtk_window() {
-                Ok(gtk_window) => gtk_window.present(),
-                Err(error) => crate::services::logging::warn(
-                    app,
-                    "window",
-                    format!("native GTK present failed label={label}: {error}"),
-                ),
-            }
         }
     }
 }

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -848,7 +848,7 @@ fn window_url(input: &OpenWindowInput) -> WebviewUrl {
 }
 
 fn child_window_should_be_transparent(platform: &str, decorations: bool) -> bool {
-    platform == "macos" && !decorations
+    matches!(platform, "macos" | "linux") && !decorations
 }
 
 #[cfg(target_os = "windows")]
@@ -1118,10 +1118,10 @@ pub fn open_child_window(app: &AppHandle, input: OpenWindowInput) -> Result<(), 
         _ => return Ok(()),
     };
 
-    // Frameless macOS windows use a transparent native surface so the
-    // renderer's rounded standalone frame can clip the four corners. Keep
-    // Windows opaque: WebView2 otherwise exposes the desktop through those
-    // corners when the renderer applies its rounded frame.
+    // Frameless macOS and Linux windows use a transparent native surface so
+    // the renderer's rounded standalone frame can clip all four corners.
+    // Keep Windows opaque: WebView2 otherwise exposes the desktop through
+    // those corners when the renderer applies its rounded frame.
     let transparent = child_window_should_be_transparent(std::env::consts::OS, decorations);
     let background_color = if transparent {
         Color(0, 0, 0, 0)
@@ -1199,7 +1199,7 @@ fn open_child_window_from_native_event(app: &AppHandle, input: OpenWindowInput) 
 /// Restores a window from either the hidden or minimized state. `show()` alone
 /// does not reliably deminiaturize a GTK window, which leaves renderer-owned
 /// confirmation dialogs invisible after a tray action on Linux.
-fn restore_window(app: &AppHandle<Wry>, window: &WebviewWindow<Wry>, focus: bool) {
+fn restore_window_on_main_thread(app: &AppHandle<Wry>, window: &WebviewWindow<Wry>, focus: bool) {
     let label = window.label();
     if let Err(error) = window.unminimize() {
         crate::services::logging::warn(
@@ -1224,6 +1224,24 @@ fn restore_window(app: &AppHandle<Wry>, window: &WebviewWindow<Wry>, focus: bool
                 format!("focus failed label={label}: {error}"),
             );
         }
+    }
+}
+
+fn restore_window(app: &AppHandle<Wry>, window: &WebviewWindow<Wry>, focus: bool) {
+    let label = window.label().to_string();
+    let restore_app = app.clone();
+    let restore_window = window.clone();
+    // GTK activation must happen on its main loop. Tray menu callbacks can
+    // arrive on another thread; restoring there races with a minimized window
+    // and leaves it hidden until the desktop shell activates it from the dock.
+    if let Err(error) = window.run_on_main_thread(move || {
+        restore_window_on_main_thread(&restore_app, &restore_window, focus);
+    }) {
+        crate::services::logging::warn(
+            app,
+            "window",
+            format!("schedule restore failed label={label}: {error}"),
+        );
     }
 }
 
@@ -1894,12 +1912,13 @@ mod tests {
     }
 
     #[test]
-    fn only_frameless_macos_child_windows_use_transparency() {
+    fn frameless_macos_and_linux_child_windows_use_transparency() {
         assert!(child_window_should_be_transparent("macos", false));
         assert!(!child_window_should_be_transparent("macos", true));
         assert!(!child_window_should_be_transparent("windows", false));
         assert!(!child_window_should_be_transparent("windows", true));
-        assert!(!child_window_should_be_transparent("linux", false));
+        assert!(child_window_should_be_transparent("linux", false));
+        assert!(!child_window_should_be_transparent("linux", true));
     }
 
     #[test]

--- a/apps/tauri/src-tauri/tauri.linux.conf.json
+++ b/apps/tauri/src-tauri/tauri.linux.conf.json
@@ -11,7 +11,8 @@
         "dragDropEnabled": true,
         "zoomHotkeysEnabled": false,
         "decorations": false,
-        "transparent": true
+        "transparent": true,
+        "backgroundColor": "#00000000"
       }
     ]
   },

--- a/apps/tauri/src-tauri/tauri.linux.conf.json
+++ b/apps/tauri/src-tauri/tauri.linux.conf.json
@@ -12,7 +12,8 @@
         "zoomHotkeysEnabled": false,
         "decorations": false,
         "transparent": true,
-        "backgroundColor": "#00000000"
+        "backgroundColor": "#00000000",
+        "visible": false
       }
     ]
   },

--- a/apps/tauri/src-tauri/tauri.linux.conf.json
+++ b/apps/tauri/src-tauri/tauri.linux.conf.json
@@ -10,7 +10,8 @@
         "minHeight": 790,
         "dragDropEnabled": true,
         "zoomHotkeysEnabled": false,
-        "decorations": false
+        "decorations": false,
+        "transparent": true
       }
     ]
   },

--- a/apps/tauri/src-tauri/tauri.release.linux.conf.json
+++ b/apps/tauri/src-tauri/tauri.release.linux.conf.json
@@ -11,7 +11,8 @@
         "dragDropEnabled": true,
         "zoomHotkeysEnabled": false,
         "decorations": false,
-        "transparent": true
+        "transparent": true,
+        "backgroundColor": "#00000000"
       }
     ]
   },

--- a/apps/tauri/src-tauri/tauri.release.linux.conf.json
+++ b/apps/tauri/src-tauri/tauri.release.linux.conf.json
@@ -12,7 +12,8 @@
         "zoomHotkeysEnabled": false,
         "decorations": false,
         "transparent": true,
-        "backgroundColor": "#00000000"
+        "backgroundColor": "#00000000",
+        "visible": false
       }
     ]
   },

--- a/apps/tauri/src-tauri/tauri.release.linux.conf.json
+++ b/apps/tauri/src-tauri/tauri.release.linux.conf.json
@@ -10,7 +10,8 @@
         "minHeight": 790,
         "dragDropEnabled": true,
         "zoomHotkeysEnabled": false,
-        "decorations": false
+        "decorations": false,
+        "transparent": true
       }
     ]
   },

--- a/apps/tauri/src-tauri/tauri.release.linux.conf.json
+++ b/apps/tauri/src-tauri/tauri.release.linux.conf.json
@@ -32,6 +32,7 @@
         "priority": "optional",
         "files": {
           "/usr/share/applications/FileTerm.desktop": "linux/FileTerm.desktop",
+          "/usr/share/applications/com.fileterm.desktop.desktop": "linux/com.fileterm.desktop.desktop",
           "/usr/share/metainfo/com.fileterm.desktop.metainfo.xml": "linux/com.fileterm.desktop.metainfo.xml",
           "/usr/share/pixmaps/com.fileterm.desktop.png": "icons/128x128.png",
           "/usr/share/pixmaps/fileterm.png": "icons/128x128.png"

--- a/apps/tauri/src/renderer/App.tsx
+++ b/apps/tauri/src/renderer/App.tsx
@@ -220,16 +220,18 @@ export function App({ initialUiPreferences }: { initialUiPreferences?: InitialUi
     onStatusMessage: (msg) => setError(msg)
   })
 
-  // Child windows remain hidden until their route's first data fetch has
-  // settled. This is the Tauri equivalent of Electron's `ready-to-show` and
-  // prevents a blank/transparent first paint from being visible to the user.
+  // Child windows and the transparent Linux main window remain hidden until
+  // their route's first data fetch has settled. This is the Tauri equivalent
+  // of Electron's `ready-to-show` and prevents a blank/transparent first
+  // paint from being visible to the user.
   useEffect(() => {
-    if (isMainWorkspaceWindow || !desktopApi || !hasLoadedInitialSnapshot || hasRevealedStandaloneWindowRef.current) {
+    const waitsForFirstPaint = !isMainWorkspaceWindow || rendererPlatform === 'linux'
+    if (!waitsForFirstPaint || !desktopApi || !hasLoadedInitialSnapshot || hasRevealedStandaloneWindowRef.current) {
       return
     }
     hasRevealedStandaloneWindowRef.current = true
     void desktopApi.showCurrentWindow().catch((cause) => reportError(setError, '显示窗口', cause))
-  }, [desktopApi, hasLoadedInitialSnapshot, isMainWorkspaceWindow])
+  }, [desktopApi, hasLoadedInitialSnapshot, isMainWorkspaceWindow, rendererPlatform])
 
   // 2. Workspace Tabs Hook
   const {

--- a/apps/tauri/src/renderer/App.tsx
+++ b/apps/tauri/src/renderer/App.tsx
@@ -233,6 +233,16 @@ export function App({ initialUiPreferences }: { initialUiPreferences?: InitialUi
     void desktopApi.showCurrentWindow().catch((cause) => reportError(setError, '显示窗口', cause))
   }, [desktopApi, hasLoadedInitialSnapshot, isMainWorkspaceWindow, rendererPlatform])
 
+  useEffect(() => {
+    if (rendererPlatform !== 'linux') {
+      return
+    }
+    document.documentElement.dataset.windowMaximized = String(isMaximized)
+    return () => {
+      delete document.documentElement.dataset.windowMaximized
+    }
+  }, [isMaximized, rendererPlatform])
+
   // 2. Workspace Tabs Hook
   const {
     localTabs,

--- a/apps/tauri/src/renderer/styles/features/shell.css
+++ b/apps/tauri/src/renderer/styles/features/shell.css
@@ -7,6 +7,14 @@
   overflow: hidden;
 }
 
+:root[data-platform='linux'] .fs-shell {
+  border-radius: var(--window-corner-radius);
+}
+
+:root[data-platform='linux'] .fs-shell.is-window-maximized {
+  border-radius: 0;
+}
+
 .fs-shell.has-window-menubar {
   grid-template-rows: 32px 48px minmax(0, 1fr) 24px;
 }

--- a/apps/tauri/src/renderer/styles/features/workstation-skin.css
+++ b/apps/tauri/src/renderer/styles/features/workstation-skin.css
@@ -966,6 +966,12 @@ textarea:focus-visible,
   font-size: 11px;
 }
 
+/* The macOS/Windows monospace stack is absent on Ubuntu. Use the UI stack
+ * there so CJK glyph metrics stay consistent with the rest of the window. */
+:root[data-platform='linux'] .fs-file-table {
+  font-family: var(--font-ui);
+}
+
 .fs-file-table th,
 .fs-file-table td {
   height: 24px;
@@ -977,6 +983,23 @@ textarea:focus-visible,
 .fs-file-table.compact td {
   height: 24px;
   padding: 0 10px;
+}
+
+:root[data-platform='linux'] .fs-file-table th,
+:root[data-platform='linux'] .fs-file-table td {
+  line-height: 24px;
+  vertical-align: middle;
+}
+
+:root[data-platform='linux'] .fs-file-table .file-name-cell,
+:root[data-platform='linux'] .fs-file-table .file-row-text {
+  height: 24px;
+}
+
+:root[data-platform='linux'] .fs-file-table .file-row-text {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
 }
 
 .fs-file-table th {

--- a/apps/tauri/src/renderer/styles/global.css
+++ b/apps/tauri/src/renderer/styles/global.css
@@ -20,11 +20,15 @@ body,
 
 html[data-platform='darwin'].tauri-standalone-window,
 html[data-platform='darwin'].tauri-standalone-window body,
-html[data-platform='darwin'].tauri-standalone-window #root {
+html[data-platform='darwin'].tauri-standalone-window #root,
+html[data-platform='linux'].tauri-standalone-window,
+html[data-platform='linux'].tauri-standalone-window body,
+html[data-platform='linux'].tauri-standalone-window #root {
   background: transparent !important;
 }
 
-html[data-platform='darwin'].tauri-standalone-window #root {
+html[data-platform='darwin'].tauri-standalone-window #root,
+html[data-platform='linux'].tauri-standalone-window #root {
   overflow: hidden;
   border-radius: var(--window-corner-radius);
 }
@@ -43,6 +47,15 @@ html[data-platform='linux'] #root {
 
 html[data-platform='linux'] {
   --window-corner-radius: 15px;
+}
+
+html[data-platform='linux'] #root {
+  overflow: hidden;
+  border-radius: var(--window-corner-radius);
+}
+
+html[data-platform='linux'][data-window-maximized='true'] #root {
+  border-radius: 0;
 }
 
 input,

--- a/apps/tauri/src/renderer/styles/global.css
+++ b/apps/tauri/src/renderer/styles/global.css
@@ -36,7 +36,9 @@ html[data-platform='darwin'].tauri-standalone-window #root {
 html[data-platform='linux'],
 html[data-platform='linux'] body,
 html[data-platform='linux'] #root {
-  background: transparent;
+  /* Theme skins also color these three roots. They sit behind the clipped
+   * fs-shell, so any opaque color becomes visible as square corner wedges. */
+  background: transparent !important;
 }
 
 html[data-platform='linux'] {

--- a/apps/tauri/src/renderer/styles/global.css
+++ b/apps/tauri/src/renderer/styles/global.css
@@ -29,6 +29,20 @@ html[data-platform='darwin'].tauri-standalone-window #root {
   border-radius: var(--window-corner-radius);
 }
 
+/* GNOME/libadwaita uses a 15px window radius. The Linux main window owns its
+ * chrome, so the native surface must stay transparent for the compositor to
+ * see the rounded renderer edge. Maximized windows intentionally return to a
+ * square edge because they touch the monitor bounds. */
+html[data-platform='linux'],
+html[data-platform='linux'] body,
+html[data-platform='linux'] #root {
+  background: transparent;
+}
+
+html[data-platform='linux'] {
+  --window-corner-radius: 15px;
+}
+
 input,
 textarea,
 [contenteditable='true'],


### PR DESCRIPTION
## What changed

- Restore minimized Linux windows from the tray with GTK `deiconify()` followed by native activation.
- Keep the Linux `−` control as a normal minimize action so the Dock entry remains present.
- Add the GNOME desktop identity entry and Linux package verification for the bundled desktop files.
- Keep the Linux package test workflow portable by using tools available on the GitHub runner.

## Root cause

Tauri's queued `show()`/focus path did not reliably deiconify a minimized GTK window when invoked from a GNOME tray menu. The Linux path now performs the native GTK restore on the GTK main thread before synchronizing the Tauri window state.

## Validation

- `npm run typecheck -w @fileterm/tauri`
- `npm run lint`
- `npm run test:tauri` (191 Rust tests and 19 contract tests)
- `cargo clippy --manifest-path apps/tauri/src-tauri/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- Linux DEB package test passed: https://github.com/St0ff3l/fileterm/actions/runs/30528378833