### PR TITLE
fix(release): add Windows portable beta artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,7 @@ jobs:
         shell: pwsh
         run: |
           $bundleDir = 'apps/tauri/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis'
+          $releaseDir = 'apps/tauri/src-tauri/target/x86_64-pc-windows-msvc/release'
           $version = $env:GITHUB_REF_NAME.TrimStart('v')
           $installer = Get-ChildItem -LiteralPath $bundleDir -Filter '*-setup.exe' -File | Select-Object -First 1
           if (-not $installer) { throw 'NSIS installer was not generated.' }
@@ -188,6 +189,22 @@ jobs:
           $targetName = "FileTerm-$version-windows-x64-setup.exe"
           Move-Item -LiteralPath $installer.FullName -Destination (Join-Path $bundleDir $targetName)
           Move-Item -LiteralPath $signature.FullName -Destination (Join-Path $bundleDir "$targetName.sig")
+
+          $portableBinary = Join-Path $releaseDir 'fileterm.exe'
+          if (-not (Test-Path -LiteralPath $portableBinary -PathType Leaf)) {
+            throw "Portable Windows binary was not generated: $portableBinary"
+          }
+          $portableDir = Join-Path $env:RUNNER_TEMP "FileTerm-$version-windows-x64-portable"
+          if (Test-Path -LiteralPath $portableDir) {
+            Remove-Item -LiteralPath $portableDir -Recurse -Force
+          }
+          New-Item -ItemType Directory -Path $portableDir | Out-Null
+          Copy-Item -LiteralPath $portableBinary -Destination (Join-Path $portableDir 'FileTerm.exe')
+          $portableArchive = Join-Path $bundleDir "FileTerm-$version-windows-x64-portable.zip"
+          Compress-Archive -Path (Join-Path $portableDir '*') -DestinationPath $portableArchive -CompressionLevel Optimal -Force
+          if (-not (Test-Path -LiteralPath $portableArchive -PathType Leaf)) {
+            throw "Portable Windows archive was not generated: $portableArchive"
+          }
 
       - name: Create GitHub Release updater manifest
         if: startsWith(github.ref, 'refs/tags/')
@@ -200,6 +217,7 @@ jobs:
           $bundleDir = 'apps/tauri/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis'
           if (-not (Get-ChildItem -LiteralPath $bundleDir -Filter '*.exe' -File)) { throw 'NSIS installer was not generated.' }
           if (-not (Get-ChildItem -LiteralPath $bundleDir -Filter '*-setup.exe.sig' -File)) { throw 'NSIS updater signature was not generated.' }
+          if (-not (Get-ChildItem -LiteralPath $bundleDir -Filter '*-portable.zip' -File)) { throw 'Portable Windows archive was not generated.' }
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v6
@@ -209,6 +227,7 @@ jobs:
             apps/tauri/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
             apps/tauri/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.sig
             apps/tauri/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/latest.json
+            apps/tauri/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.zip
           if-no-files-found: error
 
   build-linux:
@@ -315,7 +334,7 @@ jobs:
             release_flags+=(--prerelease)
           fi
 
-          mapfile -d '' assets < <(find . -type f \( -name '*.dmg' -o -name '*.exe' -o -name '*.deb' -o -name '*.AppImage' -o -name '*.sig' -o -name 'latest.json' \) -print0)
+          mapfile -d '' assets < <(find . -type f \( -name '*.dmg' -o -name '*.exe' -o -name '*.deb' -o -name '*.AppImage' -o -name '*.sig' -o -name '*.zip' -o -name 'latest.json' \) -print0)
           if [ "${#assets[@]}" -eq 0 ]; then
             echo 'No Tauri release assets were downloaded.'
             exit 1

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 前往 [GitHub Releases](https://github.com/St0ff3l/fileterm/releases/latest) 下载最新正式版：
 
 - **macOS**：提供 Apple Silicon（arm64）和 Intel（x64）安装包。
-- **Windows**：提供 x64 NSIS 安装包；已安装的正式版会在应用内下载、验签并在重启后更新。
+- **Windows**：提供 x64 NSIS 安装包和免安装 portable zip；已安装的正式版会在应用内下载、验签并在重启后更新。
 - **Linux**：提供 x64 `.deb` 安装包和 `.AppImage` 便携包。
 
 macOS 与 Linux 的“检查更新”会打开对应的 GitHub Release 下载页，由用户自行下载和安装；Windows 正式安装版使用签名的应用内更新。
@@ -144,7 +144,7 @@ npm run release:linux
 ### 发布与更新
 
 - 推送位于 `release/*` 分支提交上的 `vX.Y.Z` tag，会运行 Tauri 专用 Release Action，发布 macOS arm64/x64 DMG、Windows x64 NSIS 安装包以及 Linux x64 `.deb` / `.AppImage` 包。
-- Windows Action 同时生成带签名的 NSIS 安装器、`.sig` 签名文件和 `latest.json`；已安装 Windows 客户端从该清单验签后更新。
+- Windows Action 同时生成带签名的 NSIS 安装器、免安装 `*-windows-x64-portable.zip`、`.sig` 签名文件和 `latest.json`；已安装 Windows 客户端从该清单验签后更新。portable 版本不写入安装器注册信息，运行前仍需系统已有 WebView2 Runtime。
 - 仓库需要配置 GitHub Actions Secret `TAURI_SIGNING_PRIVATE_KEY`。它是 Tauri updater 私钥内容，只能保存为 GitHub Secret，绝不能提交到仓库。
 - macOS 发行包使用 ad hoc 签名（不使用 Apple Developer 证书或公证），不使用应用内 updater：检查到新版本后跳转 GitHub Release，由用户选择下载包；首次下载运行仍可能需要在“隐私与安全性”中手动放行。
 

--- a/apps/tauri/src-tauri/tauri.release.windows.conf.json
+++ b/apps/tauri/src-tauri/tauri.release.windows.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "bundle": {
+    "targets": ["nsis"],
     "createUpdaterArtifacts": true
   }
 }

--- a/docs/quality/release-notes-2.2.0-beta.1.md
+++ b/docs/quality/release-notes-2.2.0-beta.1.md
@@ -12,6 +12,7 @@
 - **本地对话隐私**：对话历史保存在本地；纯对话模式只发送用户输入和本地对话历史，不主动读取主机、路径、文件或终端输出。
 - **远程备份安全**：WebDAV/S3 远程备份使用加密备份包；上传时需要二次确认密码，下载时单次输入即可。密码至少 8 个字符并包含大小写字母，用户主动导出的 JSON 格式保持不变。
 - **跨平台与界面细节**：继续完善 macOS、Windows、Linux 的 AI 侧边栏、终端工作区、滚动条、按钮、图标和复制操作一致性。
+- **Windows 便携版**：Beta 发布同时提供 x64 免安装 portable zip；它不写入安装器注册信息，运行前需要系统已有 WebView2 Runtime。
 
 ### 本版本包含的主要 PR 和问题修复
 
@@ -43,6 +44,7 @@ FileTerm 2.2.0 Beta 1 is a test release centered on the AI Copilot sidebar and i
 - **Execution and context consistency**: Only the command card currently being executed is locked. Other cards remain available while the tab, host, user, and working directory are unchanged. Terminal output changes alone do not invalidate the whole batch.
 - **Local conversation privacy**: Conversation history is stored locally. Pure chat mode sends only the user input and local conversation history; it does not proactively read the host, path, files, or terminal output.
 - **Cross-platform UI polish**: Continue refining the AI sidebar and terminal workspace across macOS, Windows, and Linux, including scrollbars, buttons, icons, and copy interactions.
+- **Windows portable build**: The Beta release also provides an x64 portable zip that does not install registration entries; the system must already have the WebView2 Runtime available.
 
 ### Main PRs
 


### PR DESCRIPTION
## 变更内容

- 修复 Windows Beta 发布时因基础配置继承 `targets: all` 而尝试生成 MSI 的问题；发布 Windows 目标明确限定为 NSIS。
- 从 Tauri release binary 生成 `FileTerm-<version>-windows-x64-portable.zip`，作为独立免安装资产上传。
- 增加 portable 产物校验，并让 Release workflow 收集 `.zip` 资产。
- 更新 README 和 2.2.0 Beta 1 发布说明，明确 portable 包不写安装器注册信息，但运行环境需要已有 WebView2 Runtime。

## 根因

Windows Release job 已成功编译 `release/fileterm.exe`，失败发生在 MSI bundle 阶段：Tauri/Wix 要求 MSI 的预发布标识为纯数字，`2.2.0-beta.1` 不满足该约束。Beta 发布应只生成 NSIS 安装包，避免 MSI 阻断整个 Release。

## 验证

- `npm run typecheck -w @fileterm/tauri`
- `npm run lint`
- `npx prettier --check apps/tauri packages/core packages/shared packages/storage .github/workflows/release.yml README.md docs/quality/release-notes-2.2.0-beta.1.md`
- `npm run test:tauri`（329 unit + 19 contract tests）
- PR CI 需在 Windows runner 上验证 NSIS 和 portable zip 实际打包。
