### PR TITLE
chore: preserve GitHub-generated release contributors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,9 +304,11 @@ jobs:
           fi
 
           notes_file="docs/quality/release-notes-${tag#v}.md"
+          # Keep repository-authored release notes while retaining GitHub's
+          # generated What's Changed, Full Changelog, and Contributors blocks.
           notes_flags=(--generate-notes)
           if [ -f "${notes_file}" ]; then
-            notes_flags=(--notes-file "${notes_file}")
+            notes_flags+=(--notes "$(cat "${notes_file}")")
           fi
           release_flags=()
           if [[ "${tag}" == *-* ]]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,8 @@ npm run sync:version
 
 **关键约束**：tag 必须指向 `release/*` 分支上的 commit，否则 `validate-release-tag` 步骤会拒绝构建。
 
+发布说明正文可参考 2.1.7 的结构（版本简介、更新重点、主要 PR/问题和使用提示），但不要手写 `Contributors` 名单。发布 workflow 会在保留自定义正文的同时调用 GitHub 自动生成 Release Notes，由 GitHub 负责生成贡献者头像区域；详细规则见 `docs/quality/git-branch-release-convention.md`。
+
 ## 11. 文档维护规则
 
 - `AGENTS.md` 只放入口地图和硬约束，保持短小。

--- a/docs/quality/git-branch-release-convention.md
+++ b/docs/quality/git-branch-release-convention.md
@@ -17,6 +17,25 @@ FileTerm 采用标准 GitHub 流程：所有功能、修复和版本号更新先
 4. 在该 release 分支对应提交创建 `v<version>` tag 并推送；GitHub Actions 验证 tag 位于 `release/*` 后执行 macOS 与 Windows 打包。
 5. 稳定版本 tag（如 `v1.0.0`）创建正式 GitHub Release；带预发布后缀的 tag（如 `v1.0.1-beta.1`）创建 prerelease。
 
+## Release notes 与贡献者展示
+
+### 正文格式
+
+正式版本可以新增 `docs/quality/release-notes-x.y.z.md`，正文结构参考 2.1.7：
+
+- 版本简介
+- 更新重点
+- 主要 PR 与问题修复
+- 使用提示、反馈渠道或其他发布说明
+
+正文中不要添加手写的 `### Contributors`、贡献者名单或头像链接。贡献者区域由 GitHub 根据本次 Release 的提交和 Pull Request 自动生成，避免手工名单与实际变更不一致。
+
+### 自动生成规则
+
+发布 workflow 始终调用 `gh release create --generate-notes`。如果存在版本说明文件，文件内容通过 `--notes` 作为自定义正文传入；不要改回只使用 `--notes-file`。这样 GitHub 会在自定义正文之后继续生成 `What's Changed`、`Full Changelog` 和带头像的 `Contributors` 区域。
+
+发布完成后打开 Release 页面确认：自定义正文存在，且 GitHub 自动生成的贡献者头像区域也存在。
+
 ## Guardrails
 
 - 不直接向 `main` 或 `release/*` 推送常规功能改动。


### PR DESCRIPTION
## Summary

- Keep release notes in the 2.1.7-style structure without a hand-written Contributors section.
- Always use GitHub's generated release notes so the Contributors avatar section is preserved.
- Pass repository-authored release notes through --notes instead of replacing --generate-notes with --notes-file.
- Document the release-note format and verification steps in the release SOP.

## Validation

- npx prettier --check .github/workflows/release.yml AGENTS.md docs/quality/git-branch-release-convention.md
- git diff --check
- Pre-push npm run typecheck
