### PR TITLE
docs: align 2.2.2 release notes format

### DIFF
--- a/.agents/skills/fileterm-release/SKILL.md
+++ b/.agents/skills/fileterm-release/SKILL.md
@@ -40,6 +40,8 @@ description: FileTerm 专用 GitHub Release 发布流程。用于编写版本说
 
 推荐结构：中文正文、英文正文、GitHub 官方生成区。中文和英文都属于自定义正文，英文版本紧跟在中文版本后面；官方生成区必须由 GitHub 在最后追加。
 
+以下标题属于固定格式，必须原样保留，不得改写成“相关 Pull Request”“本版本包含的主要 PR”或其他近义标题：中文使用 `### 本版本包含的主要 PR 和问题修复`、`### 反馈与支持`，英文使用 `### Main PRs and issues`、`### Feedback & Support`。
+
 ```md
 ## FileTerm <version>
 
@@ -51,9 +53,10 @@ description: FileTerm 专用 GitHub Release 发布流程。用于编写版本说
 - **稳定性/兼容性**：平台或核心链路变化。
 - **安全与隐私**：数据发送、权限、凭据和人工确认边界。
 
-### 本版本包含的主要 PR
+### 本版本包含的主要 PR 和问题修复
 
 - [PR #123](https://github.com/St0ff3l/fileterm/pull/123)：简要说明。
+- [Issue #456](https://github.com/St0ff3l/fileterm/issues/456)：简要说明。
 
 完整变更记录请查看 [v<old> 与 v<version> 的比较](https://github.com/St0ff3l/fileterm/compare/v<old>...v<version>)。
 
@@ -75,9 +78,10 @@ One-sentence release summary in English.
 - **Stability and compatibility**: Describe platform or core workflow changes.
 - **Security and privacy**: Describe data scope, permissions, credentials, and confirmation boundaries.
 
-### Main PRs
+### Main PRs and issues
 
 - [PR #123](https://github.com/St0ff3l/fileterm/pull/123): Short description.
+- [Issue #456](https://github.com/St0ff3l/fileterm/issues/456): Short description.
 
 See the [comparison between v<old> and v<version>](https://github.com/St0ff3l/fileterm/compare/v<old>...v<version>) for the complete change set.
 

--- a/.agents/skills/fileterm-release/SKILL.md
+++ b/.agents/skills/fileterm-release/SKILL.md
@@ -51,14 +51,17 @@ description: FileTerm 专用 GitHub Release 发布流程。用于编写版本说
 - **稳定性/兼容性**：平台或核心链路变化。
 - **安全与隐私**：数据发送、权限、凭据和人工确认边界。
 
-### 本版本包含的主要 PR 和问题修复
+### 本版本包含的主要 PR
 
 - [PR #123](https://github.com/St0ff3l/fileterm/pull/123)：简要说明。
-- [Issue #456](https://github.com/St0ff3l/fileterm/issues/456)：简要说明。
+
+完整变更记录请查看 [v<old> 与 v<version> 的比较](https://github.com/St0ff3l/fileterm/compare/v<old>...v<version>)。
+
+### 反馈与支持
 
 遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
 
-也可以打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#社区交流) 加入社区。
+也可以打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81) 加入社区。
 
 ---
 
@@ -72,14 +75,17 @@ One-sentence release summary in English.
 - **Stability and compatibility**: Describe platform or core workflow changes.
 - **Security and privacy**: Describe data scope, permissions, credentials, and confirmation boundaries.
 
-### Main PRs and issues
+### Main PRs
 
 - [PR #123](https://github.com/St0ff3l/fileterm/pull/123): Short description.
-- [Issue #456](https://github.com/St0ff3l/fileterm/issues/456): Short description.
+
+See the [comparison between v<old> and v<version>](https://github.com/St0ff3l/fileterm/compare/v<old>...v<version>) for the complete change set.
+
+### Feedback & Support
 
 For problems, open a [GitHub Issue](https://github.com/St0ff3l/fileterm/issues) with the operating system, FileTerm version, connection type, reproduction steps, and redacted logs. Do not submit passwords, private keys, or tokens.
 
-Join the community through the [README community section](https://github.com/St0ff3l/fileterm#社区交流).
+Join the community through the [README community section](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81).
 ```
 
 链接要求：
@@ -88,7 +94,7 @@ Join the community through the [README community section](https://github.com/St0
 - PR 使用 `/pull/<number>`，Issue 使用 `/issues/<number>`。
 - 版本对比使用 `/compare/v<old>...v<new>`，例如：
   `[Full Changelog](https://github.com/St0ff3l/fileterm/compare/v2.1.6...v2.2.0-beta.1)`。
-- README 社区入口使用 README 锚点的完整链接，并确认锚点与 README 标题一致。
+- README 社区入口固定使用 `https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81`，并确认锚点与 README 标题一致。
 - 发布正文中的链接必须是 Markdown 链接，不要只写裸 URL，也不要把本地文件路径写入 release notes。
 - 中文正文之后必须紧跟英文正文；英文正文应翻译相同的功能范围、安全边界和反馈信息，不要新增未在中文正文确认的功能。
 

--- a/.agents/skills/fileterm-release/SKILL.md
+++ b/.agents/skills/fileterm-release/SKILL.md
@@ -42,6 +42,16 @@ description: FileTerm 专用 GitHub Release 发布流程。用于编写版本说
 
 以下标题属于固定格式，必须原样保留，不得改写成“相关 Pull Request”“本版本包含的主要 PR”或其他近义标题：中文使用 `### 本版本包含的主要 PR 和问题修复`、`### 反馈与支持`，英文使用 `### Main PRs and issues`、`### Feedback & Support`。
 
+`### 反馈与支持` 以及其下的两段中文正文、空行和链接组成一个逐字固定块，必须整体复制，不得改写、拆分、改成列表或替换链接：
+
+```md
+### 反馈与支持
+
+遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
+
+也可以打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81) 加入社区。
+```
+
 ```md
 ## FileTerm <version>
 

--- a/docs/quality/release-notes-2.2.2.md
+++ b/docs/quality/release-notes-2.2.2.md
@@ -8,11 +8,13 @@ FileTerm 2.2.2 聚焦 macOS 退出确认交互与 SSH root 大文件上传稳定
 - **SSH root 大文件上传**：root 模式的上传临时文件从 `/tmp` 调整到 `/var/tmp`，避免 `/tmp` 为 `tmpfs` 时大文件 staging 消耗服务器内存；历史 `/tmp` 临时任务仍兼容断点恢复。
 - **稳定性验证**：补充 root 上传 staging 路径兼容性测试，并继续覆盖 SSH、传输服务和 Tauri 合约测试。
 
-### 本版本包含的主要 PR 和问题修复
+### 本版本包含的主要 PR
 
 - [PR #208](https://github.com/St0ff3l/fileterm/pull/208)：稳定退出确认焦点与 root 大文件上传 staging。
 
 完整变更记录请查看 [v2.2.1 与 v2.2.2 的比较](https://github.com/St0ff3l/fileterm/compare/v2.2.1...v2.2.2)。
+
+### 反馈与支持
 
 遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
 
@@ -30,11 +32,13 @@ FileTerm 2.2.2 focuses on macOS quit confirmation behavior and SSH root-mode lar
 - **SSH root large-file uploads**: Root-mode upload staging now uses `/var/tmp` instead of `/tmp`, avoiding memory-backed staging when `/tmp` is a `tmpfs`; existing `/tmp` staging tasks remain compatible with resume.
 - **Stability validation**: Added compatibility coverage for root upload staging paths while retaining SSH, transfer-service, and Tauri contract coverage.
 
-### Main PRs and issues
+### Main PRs
 
 - [PR #208](https://github.com/St0ff3l/fileterm/pull/208): Stabilize quit confirmation focus and root large-file upload staging.
 
 See the [comparison between v2.2.1 and v2.2.2](https://github.com/St0ff3l/fileterm/compare/v2.2.1...v2.2.2) for the complete change set.
+
+### Feedback & Support
 
 For problems, open a [GitHub Issue](https://github.com/St0ff3l/fileterm/issues) with your operating system, FileTerm version, connection type, reproduction steps, and redacted logs. Do not submit passwords, private keys, or tokens.
 

--- a/docs/quality/release-notes-2.2.2.md
+++ b/docs/quality/release-notes-2.2.2.md
@@ -8,15 +8,15 @@ FileTerm 2.2.2 聚焦 macOS 退出确认交互与 SSH root 大文件上传稳定
 - **SSH root 大文件上传**：root 模式的上传临时文件从 `/tmp` 调整到 `/var/tmp`，避免 `/tmp` 为 `tmpfs` 时大文件 staging 消耗服务器内存；历史 `/tmp` 临时任务仍兼容断点恢复。
 - **稳定性验证**：补充 root 上传 staging 路径兼容性测试，并继续覆盖 SSH、传输服务和 Tauri 合约测试。
 
-### 相关 Pull Request
+### 本版本包含的主要 PR 和问题修复
 
 - [PR #208](https://github.com/St0ff3l/fileterm/pull/208)：稳定退出确认焦点与 root 大文件上传 staging。
 
-### 反馈与支持
+完整变更记录请查看 [v2.2.1 与 v2.2.2 的比较](https://github.com/St0ff3l/fileterm/compare/v2.2.1...v2.2.2)。
 
-- [提交 Issue](https://github.com/St0ff3l/fileterm/issues/new)
-- [查看完整文档](https://github.com/St0ff3l/fileterm#readme)
-- [加入社区讨论](https://github.com/St0ff3l/fileterm/discussions)
+遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
+
+也可以打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81) 加入社区。
 
 ---
 
@@ -30,12 +30,12 @@ FileTerm 2.2.2 focuses on macOS quit confirmation behavior and SSH root-mode lar
 - **SSH root large-file uploads**: Root-mode upload staging now uses `/var/tmp` instead of `/tmp`, avoiding memory-backed staging when `/tmp` is a `tmpfs`; existing `/tmp` staging tasks remain compatible with resume.
 - **Stability validation**: Added compatibility coverage for root upload staging paths while retaining SSH, transfer-service, and Tauri contract coverage.
 
-### Related Pull Request
+### Main PRs and issues
 
 - [PR #208](https://github.com/St0ff3l/fileterm/pull/208): Stabilize quit confirmation focus and root large-file upload staging.
 
-### Feedback & Support
+See the [comparison between v2.2.1 and v2.2.2](https://github.com/St0ff3l/fileterm/compare/v2.2.1...v2.2.2) for the complete change set.
 
-- [Report an issue](https://github.com/St0ff3l/fileterm/issues/new)
-- [Read the documentation](https://github.com/St0ff3l/fileterm#readme)
-- [Join the community](https://github.com/St0ff3l/fileterm/discussions)
+For problems, open a [GitHub Issue](https://github.com/St0ff3l/fileterm/issues) with your operating system, FileTerm version, connection type, reproduction steps, and redacted logs. Do not submit passwords, private keys, or tokens.
+
+Join the community through the [README community section](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81).

--- a/docs/quality/release-notes-2.2.2.md
+++ b/docs/quality/release-notes-2.2.2.md
@@ -8,7 +8,7 @@ FileTerm 2.2.2 聚焦 macOS 退出确认交互与 SSH root 大文件上传稳定
 - **SSH root 大文件上传**：root 模式的上传临时文件从 `/tmp` 调整到 `/var/tmp`，避免 `/tmp` 为 `tmpfs` 时大文件 staging 消耗服务器内存；历史 `/tmp` 临时任务仍兼容断点恢复。
 - **稳定性验证**：补充 root 上传 staging 路径兼容性测试，并继续覆盖 SSH、传输服务和 Tauri 合约测试。
 
-### 本版本包含的主要 PR
+### 本版本包含的主要 PR 和问题修复
 
 - [PR #208](https://github.com/St0ff3l/fileterm/pull/208)：稳定退出确认焦点与 root 大文件上传 staging。
 
@@ -32,7 +32,7 @@ FileTerm 2.2.2 focuses on macOS quit confirmation behavior and SSH root-mode lar
 - **SSH root large-file uploads**: Root-mode upload staging now uses `/var/tmp` instead of `/tmp`, avoiding memory-backed staging when `/tmp` is a `tmpfs`; existing `/tmp` staging tasks remain compatible with resume.
 - **Stability validation**: Added compatibility coverage for root upload staging paths while retaining SSH, transfer-service, and Tauri contract coverage.
 
-### Main PRs
+### Main PRs and issues
 
 - [PR #208](https://github.com/St0ff3l/fileterm/pull/208): Stabilize quit confirmation focus and root large-file upload staging.
 


### PR DESCRIPTION
## Summary

- Restore the prescribed prose-style issue feedback and community links in the 2.2.2 release notes.
- Use the standard PR/issues section and comparison link.
- Remove the non-standard Feedback & Support bullet list.

## Validation

- Prettier hook passed.
- Pre-push typecheck passed.