### PR TITLE
chore: bump version to 2.1.6

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -25,8 +25,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.1.5",
-    "@fileterm/shared": "2.1.5",
+    "@fileterm/core": "2.1.6",
+    "@fileterm/shared": "2.1.6",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "arboard",
  "async-trait",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.1.5"
+version = "2.1.6"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
+++ b/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
@@ -58,7 +58,7 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-    <release version="2.1.5" date="2026-07-31">
+    <release version="2.1.6" date="2026-08-03">
       <description>
         <p>Official release with multi-tab remote terminal and file management workspace.</p>
       </description>

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,10 +33,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "dependencies": {
-        "@fileterm/core": "2.1.5",
-        "@fileterm/shared": "2.1.5",
+        "@fileterm/core": "2.1.6",
+        "@fileterm/shared": "2.1.6",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -4082,17 +4082,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.1.5"
+      "version": "2.1.6"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.1.5"
+      "version": "2.1.6"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "dependencies": {
-        "@fileterm/core": "2.1.5"
+        "@fileterm/core": "2.1.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.1.5"
+    "@fileterm/core": "2.1.6"
   }
 }


### PR DESCRIPTION
## Summary
- bump all workspace and Tauri package metadata from 2.1.5 to 2.1.6
- synchronize package lockfile and Cargo metadata

## Validation
- npm run sync:version
- pre-push typecheck passed