### PR TITLE
fix: prevent terminal input leakage when switching tabs

### DIFF
--- a/apps/tauri/src/renderer/components/TerminalView.tsx
+++ b/apps/tauri/src/renderer/components/TerminalView.tsx
@@ -152,16 +152,51 @@ function isFocusTrackingSequence(data: string) {
   return data === `${escape}[I` || data === `${escape}[O`
 }
 
-function isHydratedTerminalResponse(data: string) {
+function readHydrationControlSequence(data: string, start: number, escape: string) {
+  const csiPrefix = `${escape}[`
+  if (data.startsWith(csiPrefix, start)) {
+    for (let index = start + csiPrefix.length; index < data.length; index += 1) {
+      const code = data.charCodeAt(index)
+      if (code >= 0x40 && code <= 0x7e) {
+        return data.slice(start, index + 1)
+      }
+    }
+    return null
+  }
+
+  const oscPrefix = `${escape}]`
+  const dcsPrefix = `${escape}P`
+  const isOsc = data.startsWith(oscPrefix, start)
+  const isDcs = data.startsWith(dcsPrefix, start)
+  if (!isOsc && !isDcs) {
+    return null
+  }
+
+  const stringStart = start + 2
+  const bell = String.fromCharCode(7)
+  const stringTerminator = `${escape}\\`
+  const bellIndex = isOsc ? data.indexOf(bell, stringStart) : -1
+  const stringTerminatorIndex = data.indexOf(stringTerminator, stringStart)
+  let end = -1
+  if (bellIndex >= 0 && stringTerminatorIndex >= 0) {
+    end = Math.min(bellIndex + bell.length, stringTerminatorIndex + stringTerminator.length)
+  } else if (bellIndex >= 0) {
+    end = bellIndex + bell.length
+  } else if (stringTerminatorIndex >= 0) {
+    end = stringTerminatorIndex + stringTerminator.length
+  }
+  return end >= 0 ? data.slice(start, end) : null
+}
+
+function isHydrationResponseSequence(sequence: string, escape: string) {
   // A transcript is a recording of PTY output, not a live terminal state.
   // When it is replayed after a tab switch, xterm can answer historical
   // terminal queries (CPR/DA/mode/color/window reports) and emit those
   // answers through onData. Forwarding the synthetic answers to the now-idle
   // shell makes it echo fragments such as `;201R` or `2RR0;276;0c`.
-  const escape = String.fromCharCode(27)
   const csiPrefix = `${escape}[`
-  if (data.startsWith(csiPrefix)) {
-    const csi = data.slice(csiPrefix.length)
+  if (sequence.startsWith(csiPrefix)) {
+    const csi = sequence.slice(csiPrefix.length)
     if (csi === '0n') return true
     if (/^\??\d+(?:;\d+)*R$/.test(csi)) return true
     if (/^(?:\?|>)[\d;]*c$/.test(csi)) return true
@@ -170,8 +205,8 @@ function isHydratedTerminalResponse(data: string) {
   }
 
   const oscPrefix = `${escape}]`
-  if (data.startsWith(oscPrefix)) {
-    const osc = data.slice(oscPrefix.length)
+  if (sequence.startsWith(oscPrefix)) {
+    const osc = sequence.slice(oscPrefix.length)
     const stringTerminator = `${escape}\\`
     const body = osc.endsWith(String.fromCharCode(7))
       ? osc.slice(0, -1)
@@ -185,12 +220,39 @@ function isHydratedTerminalResponse(data: string) {
 
   const dcsPrefix = `${escape}P`
   const dcsTerminator = `${escape}\\`
-  if (data.startsWith(dcsPrefix) && data.endsWith(dcsTerminator)) {
-    const dcs = data.slice(dcsPrefix.length, -dcsTerminator.length)
+  if (sequence.startsWith(dcsPrefix) && sequence.endsWith(dcsTerminator)) {
+    const dcs = sequence.slice(dcsPrefix.length, -dcsTerminator.length)
     return /^[01]\$r[\s\S]*$/.test(dcs)
   }
 
   return false
+}
+
+function stripHydratedTerminalResponses(data: string) {
+  const escape = String.fromCharCode(27)
+  let result = ''
+  let removedResponse = false
+  let index = 0
+
+  while (index < data.length) {
+    if (data[index] !== escape) {
+      result += data[index]
+      index += 1
+      continue
+    }
+
+    const sequence = readHydrationControlSequence(data, index, escape)
+    if (sequence && isHydrationResponseSequence(sequence, escape)) {
+      removedResponse = true
+      index += sequence.length
+      continue
+    }
+
+    result += data[index]
+    index += 1
+  }
+
+  return removedResponse ? result : data
 }
 
 type VimVisualSelection = {
@@ -1593,7 +1655,10 @@ export const TerminalView = memo(function TerminalView({
     }
 
     const onDataDispose = terminal.onData((data) => {
-      if (replayingTranscriptRef.current && isHydratedTerminalResponse(data)) {
+      if (replayingTranscriptRef.current) {
+        data = stripHydratedTerminalResponses(data)
+      }
+      if (!data) {
         return
       }
 

--- a/apps/tauri/src/renderer/components/TerminalView.tsx
+++ b/apps/tauri/src/renderer/components/TerminalView.tsx
@@ -152,6 +152,47 @@ function isFocusTrackingSequence(data: string) {
   return data === `${escape}[I` || data === `${escape}[O`
 }
 
+function isHydratedTerminalResponse(data: string) {
+  // A transcript is a recording of PTY output, not a live terminal state.
+  // When it is replayed after a tab switch, xterm can answer historical
+  // terminal queries (CPR/DA/mode/color/window reports) and emit those
+  // answers through onData. Forwarding the synthetic answers to the now-idle
+  // shell makes it echo fragments such as `;201R` or `2RR0;276;0c`.
+  const escape = String.fromCharCode(27)
+  const csiPrefix = `${escape}[`
+  if (data.startsWith(csiPrefix)) {
+    const csi = data.slice(csiPrefix.length)
+    if (csi === '0n') return true
+    if (/^\??\d+(?:;\d+)*R$/.test(csi)) return true
+    if (/^(?:\?|>)[\d;]*c$/.test(csi)) return true
+    if (/^(?:4|6|8);\d+(?:;\d+)?t$/.test(csi)) return true
+    if (/^(?:\?)?\d+(?:;\d+)*\$y$/.test(csi)) return true
+  }
+
+  const oscPrefix = `${escape}]`
+  if (data.startsWith(oscPrefix)) {
+    const osc = data.slice(oscPrefix.length)
+    const stringTerminator = `${escape}\\`
+    const body = osc.endsWith(String.fromCharCode(7))
+      ? osc.slice(0, -1)
+      : osc.endsWith(stringTerminator)
+        ? osc.slice(0, -stringTerminator.length)
+        : null
+    if (body !== null && /^(?:4;\d+|10|11|12);rgb:[0-9a-f]+(?:\/[0-9a-f]+){2}$/i.test(body)) {
+      return true
+    }
+  }
+
+  const dcsPrefix = `${escape}P`
+  const dcsTerminator = `${escape}\\`
+  if (data.startsWith(dcsPrefix) && data.endsWith(dcsTerminator)) {
+    const dcs = data.slice(dcsPrefix.length, -dcsTerminator.length)
+    return /^[01]\$r[\s\S]*$/.test(dcs)
+  }
+
+  return false
+}
+
 type VimVisualSelection = {
   text: string
   mode: 'character' | 'line' | 'block'
@@ -586,6 +627,8 @@ export const TerminalView = memo(function TerminalView({
   const imeCompositionTextRef = useRef('')
   const imeCompositionEndedAtRef = useRef(0)
   const imeCompositionDataForwardedRef = useRef(false)
+  const replayingTranscriptRef = useRef(false)
+  const transcriptReplayGenerationRef = useRef(0)
   // `onData` is registered once for the xterm instance.  Reading the prop
   // through a ref prevents a stale terminal-state event from a background
   // tab from swallowing keystrokes after this tab is brought back.
@@ -987,8 +1030,20 @@ export const TerminalView = memo(function TerminalView({
       writeFrameRef.current = null
     }
     isWritingRef.current = false
+    const replayGeneration = transcriptReplayGenerationRef.current + 1
+    transcriptReplayGenerationRef.current = replayGeneration
+    replayingTranscriptRef.current = true
     terminal.reset()
-    terminal.write(formatTerminalChunk(terminal, renderedTranscriptRef.current))
+    const replayText = formatTerminalChunk(terminal, renderedTranscriptRef.current)
+    if (replayText) {
+      terminal.write(replayText, () => {
+        if (transcriptReplayGenerationRef.current === replayGeneration) {
+          replayingTranscriptRef.current = false
+        }
+      })
+    } else {
+      replayingTranscriptRef.current = false
+    }
     suppressHydratedChunksUntilRef.current = Date.now() + 1500
   }
 
@@ -1436,6 +1491,10 @@ export const TerminalView = memo(function TerminalView({
         return false
       }
 
+      if (replayingTranscriptRef.current) {
+        return true
+      }
+
       if (parsed.data === '?') {
         let clipboardText = ''
         try {
@@ -1534,6 +1593,10 @@ export const TerminalView = memo(function TerminalView({
     }
 
     const onDataDispose = terminal.onData((data) => {
+      if (replayingTranscriptRef.current && isHydratedTerminalResponse(data)) {
+        return
+      }
+
       if (imeCompositionActiveRef.current) {
         // Intermediate composition text is owned by the IME and must never
         // reach the remote PTY before compositionend.
@@ -2216,6 +2279,8 @@ export const TerminalView = memo(function TerminalView({
       pendingWriteRef.current = ''
       renderedTranscriptRef.current = ''
       suppressHydratedChunksUntilRef.current = 0
+      replayingTranscriptRef.current = false
+      transcriptReplayGenerationRef.current += 1
       preserveVisibleBufferRef.current = false
       lastSyncedSizeRef.current = null
       lastObservedHostRectRef.current = null


### PR DESCRIPTION
## Summary

- filter xterm-generated terminal responses while a tab transcript is being hydrated
- strip concatenated and mixed CSI, OSC, and DCS replies so switching tabs cannot write synthetic data into the remote shell
- preserve ordinary user input and focus/clipboard traffic

## Validation

- `npm run typecheck -w @fileterm/tauri`
- `npm run lint`
- `npx prettier --check apps/tauri packages/core packages/shared packages/storage`
- `npm run test:tauri`
- `cargo clippy --manifest-path apps/tauri/src-tauri/Cargo.toml --locked --all-targets --all-features -- -D warnings`