### PR TITLE
fix: stabilize quit confirmation and root uploads

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -25,8 +25,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.1",
-    "@fileterm/shared": "2.2.1",
+    "@fileterm/core": "2.2.2",
+    "@fileterm/shared": "2.2.2",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.2.1"
+version = "2.2.2"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
+++ b/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
@@ -58,7 +58,7 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-    <release version="2.2.1" date="2026-08-21">
+    <release version="2.2.2" date="2026-08-21">
       <description>
         <p>Official release with multi-tab remote terminal and file management workspace.</p>
       </description>

--- a/apps/tauri/src-tauri/src/services/transfers.rs
+++ b/apps/tauri/src-tauri/src/services/transfers.rs
@@ -16,6 +16,10 @@ const UPDATE_INTERVAL: Duration = Duration::from_millis(200);
 const SPEED_SAMPLE_INTERVAL: Duration = Duration::from_millis(120);
 const TRANSFER_STOP_TIMEOUT: Duration = Duration::from_secs(15);
 const PARTIAL_SUFFIX: &str = ".fileterm-part";
+// /tmp is frequently mounted as tmpfs on small Linux hosts. Keep new root
+// upload staging on the disk-oriented temporary filesystem instead.
+const ROOT_STAGING_PREFIX: &str = "/var/tmp/fileterm-root-upload-";
+const LEGACY_ROOT_STAGING_PREFIX: &str = "/tmp/fileterm-root-upload-";
 
 fn is_false(value: &bool) -> bool {
     !*value
@@ -201,10 +205,14 @@ fn root_staging_path(name: &str) -> String {
         })
         .collect::<String>();
     format!(
-        "/tmp/fileterm-root-upload-{}-{}.part",
+        "{ROOT_STAGING_PREFIX}{}-{}.part",
         uuid::Uuid::new_v4(),
         safe_name
     )
+}
+
+pub(crate) fn is_root_upload_staging_path(path: &str) -> bool {
+    path.starts_with(ROOT_STAGING_PREFIX) || path.starts_with(LEGACY_ROOT_STAGING_PREFIX)
 }
 
 fn normalize_root_upload_staging(task: &mut TransferTask) {
@@ -216,13 +224,11 @@ fn normalize_root_upload_staging(task: &mut TransferTask) {
         (task.destination_path.as_deref(), task.partial_path.clone())
     {
         if task.staging_path.is_none() {
-            task.staging_path = Some(
-                if current_partial.starts_with("/tmp/fileterm-root-upload-") {
-                    current_partial
-                } else {
-                    root_staging_path(&task.name)
-                },
-            );
+            task.staging_path = Some(if is_root_upload_staging_path(&current_partial) {
+                current_partial
+            } else {
+                root_staging_path(&task.name)
+            });
         }
         task.partial_path = Some(partial_path(destination));
     }
@@ -230,13 +236,11 @@ fn normalize_root_upload_staging(task: &mut TransferTask) {
     if let Some(manifest) = task.manifest.as_mut() {
         for entry in &mut manifest.files {
             if entry.staging_path.is_none() {
-                entry.staging_path = Some(
-                    if entry.partial_path.starts_with("/tmp/fileterm-root-upload-") {
-                        entry.partial_path.clone()
-                    } else {
-                        root_staging_path(&entry.relative_path)
-                    },
-                );
+                entry.staging_path = Some(if is_root_upload_staging_path(&entry.partial_path) {
+                    entry.partial_path.clone()
+                } else {
+                    root_staging_path(&entry.relative_path)
+                });
             }
             entry.partial_path = partial_path(&entry.destination_path);
         }
@@ -2572,10 +2576,11 @@ pub async fn shutdown(app: &AppHandle) -> Result<(), AppError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        can_resume_from, failure_status, interrupt_status, join_remote_path, manifest_totals,
-        normalize_root_upload_staging, partial_path, progress_event_due, relative_remote_path,
-        select_journal_tasks, TransferFileIdentity, TransferManifest, TransferManifestEntry,
-        TransferTask, JOURNAL_MAX_TASKS, UPDATE_INTERVAL,
+        can_resume_from, failure_status, interrupt_status, is_root_upload_staging_path,
+        join_remote_path, manifest_totals, normalize_root_upload_staging, partial_path,
+        progress_event_due, relative_remote_path, root_staging_path, select_journal_tasks,
+        TransferFileIdentity, TransferManifest, TransferManifestEntry, TransferTask,
+        JOURNAL_MAX_TASKS, UPDATE_INTERVAL,
     };
 
     #[test]
@@ -2632,6 +2637,18 @@ mod tests {
         assert!(progress_event_due(None, now));
         assert!(!progress_event_due(Some(now - UPDATE_INTERVAL / 2), now));
         assert!(progress_event_due(Some(now - UPDATE_INTERVAL), now));
+    }
+
+    #[test]
+    fn new_root_upload_staging_uses_disk_backed_temp_path() {
+        let path = root_staging_path("debian.iso");
+
+        assert!(path.starts_with("/var/tmp/fileterm-root-upload-"));
+        assert!(is_root_upload_staging_path(&path));
+        assert!(is_root_upload_staging_path(
+            "/tmp/fileterm-root-upload-legacy.part"
+        ));
+        assert!(!is_root_upload_staging_path("/home/user/debian.iso"));
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/sessions/ssh.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh.rs
@@ -39,7 +39,7 @@ use tokio_socks::tcp::Socks5Stream;
 use tokio_util::sync::CancellationToken;
 
 use super::{TransferFileStat, WorkerCmd};
-use crate::services::WorkspaceTabStatus;
+use crate::services::{transfers::is_root_upload_staging_path, WorkspaceTabStatus};
 
 const DEFAULT_SSH_KEY_FILES: [&str; 4] = ["id_ed25519", "id_ecdsa", "id_rsa", "id_dsa"];
 const SSH_INTERACTION_TIMEOUT: Duration = Duration::from_secs(300);
@@ -6021,7 +6021,7 @@ async fn handle_worker_cmd(
             let su = sudo_user.clone();
             let sp = sudo_password.clone();
             tokio::spawn(async move {
-                // Root uploads are deliberately staged under /tmp first. The
+                // Root uploads are deliberately staged under /var/tmp first. The
                 // login user's SFTP channel transfers the bulk bytes there,
                 // then CommitRemoteStaging performs one short sudo/su command
                 // to create the protected .fileterm-part. This keeps su out
@@ -7503,10 +7503,6 @@ async fn replace_remote_file(
 // ─────────────────────────────────────────────────────────────────────────────
 // root-mode helpers (exec channel + `sudo` / `su`)
 // ─────────────────────────────────────────────────────────────────────────────
-
-fn is_root_upload_staging_path(path: &str) -> bool {
-    path.starts_with("/tmp/fileterm-root-upload-")
-}
 
 fn root_stat_shell_command(path: &str) -> String {
     format!(
@@ -9863,6 +9859,9 @@ mod tests {
 
     #[test]
     fn root_upload_staging_is_transferred_through_login_sftp() {
+        assert!(is_root_upload_staging_path(
+            "/var/tmp/fileterm-root-upload-a57f-example.part"
+        ));
         assert!(is_root_upload_staging_path(
             "/tmp/fileterm-root-upload-a57f-example.part"
         ));

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/apps/tauri/src/renderer/App.tsx
+++ b/apps/tauri/src/renderer/App.tsx
@@ -1484,6 +1484,7 @@ export function App({ initialUiPreferences }: { initialUiPreferences?: InitialUi
             {t.closeConfirmHide}
           </button>
         ) : null,
+        initialFocus: 'dialog' as const,
         onClose: () => resolveWindowCloseConfirmation('cancel'),
         onConfirm: () => resolveWindowCloseConfirmation('quit'),
         title: t.closeConfirmTitle

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -226,7 +226,7 @@ platform probe
 - 文件区手动切换 user/root 只改变独立的 SFTP/exec 文件通道，不向交互终端写命令；相同 shell 用户的重复 prompt 不会覆盖手动选择。
 - 终端与文件通道不是同一远端进程。文件区进入特权身份会通过独立 exec channel 重建与终端一致的 sudo 或 su 策略；优先复用终端输入期间已捕获的授权，也支持远端免密 sudo / su。
 - 普通远程 exec 的 `sudo` / `su` 前缀由 Rust 在独立 exec channel 中处理：sudo 使用 `-S` 通过 stdin 发送凭据，su 只在该独立 exec channel 上设置受控 PTY 标志；密码不进入命令文本、可见终端、日志或 tool result。凭据优先使用用户明确的一次性参数、加密 profile，缺失时由 Rust 恢复、解除最小化并聚焦主窗口，再展示本地安全 prompt；Copilot 对话区和工具活动都会显示等待前台输入的说明。主窗口/renderer 不可用时返回 `SUDO_PASSWORD_NEEDED` / `SU_PASSWORD_NEEDED`，用户取消或超时返回对应的 `*_PASSWORD_CANCELLED`，由 Agent 按结果处理。MFA/验证码/确认/REPL 等 generic input 仍返回 `REMOTE_INTERACTIVE_INPUT_REQUIRED`。
-- 特权上传的字节流仍走登录用户可写的随机 /tmp SFTP staging，只有 staging → 目标断点/替换等短文件命令走 sudo/su，避免把大文件流塞进 su 的 PTY。
+- 特权上传的字节流仍走登录用户可写的随机 /var/tmp SFTP staging，只有 staging → 目标断点/替换等短文件命令走 sudo/su，避免把大文件流塞进 su 的 PTY；历史 /tmp staging 任务继续兼容恢复，避免把旧断点遗留在不可访问路径。
 
 ## 4.5 MCP / CLI 外部 Agent 桥接边界
 
@@ -561,7 +561,7 @@ interface WorkspaceTab {
 - 普通断线和暂停保留临时文件；只有显式丢弃才清理断点。
 - 本地最终替换采用可回滚的备份重命名。Windows 文件占用导致替换失败时保留 `.fileterm-part`，避免丢失已传数据。
 - 目录任务持久化逐文件 manifest：已完成文件经过目标大小复核后跳过，当前文件按真实 `.fileterm-part` 长度继续。
-- SFTP root 上传为每个任务同时持久化不可预测的 /tmp staging 路径和目标同目录 .fileterm-part：登录用户的 SFTP 通道写入 staging（始终保存源文件从 0 开始的连续前缀），完成校验后由 sudo/su 用短命令复制为目标 partial，再校验并替换正式文件。失败恢复优先检查 staging，若 staging 已提交则改查目标 partial。普通 SFTP/FTP/FTPS 直接写目标同目录断点。
+- SFTP root 上传为每个任务同时持久化不可预测的 /var/tmp staging 路径和目标同目录 .fileterm-part：登录用户的 SFTP 通道写入 staging（始终保存源文件从 0 开始的连续前缀），完成校验后由 sudo/su 用短命令复制为目标 partial，再校验并替换正式文件。失败恢复优先检查 staging，若 staging 已提交则改查目标 partial。历史 /tmp staging 任务按原路径恢复。普通 SFTP/FTP/FTPS 直接写目标同目录断点。
 - FTP 上传优先使用 `APPE`，服务器不支持时回退 `REST + STOR`；回退结果不安全时删除断点并从零重传，避免拼接出等长但错误的文件。
 - FTP 安全模式明确区分未加密 FTP、显式 FTPS 和隐式 FTPS。
 - SFTP 可恢复路径保持有序流式写入。并行绝对 offset 会让文件长度无法证明前缀连续，因此在没有持久化范围位图前不用于断点判断。

--- a/docs/decisions/0003-resumable-transfer-staging.md
+++ b/docs/decisions/0003-resumable-transfer-staging.md
@@ -7,7 +7,7 @@ Accepted（2026-07-03，2026-07-16 修订 root 提交流程）
 ## 决策
 
 1. 普通 SFTP、FTP、显式 FTPS、隐式 FTPS 上传写入目标同目录的 `.fileterm-part`，完成大小校验后再 rename 到正式文件。
-2. SSH root 文件模式先顺序写入任务独占的 `/tmp/fileterm-root-upload-*.part`，因为登录用户通常无权在目标目录创建文件。完整大小校验通过后，由 sudo 把 staging 移到目标同目录的 `.fileterm-part`，再次校验后再执行最终替换。这样 `/tmp` 与目标目录跨文件系统时，正式目标也不会参与非原子的跨设备移动。
+2. SSH root 文件模式先顺序写入任务独占的 `/var/tmp/fileterm-root-upload-*.part`，因为登录用户通常无权在目标目录创建文件；选择 `/var/tmp` 是为了避开经常被挂载为 `tmpfs` 的 `/tmp`，避免大文件 staging 消耗服务器内存。完整大小校验通过后，由 sudo 把 staging 移到目标同目录的 `.fileterm-part`，再次校验后再执行最终替换。这样 staging 与目标目录跨文件系统时，正式目标也不会参与非原子的跨设备移动。历史上已创建的 `/tmp/fileterm-root-upload-*.part` 任务继续按原路径恢复。
 3. SFTP 替换目标前检查符号链接和 uid。符号链接或属主不同的目标采用原 inode 写回；普通文件尽量继承原权限后再 rename。
 4. FTP 上传优先 `APPE`；不支持时尝试 `REST + STOR`。如果结果无法通过大小校验，删除不可信断点并从零上传。
 5. 可恢复 SFTP 不采用无序并行写。只有在未来引入持久化范围位图并能证明连续区间后，才考虑把并行绝对 offset 加入恢复路径。
@@ -23,6 +23,6 @@ Accepted（2026-07-03，2026-07-16 修订 root 提交流程）
 
 - 正式目标在传输完成前保持可用。
 - root 上传保留原有权限兼容路径，同时具备跨连接恢复能力。
-- root journal 分别持久化 `/tmp` staging 与目标目录 partial；旧版仅记录 `/tmp` partial 的任务在读取 journal 时自动迁移。
+- root journal 分别持久化 `/var/tmp` staging 与目标目录 partial；旧版仅记录 `/tmp` staging 的任务在读取 journal 时自动迁移并继续使用原路径。
 - 普通文件 rename 仍可能改变 inode；对符号链接和可检测的其他属主目标使用保守写回。
 - 目录传输 journal 会随文件数增长，但只在状态边界持久化，不按每个数据块写盘。

--- a/docs/quality/release-notes-2.2.2.md
+++ b/docs/quality/release-notes-2.2.2.md
@@ -1,0 +1,33 @@
+## FileTerm 2.2.2
+
+FileTerm 2.2.2 聚焦 macOS 退出确认交互与 SSH root 大文件上传稳定性。
+
+### 2.2.2 更新重点
+
+- **macOS 退出确认**：通过 `Cmd+Q` 触发确认弹窗时，将焦点落在弹窗本身，避免部分场景下默认高亮“取消”按钮。
+- **SSH root 大文件上传**：root 模式的上传临时文件从 `/tmp` 调整到 `/var/tmp`，避免 `/tmp` 为 `tmpfs` 时大文件 staging 消耗服务器内存；历史 `/tmp` 临时任务仍兼容断点恢复。
+- **稳定性验证**：补充 root 上传 staging 路径兼容性测试，并继续覆盖 SSH、传输服务和 Tauri 合约测试。
+
+### 反馈与支持
+
+- [提交 Issue](https://github.com/St0ff3l/fileterm/issues/new)
+- [查看完整文档](https://github.com/St0ff3l/fileterm#readme)
+- [加入社区讨论](https://github.com/St0ff3l/fileterm/discussions)
+
+---
+
+## FileTerm 2.2.2
+
+FileTerm 2.2.2 focuses on macOS quit confirmation behavior and SSH root-mode large-file upload stability.
+
+### Highlights
+
+- **macOS quit confirmation**: When `Cmd+Q` opens the confirmation dialog, focus is placed on the dialog itself instead of leaving the Cancel button highlighted in some cases.
+- **SSH root large-file uploads**: Root-mode upload staging now uses `/var/tmp` instead of `/tmp`, avoiding memory-backed staging when `/tmp` is a `tmpfs`; existing `/tmp` staging tasks remain compatible with resume.
+- **Stability validation**: Added compatibility coverage for root upload staging paths while retaining SSH, transfer-service, and Tauri contract coverage.
+
+### Feedback & Support
+
+- [Report an issue](https://github.com/St0ff3l/fileterm/issues/new)
+- [Read the documentation](https://github.com/St0ff3l/fileterm#readme)
+- [Join the community](https://github.com/St0ff3l/fileterm/discussions)

--- a/docs/quality/release-notes-2.2.2.md
+++ b/docs/quality/release-notes-2.2.2.md
@@ -8,6 +8,10 @@ FileTerm 2.2.2 聚焦 macOS 退出确认交互与 SSH root 大文件上传稳定
 - **SSH root 大文件上传**：root 模式的上传临时文件从 `/tmp` 调整到 `/var/tmp`，避免 `/tmp` 为 `tmpfs` 时大文件 staging 消耗服务器内存；历史 `/tmp` 临时任务仍兼容断点恢复。
 - **稳定性验证**：补充 root 上传 staging 路径兼容性测试，并继续覆盖 SSH、传输服务和 Tauri 合约测试。
 
+### 相关 Pull Request
+
+- [PR #208](https://github.com/St0ff3l/fileterm/pull/208)：稳定退出确认焦点与 root 大文件上传 staging。
+
 ### 反馈与支持
 
 - [提交 Issue](https://github.com/St0ff3l/fileterm/issues/new)
@@ -25,6 +29,10 @@ FileTerm 2.2.2 focuses on macOS quit confirmation behavior and SSH root-mode lar
 - **macOS quit confirmation**: When `Cmd+Q` opens the confirmation dialog, focus is placed on the dialog itself instead of leaving the Cancel button highlighted in some cases.
 - **SSH root large-file uploads**: Root-mode upload staging now uses `/var/tmp` instead of `/tmp`, avoiding memory-backed staging when `/tmp` is a `tmpfs`; existing `/tmp` staging tasks remain compatible with resume.
 - **Stability validation**: Added compatibility coverage for root upload staging paths while retaining SSH, transfer-service, and Tauri contract coverage.
+
+### Related Pull Request
+
+- [PR #208](https://github.com/St0ff3l/fileterm/pull/208): Stabilize quit confirmation focus and root large-file upload staging.
 
 ### Feedback & Support
 

--- a/docs/quality/resumable-transfers.md
+++ b/docs/quality/resumable-transfers.md
@@ -27,4 +27,4 @@ git diff --check
 
 Electron 真实 socket 协议夹具位于 `apps/electron/test/protocol/`，包含本地 OpenSSH SFTP、FTP、显式 FTPS 和隐式 FTPS。受限环境缺少 sshd/openssl 或禁止监听 localhost 时相应用例显示 skipped；普通 macOS/Linux 开发机或 CI 中必须执行为 pass。
 
-Tauri 的 Rust 回归位于 `apps/tauri/src-tauri/src/sessions/` 与 `services/transfers.rs`：本地 OpenSSH 覆盖认证、exec、SFTP 和代理链路，本地 FTP/FTPS socket 夹具覆盖明文及两类 TLS 数据通道，并分别断言 `APPE -> SIZE` 与 `APPE 失败 -> REST -> STOR -> SIZE` 的续传命令顺序；transfer 单测覆盖 root 旧 journal 到“两阶段 staging + partial”的迁移。发行候选还需在真实服务器上验证传输期间并发浏览、root 目标目录与 `/tmp` 跨文件系统、断线后重新授权继续三项场景。
+Tauri 的 Rust 回归位于 `apps/tauri/src-tauri/src/sessions/` 与 `services/transfers.rs`：本地 OpenSSH 覆盖认证、exec、SFTP 和代理链路，本地 FTP/FTPS socket 夹具覆盖明文及两类 TLS 数据通道，并分别断言 `APPE -> SIZE` 与 `APPE 失败 -> REST -> STOR -> SIZE` 的续传命令顺序；transfer 单测覆盖 root 旧 journal 到“两阶段 staging + partial”的迁移。发行候选还需在真实服务器上验证传输期间并发浏览、root 目标目录与 `/var/tmp` 跨文件系统、断线后重新授权继续三项场景。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,10 +33,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dependencies": {
-        "@fileterm/core": "2.2.1",
-        "@fileterm/shared": "2.2.1",
+        "@fileterm/core": "2.2.2",
+        "@fileterm/shared": "2.2.2",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -5501,17 +5501,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.2.1"
+      "version": "2.2.2"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.2.1"
+      "version": "2.2.2"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dependencies": {
-        "@fileterm/core": "2.2.1"
+        "@fileterm/core": "2.2.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.1"
+    "@fileterm/core": "2.2.2"
   }
 }


### PR DESCRIPTION
## Summary

- Keep macOS Cmd+Q confirmation focus on the dialog instead of the Cancel action in affected focus states.
- Stage root-mode SSH uploads under `/var/tmp` to avoid memory-backed `/tmp` staging, while preserving legacy `/tmp` resume compatibility.
- Prepare synchronized FileTerm 2.2.2 versions and release notes.

## Validation

- `npm run typecheck -w @fileterm/tauri`
- `npm run lint`
- `npx prettier --check apps/tauri packages/core packages/shared packages/storage`
- `cargo fmt --all -- --check`
- `npm run test:tauri` (368 unit tests + 19 contract tests)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`