### PR TITLE
fix(ssh): harden jump-host metrics diagnostics

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.2.8-beta.1",
+  "version": "2.2.8-beta.2",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -26,8 +26,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.1",
-    "@fileterm/shared": "2.2.8-beta.1",
+    "@fileterm/core": "2.2.8-beta.2",
+    "@fileterm/shared": "2.2.8-beta.2",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.2.8-beta.1"
+version = "2.2.8-beta.2"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.2.8-beta.1"
+version = "2.2.8-beta.2"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
+++ b/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
@@ -58,7 +58,7 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-    <release version="2.2.8-beta.1" date="2026-09-02">
+    <release version="2.2.8-beta.2" date="2026-09-02">
       <description>
         <p>Official release with multi-tab remote terminal and file management workspace.</p>
       </description>

--- a/apps/tauri/src-tauri/src/commands/platform_commands.rs
+++ b/apps/tauri/src-tauri/src/commands/platform_commands.rs
@@ -507,6 +507,37 @@ pub fn app_open_logs_directory(app: AppHandle) -> Result<(), AppError> {
     open::that(log_directory).map_err(|error| AppError::Command(error.to_string()))
 }
 
+/// Write a bounded renderer-side diagnostic into the same local app log as
+/// backend session events. This is intentionally limited to the four levels
+/// understood by the structured logger so a stale or malformed WebView cannot
+/// create an unparseable log stream. The logger performs the final secret
+/// redaction and one-line/size bounding.
+#[tauri::command]
+pub fn app_write_diagnostic_log(
+    app: AppHandle,
+    level: String,
+    scope: String,
+    message: String,
+) -> Result<(), AppError> {
+    let normalized_level = level.trim().to_ascii_uppercase();
+    let level = match normalized_level.as_str() {
+        "DEBUG" => "DEBUG",
+        "INFO" => "INFO",
+        "WARN" => "WARN",
+        "ERROR" => "ERROR",
+        _ => {
+            return Err(AppError::Command(
+                "诊断日志级别无效，仅支持 DEBUG/INFO/WARN/ERROR".to_string(),
+            ));
+        }
+    };
+    if scope.trim().is_empty() {
+        return Err(AppError::Command("诊断日志 scope 不能为空".to_string()));
+    }
+    crate::services::logging::write(&app, level, &scope, message);
+    Ok(())
+}
+
 pub use crate::services::serial_ports::SerialPortSnapshot as SerialPortListItem;
 
 #[tauri::command]

--- a/apps/tauri/src-tauri/src/lib/runtime.rs
+++ b/apps/tauri/src-tauri/src/lib/runtime.rs
@@ -451,6 +451,7 @@ pub fn run() {
             crate::commands::app_download_update,
             crate::commands::app_install_update,
             crate::commands::app_open_logs_directory,
+            crate::commands::app_write_diagnostic_log,
             crate::commands::app_list_serial_ports,
             crate::commands::app_serial_control,
             crate::commands::app_serial_transfer,

--- a/apps/tauri/src-tauri/src/sessions/ssh/device_mode.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/device_mode.rs
@@ -280,6 +280,8 @@ fn effective_resource_monitoring_enabled(profile: &Value) -> bool {
     effective_exec_channel_enabled(profile) && resource_monitoring_enabled(profile)
 }
 
+const RESOURCE_MONITORING_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(5);
+
 async fn disable_resource_monitoring_capability(
     app: &AppHandle,
     tab_id: &str,
@@ -295,13 +297,29 @@ async fn disable_resource_monitoring_capability(
             if changed {
                 session.system_metrics = None;
             }
-            changed
+            Some(changed)
         } else {
-            false
+            None
         }
     };
 
+    let Some(changed) = changed else {
+        crate::services::logging::session(
+            app,
+            "WARN",
+            "metrics",
+            tab_id,
+            format!("resource monitoring disable skipped session_not_found reason={reason}"),
+        );
+        return;
+    };
+
     if !changed {
+        crate::services::logging::debug(
+            app,
+            &format!("metrics:{tab_id}"),
+            format!("resource monitoring already disabled reason={reason}"),
+        );
         return;
     }
 
@@ -310,10 +328,69 @@ async fn disable_resource_monitoring_capability(
         "WARN",
         "metrics",
         tab_id,
-        format!("resource monitoring disabled: {reason}"),
+        format!(
+            "resource monitoring capability transition from=true to=false reason={reason}"
+        ),
     );
-    if let Ok(snapshot) = crate::commands::get_workspace_snapshot(app.clone()).await {
-        let _ = app.emit("workspace:snapshot", snapshot);
+    crate::services::logging::session(
+        app,
+        "DEBUG",
+        "metrics",
+        tab_id,
+        "resource monitoring snapshot build started capability=false",
+    );
+    match timeout(
+        RESOURCE_MONITORING_SNAPSHOT_TIMEOUT,
+        crate::commands::get_workspace_snapshot(app.clone()),
+    )
+    .await
+    {
+        Ok(Ok(snapshot)) => {
+            let workspace_revision = snapshot
+                .get("workspaceRevision")
+                .and_then(Value::as_u64)
+                .map(|revision| revision.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            match app.emit("workspace:snapshot", snapshot) {
+                Ok(()) => crate::services::logging::session(
+                    app,
+                    "INFO",
+                    "metrics",
+                    tab_id,
+                    format!(
+                        "resource monitoring disabled snapshot emitted resource_monitoring=false workspace_revision={workspace_revision}"
+                    ),
+                ),
+                Err(error) => crate::services::logging::session(
+                    app,
+                    "WARN",
+                    "metrics",
+                    tab_id,
+                    format!(
+                        "resource monitoring disabled snapshot emission failed resource_monitoring=false workspace_revision={workspace_revision} error={error}"
+                    ),
+                ),
+            }
+        }
+        Ok(Err(error)) => crate::services::logging::session(
+            app,
+            "WARN",
+            "metrics",
+            tab_id,
+            format!(
+                "resource monitoring disabled snapshot build failed resource_monitoring=false error={error}"
+            ),
+        ),
+        Err(_) => crate::services::logging::session(
+            app,
+            "WARN",
+            "metrics",
+            tab_id,
+            format!(
+                "resource monitoring disabled snapshot build timed out resource_monitoring=false timeout_secs={}",
+                RESOURCE_MONITORING_SNAPSHOT_TIMEOUT.as_secs()
+            ),
+        ),
     }
 }
 

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/loop.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/loop.rs
@@ -172,7 +172,7 @@ async fn run_worker_loop(
     });
 
     // ── Probe platform ─────────────────────────────────────────────────────
-    // 加 timeout：probe 内部最多 4 次串行 exec_command，每次都用
+    // 加 timeout：probe 内部最多 6 次串行 exec_command，每次都用
     // channel.wait() 循环读取且无内层 timeout。服务器在 exec 模式下卡住
     // 时整个 probe 会永久 await，worker 永远起不来。超时后回落到
     // "unknown"，shell CWD 注入会被 fail-closed 门控跳过，终端仍可用。
@@ -186,9 +186,22 @@ async fn run_worker_loop(
         );
         "unknown".to_string()
     } else if exec_channel_enabled {
+        crate::services::logging::session(
+            app,
+            "DEBUG",
+            "metrics",
+            tab_id,
+            format!(
+                "platform probe started exec_enabled=true timeout_secs={}",
+                PLATFORM_PROBE_TIMEOUT.as_secs()
+            ),
+        );
         match timeout(
             PLATFORM_PROBE_TIMEOUT,
-            crate::sessions::system_metrics::probe_remote_platform(&handle),
+            crate::sessions::system_metrics::probe_remote_platform_for_session(
+                &handle,
+                Some(tab_id),
+            ),
         )
         .await
         {

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/metrics.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/metrics.rs
@@ -2,6 +2,71 @@ const METRICS_MAX_BLOCK_BYTES: usize = 256 * 1024;
 const METRICS_MAX_BUFFER_BYTES: usize = 1_000_000;
 const METRICS_BUFFER_TARGET_BYTES: usize = 500_000;
 const METRICS_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
+const METRICS_STDERR_EXTENDED_DATA_TYPE: u32 = 1;
+/// Keep enough of the remote stderr tail to identify a missing command,
+/// shell syntax error, or permission failure without allowing a noisy remote
+/// process to turn diagnostics into an unbounded log stream. The logger also
+/// redacts common secret-labelled values before writing the line.
+const METRICS_STDERR_TAIL_BYTES: usize = 8 * 1024;
+
+fn append_metrics_stderr_tail(tail: &mut Vec<u8>, chunk: &[u8]) {
+    if chunk.len() >= METRICS_STDERR_TAIL_BYTES {
+        tail.clear();
+        tail.extend_from_slice(&chunk[chunk.len() - METRICS_STDERR_TAIL_BYTES..]);
+        return;
+    }
+
+    let required_drop = tail
+        .len()
+        .saturating_add(chunk.len())
+        .saturating_sub(METRICS_STDERR_TAIL_BYTES);
+    if required_drop > 0 {
+        tail.drain(..required_drop);
+    }
+    tail.extend_from_slice(chunk);
+}
+
+#[cfg(test)]
+mod metrics_tests {
+    use super::{append_metrics_stderr_tail, METRICS_STDERR_TAIL_BYTES};
+
+    #[test]
+    fn stderr_tail_is_bounded_and_keeps_latest_bytes() {
+        let mut tail = Vec::new();
+        append_metrics_stderr_tail(&mut tail, &[b'a'; METRICS_STDERR_TAIL_BYTES]);
+        append_metrics_stderr_tail(&mut tail, b"tail");
+
+        assert_eq!(tail.len(), METRICS_STDERR_TAIL_BYTES);
+        assert_eq!(&tail[tail.len() - 4..], b"tail");
+        assert!(tail[..tail.len() - 4].iter().all(|byte| *byte == b'a'));
+    }
+
+    #[test]
+    fn stderr_tail_discards_old_chunk_when_new_chunk_exceeds_cap() {
+        let mut tail = Vec::new();
+        let chunk = (0..METRICS_STDERR_TAIL_BYTES + 32)
+            .map(|index| (index % 251) as u8)
+            .collect::<Vec<_>>();
+        append_metrics_stderr_tail(&mut tail, &chunk);
+
+        assert_eq!(tail.len(), METRICS_STDERR_TAIL_BYTES);
+        assert_eq!(tail, chunk[chunk.len() - METRICS_STDERR_TAIL_BYTES..]);
+    }
+}
+
+fn metrics_stderr_preview(tail: &[u8]) -> String {
+    if tail.is_empty() {
+        "<empty>".to_string()
+    } else {
+        String::from_utf8_lossy(tail).into_owned()
+    }
+}
+
+fn metrics_exit_status_label(exit_status: Option<u32>) -> String {
+    exit_status
+        .map(|status| status.to_string())
+        .unwrap_or_else(|| "none".to_string())
+}
 
 fn should_log_metrics_anomaly(count: u64) -> bool {
     count <= 3 || count.is_power_of_two()
@@ -85,7 +150,19 @@ if effective_resource_monitoring_enabled(profile) {
             "INFO",
             "metrics",
             &metrics_tid,
-            format!("collector starting platform={metrics_plat} interval_seconds={metrics_interval_seconds}"),
+            format!(
+                "collector starting platform={} collector_variant={} interval_seconds={metrics_interval_seconds}",
+                metrics_plat,
+                if metrics_plat == "windows" {
+                    "windows"
+                } else if metrics_plat == "freebsd" {
+                    "freebsd"
+                } else if metrics_plat == "busybox" {
+                    "busybox"
+                } else {
+                    "posix-linux"
+                },
+            ),
         );
 
         // Build the infinite-loop script. Each iteration emits a
@@ -132,6 +209,7 @@ if effective_resource_monitoring_enabled(profile) {
         // 加 timeout：服务器 MaxSessions 满或网络抖动时这一步会卡住，
         // 不加超时 metrics task 会永久 await，虽然不阻塞主循环，但
         // 用户看不到系统监控数据且 worker 不会自动重试。
+        let collector_started_at = Instant::now();
         let mut channel = match timeout(
             SHELL_INIT_STEP_TIMEOUT,
             metrics_handle.channel_open_session(),
@@ -166,7 +244,14 @@ if effective_resource_monitoring_enabled(profile) {
         let collector_start = if let Some(command) = windows_command.as_deref() {
             timeout(SHELL_INIT_STEP_TIMEOUT, channel.exec(true, command)).await
         } else {
-            timeout(SHELL_INIT_STEP_TIMEOUT, channel.request_shell(true)).await
+            // Run the POSIX collector through an explicit non-interactive
+            // `sh -s` command instead of the user's login shell. CentOS/RHEL
+            // hosts commonly retain bash startup policy (or a restricted
+            // vendor shell) that can exit a no-PTY request-shell channel as
+            // soon as it receives a script. `sh -s` is available on the
+            // documented POSIX server families and keeps startup files,
+            // prompts, and aliases out of the metrics stream.
+            timeout(SHELL_INIT_STEP_TIMEOUT, channel.exec(true, "sh -s")).await
         };
         let collector_start = match collector_start {
             Ok(inner) => inner,
@@ -250,7 +335,13 @@ if effective_resource_monitoring_enabled(profile) {
             "metrics",
             &metrics_tid,
             format!(
-                "collector started; waiting for first sample idle_timeout_secs={}",
+                "collector started; waiting for first sample transport={} script_bytes={} idle_timeout_secs={}",
+                if windows_command.is_some() {
+                    "exec"
+                } else {
+                    "exec-sh-stdin"
+                },
+                script_body.as_deref().map(str::len).unwrap_or(0),
                 metrics_idle_timeout.as_secs()
             ),
         );
@@ -263,6 +354,11 @@ if effective_resource_monitoring_enabled(profile) {
         let mut malformed_block_count = 0_u64;
         let mut oversized_block_count = 0_u64;
         let mut dropped_buffer_bytes = 0_u64;
+        let mut stdout_bytes = 0_u64;
+        let mut stderr_bytes = 0_u64;
+        let mut stderr_tail = Vec::with_capacity(METRICS_STDERR_TAIL_BYTES);
+        let mut collector_exit_code = None;
+        let mut remote_terminal_event = "none";
         let close_reason = loop {
             tokio::select! {
                 biased;
@@ -299,6 +395,7 @@ if effective_resource_monitoring_enabled(profile) {
                             break "idle-timeout";
                         }
                         Ok(Some(ChannelMsg::Data { data })) => {
+                            stdout_bytes = stdout_bytes.saturating_add(data.len() as u64);
                             buffer.extend_from_slice(data.as_ref());
                             // Drain all complete blocks from the buffer.
                             while let Some(idx) = find_subsequence(&buffer, marker_bytes) {
@@ -428,33 +525,189 @@ if effective_resource_monitoring_enabled(profile) {
                                 );
                             }
                         }
-                        Ok(Some(ChannelMsg::ExtendedData { data, .. })) => {
-                            buffer.extend_from_slice(data.as_ref());
-                            if buffer.len() > METRICS_MAX_BUFFER_BYTES {
-                                let dropped = buffer.len() - METRICS_BUFFER_TARGET_BYTES;
-                                buffer.drain(..dropped);
-                                dropped_buffer_bytes =
-                                    dropped_buffer_bytes.saturating_add(dropped as u64);
+                        Ok(Some(ChannelMsg::ExtendedData { data, ext })) => {
+                            if ext == METRICS_STDERR_EXTENDED_DATA_TYPE {
+                                stderr_bytes = stderr_bytes.saturating_add(data.len() as u64);
+                                append_metrics_stderr_tail(&mut stderr_tail, data.as_ref());
+                            } else {
                                 crate::services::logging::session(
                                     &metrics_app,
                                     "WARN",
                                     "metrics",
                                     &metrics_tid,
                                     format!(
-                                        "collector stderr buffer capped dropped_bytes={} total_dropped_bytes={} buffer_bytes={}",
-                                        dropped,
-                                        dropped_buffer_bytes,
-                                        buffer.len(),
+                                        "collector unexpected extended data ext={} bytes={}",
+                                        ext,
+                                        data.len()
                                     ),
                                 );
                             }
                         }
-                        Ok(Some(ChannelMsg::ExitStatus { .. })) | Ok(None) => {
+                        Ok(Some(ChannelMsg::ExitStatus { exit_status })) => {
+                            collector_exit_code = Some(exit_status);
+                            remote_terminal_event = "exit-status";
+                            crate::services::logging::session(
+                                &metrics_app,
+                                if exit_status == 0 { "INFO" } else { "WARN" },
+                                "metrics",
+                                    &metrics_tid,
+                                    format!(
+                                        "collector exit status exit_code={} stderr_bytes={} stderr_tail={} elapsed_ms={}",
+                                        exit_status,
+                                    stderr_bytes,
+                                    metrics_stderr_preview(&stderr_tail),
+                                    collector_started_at.elapsed().as_millis(),
+                                ),
+                            );
                             if !metrics_cancellation.is_cancelled() {
                                 disable_resource_monitoring_capability(
                                     &metrics_app,
                                     &metrics_tid,
-                                    "collector channel closed",
+                                    format!("collector exited with status {exit_status}"),
+                                )
+                                .await;
+                            }
+                            break "channel-exit";
+                        }
+                        Ok(Some(ChannelMsg::ExitSignal {
+                            signal_name,
+                            core_dumped,
+                            error_message,
+                            lang_tag,
+                        })) => {
+                            remote_terminal_event = "exit-signal";
+                            crate::services::logging::session(
+                                &metrics_app,
+                                "WARN",
+                                "metrics",
+                                &metrics_tid,
+                                format!(
+                                    "collector exit signal signal={signal_name:?} core_dumped={core_dumped} error_message={error_message:?} lang_tag={lang_tag:?} stderr_bytes={} stderr_tail={}",
+                                    stderr_bytes,
+                                    metrics_stderr_preview(&stderr_tail),
+                                ),
+                            );
+                            if !metrics_cancellation.is_cancelled() {
+                                disable_resource_monitoring_capability(
+                                    &metrics_app,
+                                    &metrics_tid,
+                                    format!("collector terminated by signal {signal_name:?}"),
+                                )
+                                .await;
+                            }
+                            break "channel-exit-signal";
+                        }
+                        Ok(Some(ChannelMsg::Eof)) => {
+                            remote_terminal_event = "eof";
+                            crate::services::logging::session(
+                                &metrics_app,
+                                "WARN",
+                                "metrics",
+                                &metrics_tid,
+                                format!(
+                                    "remote collector sent EOF before exit status stdout_bytes={} stderr_bytes={} stderr_tail={}",
+                                    stdout_bytes,
+                                    stderr_bytes,
+                                    metrics_stderr_preview(&stderr_tail),
+                                ),
+                            );
+                            if !metrics_cancellation.is_cancelled() {
+                                disable_resource_monitoring_capability(
+                                    &metrics_app,
+                                    &metrics_tid,
+                                    "remote collector sent EOF before exit status",
+                                )
+                                .await;
+                            }
+                            break "remote-eof";
+                        }
+                        Ok(Some(ChannelMsg::Close)) => {
+                            remote_terminal_event = "close";
+                            crate::services::logging::session(
+                                &metrics_app,
+                                "WARN",
+                                "metrics",
+                                &metrics_tid,
+                                format!(
+                                    "remote collector sent channel close stdout_bytes={} stderr_bytes={} stderr_tail={}",
+                                    stdout_bytes,
+                                    stderr_bytes,
+                                    metrics_stderr_preview(&stderr_tail),
+                                ),
+                            );
+                            if !metrics_cancellation.is_cancelled() {
+                                disable_resource_monitoring_capability(
+                                    &metrics_app,
+                                    &metrics_tid,
+                                    "remote collector sent channel close without exit status",
+                                )
+                                .await;
+                            }
+                            break "remote-close";
+                        }
+                        Ok(Some(ChannelMsg::Failure)) => {
+                            remote_terminal_event = "failure";
+                            crate::services::logging::session(
+                                &metrics_app,
+                                "WARN",
+                                "metrics",
+                                &metrics_tid,
+                                format!(
+                                    "remote collector channel request failed stdout_bytes={} stderr_bytes={} stderr_tail={}",
+                                    stdout_bytes,
+                                    stderr_bytes,
+                                    metrics_stderr_preview(&stderr_tail),
+                                ),
+                            );
+                            if !metrics_cancellation.is_cancelled() {
+                                disable_resource_monitoring_capability(
+                                    &metrics_app,
+                                    &metrics_tid,
+                                    "remote collector channel request failed",
+                                )
+                                .await;
+                            }
+                            break "remote-failure";
+                        }
+                        Ok(Some(ChannelMsg::OpenFailure(reason))) => {
+                            remote_terminal_event = "open-failure";
+                            crate::services::logging::session(
+                                &metrics_app,
+                                "WARN",
+                                "metrics",
+                                &metrics_tid,
+                                format!("remote collector channel open failure reason={reason:?}"),
+                            );
+                            if !metrics_cancellation.is_cancelled() {
+                                disable_resource_monitoring_capability(
+                                    &metrics_app,
+                                    &metrics_tid,
+                                    "remote collector channel open failure",
+                                )
+                                .await;
+                            }
+                            break "remote-open-failure";
+                        }
+                        Ok(None) => {
+                            remote_terminal_event = "stream-ended";
+                            crate::services::logging::session(
+                                &metrics_app,
+                                "WARN",
+                                "metrics",
+                                &metrics_tid,
+                                format!(
+                                    "collector channel stream ended without terminal event reason=remote-stream-ended-or-transport-drop stdout_bytes={} stderr_bytes={} stderr_tail={} elapsed_ms={}",
+                                    stdout_bytes,
+                                    stderr_bytes,
+                                    metrics_stderr_preview(&stderr_tail),
+                                    collector_started_at.elapsed().as_millis(),
+                                ),
+                            );
+                            if !metrics_cancellation.is_cancelled() {
+                                disable_resource_monitoring_capability(
+                                    &metrics_app,
+                                    &metrics_tid,
+                                    "collector channel ended without exit status",
                                 )
                                 .await;
                             }
@@ -473,11 +726,15 @@ if effective_resource_monitoring_enabled(profile) {
             "metrics",
             &metrics_tid,
             format!(
-                "collector stopped reason={close_reason} samples={} malformed_samples={} oversized_samples={} dropped_buffer_bytes={}",
+                "collector stopped reason={close_reason} remote_terminal_event={remote_terminal_event} exit_code={} samples={} malformed_samples={} oversized_samples={} dropped_buffer_bytes={} stdout_bytes={} stderr_bytes={} stderr_tail={}",
+                metrics_exit_status_label(collector_exit_code),
                 sample_count,
                 malformed_block_count,
                 oversized_block_count,
                 dropped_buffer_bytes,
+                stdout_bytes,
+                stderr_bytes,
+                metrics_stderr_preview(&stderr_tail),
             ),
         );
     });

--- a/apps/tauri/src-tauri/src/sessions/system_metrics/exec.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics/exec.rs
@@ -1,24 +1,30 @@
 pub async fn probe_remote_platform<H: Handler>(handle: &Handle<H>) -> String {
-    // 1. Try POSIX probe
-    let posix_cmd = "sh -lc 'printf \"__FILETERM_PROBE_START__\\n\"; uname -s 2>/dev/null; shell_exe=$(readlink /proc/$$/exe 2>/dev/null || readlink /bin/sh 2>/dev/null || true); case \"$shell_exe\" in *busybox*) printf \"busybox\\n\" ;; esac; if [ -f /etc/openwrt_release ]; then printf \"openwrt\\n\"; fi; printf \"__FILETERM_PROBE_END__\\n\"'";
+    probe_remote_platform_for_session(handle, None).await
+}
 
-    let posix_result = exec_command(handle, posix_cmd).await;
-    eprintln!(
-        "[SSH probe] posix exec_command result_ok={} len={}",
-        posix_result.is_ok(),
-        posix_result.as_ref().map(|s| s.len()).unwrap_or(0)
-    );
-    if let Ok(output) = &posix_result {
+/// Probe the remote platform while attaching the tab id to diagnostic lines.
+/// The context-free wrapper above keeps the pure protocol tests and other
+/// callers stable; worker sessions use this variant so concurrent tabs can be
+/// separated in the exported app log.
+pub(crate) async fn probe_remote_platform_for_session<H: Handler>(
+    handle: &Handle<H>,
+    tab_id: Option<&str>,
+) -> String {
+    // 1. Try POSIX probe
+    let posix_cmd = "sh -lc 'printf \"__FILETERM_PROBE_START__\\n\"; uname -s 2>/dev/null; shell_exe=$(readlink /proc/$$/exe 2>/dev/null || readlink /bin/sh 2>/dev/null || true); case \"$shell_exe\" in *busybox*) printf \"busybox\\n\" ;; esac; if [ -f /etc/openwrt_release ]; then printf \"openwrt\\n\"; fi; if [ -r /etc/centos-release ] || [ -r /etc/redhat-release ] || [ -r /etc/fedora-release ]; then printf \"linux\\n\"; fi; printf \"__FILETERM_PROBE_END__\\n\"'";
+
+    let posix_result = exec_command_with_status_detailed(handle, posix_cmd).await;
+    log_probe_result("posix", &posix_result, tab_id);
+    if let Ok(result) = &posix_result {
         // CRLF normalization — Windows remotes emit `\r\n` which would
         // pollute platform detection (e.g. `linux\r` fails `contains`).
-        let output = output.replace("\r\n", "\n").replace('\r', "\n");
-        eprintln!(
-            "[SSH probe] posix normalized output (first 300): {:?}",
-            output.chars().take(300).collect::<String>()
-        );
+        let output = result.output.replace("\r\n", "\n").replace('\r', "\n");
         if let Some(body) = extract_probe_body(&output) {
-            eprintln!("[SSH probe] body='{}'", body);
             if let Some(platform) = classify_posix_probe_body(&body) {
+                log_probe_message(
+                    tab_id,
+                    format!("probe=posix classified platform={platform}"),
+                );
                 return platform.to_string();
             }
         }
@@ -28,9 +34,37 @@ pub async fn probe_remote_platform<H: Handler>(handle: &Handle<H>) -> String {
     // shell (`sh -lc`) or print an unexpected login banner around it. Keep a
     // bare POSIX fallback so platform detection does not depend on shell
     // startup files. This is especially useful for hosted Debian 12 images.
-    if let Ok(output) = exec_command(handle, "uname -s 2>/dev/null").await {
-        let output = output.replace("\r\n", "\n").replace('\r', "\n");
+    let fallback_probe = "uname -s 2>/dev/null; if [ -r /etc/centos-release ] || [ -r /etc/redhat-release ] || [ -r /etc/fedora-release ]; then cat /etc/centos-release /etc/redhat-release /etc/fedora-release 2>/dev/null; fi";
+    let fallback_result = exec_command_with_status_detailed(handle, fallback_probe).await;
+    log_probe_result("posix-fallback", &fallback_result, tab_id);
+    if let Ok(result) = &fallback_result {
+        let output = result.output.replace("\r\n", "\n").replace('\r', "\n");
         if let Some(platform) = classify_posix_probe_body(&output) {
+            log_probe_message(
+                tab_id,
+                format!("probe=posix-fallback classified platform={platform}"),
+            );
+            return platform.to_string();
+        }
+    }
+
+    // RHEL/CentOS 7 documents `/etc/redhat-release` as the release identity
+    // source. Keep a direct `cat` probe after the generic POSIX probes so a
+    // restricted login shell (or an image without a usable `sh -lc`) can
+    // still be recognized without depending on `/etc/os-release`.
+    let release_result = exec_command_with_status_detailed(
+        handle,
+        "cat /etc/redhat-release /etc/centos-release /etc/fedora-release /etc/os-release 2>/dev/null",
+    )
+    .await;
+    log_probe_result("release-files", &release_result, tab_id);
+    if let Ok(result) = &release_result {
+        let output = result.output.replace("\r\n", "\n").replace('\r', "\n");
+        if let Some(platform) = classify_posix_probe_body(&output) {
+            log_probe_message(
+                tab_id,
+                format!("probe=release-files classified platform={platform}"),
+            );
             return platform.to_string();
         }
     }
@@ -42,21 +76,58 @@ pub async fn probe_remote_platform<H: Handler>(handle: &Handle<H>) -> String {
         "cmd /c ver",
     ];
     for cmd in &windows_cmds {
-        if let Ok(output) = exec_command(handle, cmd).await {
+        let result = exec_command_with_status_detailed(handle, cmd).await;
+        log_probe_result(cmd, &result, tab_id);
+        if let Ok(result) = &result {
+            let output = &result.output;
             let output = output.replace("\r\n", "\n").replace('\r', "\n");
-            eprintln!(
-                "[SSH probe] windows cmd='{}' output='{}'",
-                cmd,
-                output.chars().take(100).collect::<String>()
-            );
             if let Some(platform) = classify_windows_probe_output(&output) {
+                log_probe_message(tab_id, format!("probe={cmd} classified platform={platform}"));
                 return platform.to_string();
             }
         }
     }
 
-    eprintln!("[SSH probe] all probes failed — returning 'unknown'");
+    log_probe_message(tab_id, "all probes failed; returning platform=unknown");
     "unknown".to_string()
+}
+
+fn log_probe_scope(tab_id: Option<&str>) -> String {
+    tab_id
+        .map(|tab_id| format!("ssh-probe:{tab_id}"))
+        .unwrap_or_else(|| "ssh-probe".to_string())
+}
+
+fn log_probe_message(tab_id: Option<&str>, message: impl AsRef<str>) {
+    let scope = log_probe_scope(tab_id);
+    crate::services::logging::debug_global(&scope, message);
+}
+
+fn log_probe_result(
+    label: &str,
+    result: &Result<ExecCommandResult, String>,
+    tab_id: Option<&str>,
+) {
+    let scope = log_probe_scope(tab_id);
+    match result {
+        Ok(result) => crate::services::logging::debug_global(
+            &scope,
+            format!(
+                "probe={label} result=ok exit_code={} timed_out={} output_truncated={} output={:?}",
+                result
+                    .exit_code
+                    .map(|status| status.to_string())
+                    .unwrap_or_else(|| "none".to_string()),
+                result.timed_out,
+                result.output_truncated,
+                result.output.chars().take(300).collect::<String>(),
+            ),
+        ),
+        Err(error) => crate::services::logging::debug_global(
+            &scope,
+            format!("probe={label} result=error error={error}"),
+        ),
+    }
 }
 
 /// Classify the body of the POSIX probe (the text between
@@ -71,7 +142,14 @@ fn classify_posix_probe_body(body: &str) -> Option<&'static str> {
     if normalized.contains("openwrt") || normalized.contains("busybox") {
         return Some("busybox");
     }
-    if normalized.contains("linux") {
+    if normalized.contains("linux")
+        || normalized.contains("centos")
+        || normalized.contains("red hat")
+        || normalized.contains("rhel")
+        || normalized.contains("fedora")
+        || normalized.contains("rocky linux")
+        || normalized.contains("almalinux")
+    {
         return Some("linux");
     }
     if normalized.contains("freebsd") {

--- a/apps/tauri/src-tauri/src/sessions/system_metrics/freebsd.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics/freebsd.rs
@@ -9,6 +9,8 @@
 /// match the POSIX parser so the renderer does not need a second protocol.
 pub fn build_freebsd_metrics_command() -> String {
     r#"cd / >/dev/null 2>&1 || true
+# Keep sysctl/ps/df/swapinfo output stable on localized legacy hosts.
+export LC_ALL=C
 sleep_interval="0.15"
 
 read_number() {

--- a/apps/tauri/src-tauri/src/sessions/system_metrics/posix.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics/posix.rs
@@ -2,6 +2,9 @@ pub fn build_posix_metrics_command(platform: &str) -> String {
     let complete_marker = "__FILETERM_METRICS_COMPLETE__";
     format!(
         r#"cd / >/dev/null 2>&1 || true
+# Keep procps/coreutils output stable on localized CentOS/RHEL 7 hosts.
+# The parser consumes command output rather than translated table headers.
+export LC_ALL=C
 sleep_interval="0.15"
 sleep "$sleep_interval" >/dev/null 2>&1 || sleep_interval="1"
 run_bounded() {{

--- a/apps/tauri/src-tauri/src/sessions/system_metrics/tests.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics/tests.rs
@@ -51,6 +51,7 @@ mod tests {
         // 进程输出格式：pid|user|rss(M)|pcpu(已归一化)|pmem|args
         assert!(command.contains(r#"printf "%s|%s|%.1fM|%.1f|%s|%s\n"#));
         assert!(command.contains("getconf _NPROCESSORS_ONLN"));
+        assert!(command.contains("export LC_ALL=C"));
         assert!(command.contains("for (row_index = 1; row_index <= model_count; row_index++)"));
         assert!(!command.contains("for (index = 1; index <= model_count; index++)"));
         assert!(!command.contains(r#"printf "%s|%sK/%sK\\n"#));
@@ -96,6 +97,7 @@ mod tests {
         assert!(command.contains("hw.physmem"));
         assert!(command.contains("swapinfo -k"));
         assert!(command.contains("df -kP"));
+        assert!(command.contains("export LC_ALL=C"));
         assert!(command.contains("ps -axo pid=,user=,rss=,pcpu=,pmem=,command="));
         assert!(command.contains("rctl -u"));
         assert!(command.contains("rctl -l"));
@@ -477,6 +479,14 @@ devil() {{
         // CRLF pollution is normalized by the caller, but the classifier is
         // tolerant of stray case differences.
         assert_eq!(classify_posix_probe_body("LINUX\n"), Some("linux"));
+        assert_eq!(
+            classify_posix_probe_body("CentOS Linux release 7.9.2009 (Core)\n"),
+            Some("linux")
+        );
+        assert_eq!(
+            classify_posix_probe_body("Red Hat Enterprise Linux Server release 7.9\n"),
+            Some("linux")
+        );
         assert_eq!(classify_posix_probe_body("busybox\n"), Some("busybox"));
         assert_eq!(classify_posix_probe_body("OpenWrt\n"), Some("busybox"));
     }

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.2.8-beta.1",
+  "version": "2.2.8-beta.2",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/apps/tauri/src/bridge/tauri-api.ts
+++ b/apps/tauri/src/bridge/tauri-api.ts
@@ -502,6 +502,8 @@ export async function createTauriApi(): Promise<FileTermDesktopApi> {
       }),
     openExternalUrl: (url: string) => invoke<void>('app_open_external_url', { url }),
     openLogsDirectory: () => invoke<void>('app_open_logs_directory'),
+    writeDiagnosticLog: (level: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR', scope: string, message: string) =>
+      invoke<void>('app_write_diagnostic_log', { level, scope, message }),
     listSerialPorts: () => invoke<SerialPortInfo[]>('app_list_serial_ports'),
     onSerialPortsChanged: (listener: (ports: SerialPortInfo[]) => void) => subscribe('serial:ports-changed', listener),
     serialControl: (tabId: string, action: SerialControlAction, value?: boolean, durationMs?: number) =>
@@ -815,7 +817,8 @@ export async function createTauriApi(): Promise<FileTermDesktopApi> {
     onTransferUpdate: (listener: (transfer: TransferTask) => void) => subscribe('transfer:update', listener),
     onSerialTransferProgress: (listener: (progress: SerialTransferProgress) => void) =>
       subscribe('serial:transfer-progress', listener),
-    onWorkspaceSnapshot: (listener: (snapshot: WorkspaceSnapshot) => void) => subscribe('workspace:snapshot', listener),
+    onWorkspaceSnapshot: (listener: (snapshot: WorkspaceSnapshot) => void) =>
+      subscribeReady('workspace:snapshot', listener),
     onSessionMetrics: (listener: (payload: SessionMetricsUpdate) => void) =>
       subscribe('workspace:sessionMetrics', listener),
     onRemoteFilesChanged: (listener: (payload: RemoteFilesUpdate) => void) =>

--- a/apps/tauri/src/renderer/hooks/use-app-workspace.ts
+++ b/apps/tauri/src/renderer/hooks/use-app-workspace.ts
@@ -136,6 +136,7 @@ export function useAppWorkspace({
   const [isWorkspaceTransitionActive, setIsWorkspaceTransitionActive] = useState(true)
   const [isWorkspaceSwitching, setIsWorkspaceSwitching] = useState(false)
   const hasRenderedWorkspaceRef = useRef(false)
+  const lastResourceMonitoringDiagnosticRef = useRef('')
 
   const {
     localTabs,
@@ -259,6 +260,39 @@ export function useAppWorkspace({
   const aiCopilotTargetSession = activePaneSession ?? activeSession
   const isAiCopilotAvailable = Boolean(activeTab)
   const shouldShowAiCopilot = isAiCopilotOpen && !isHomeWorkspaceVisible
+
+  useEffect(() => {
+    if (!desktopApi || !activeTab) {
+      return
+    }
+    const resourceMonitoring = activeSession?.capabilities?.resourceMonitoring
+    const collapseReason = !activeSshResourceMonitoring
+      ? 'profile-disabled'
+      : resourceMonitoring === false
+        ? 'remote-capability-disabled'
+        : isWorkspaceFocusMode
+          ? 'workspace-focus'
+          : isSystemSidebarUserCollapsed
+            ? 'user-collapsed'
+            : 'none'
+    const diagnostic = `resource monitoring UI state tab_id=${activeTab.id} connected=${activeSession?.connected === true} configured=${activeSshResourceMonitoring} capability=${resourceMonitoring === undefined ? 'unknown' : resourceMonitoring} available=${isResourceMonitoringAvailable} sidebar_rendered=${shouldShowSystemSidebar} sidebar_collapsed=${isSystemSidebarCollapsed} collapse_reason=${collapseReason}`
+    if (lastResourceMonitoringDiagnosticRef.current === diagnostic) {
+      return
+    }
+    lastResourceMonitoringDiagnosticRef.current = diagnostic
+    void desktopApi.writeDiagnosticLog('DEBUG', 'renderer:workspace', diagnostic).catch(() => undefined)
+  }, [
+    activeSession?.capabilities?.resourceMonitoring,
+    activeSession?.connected,
+    activeSshResourceMonitoring,
+    activeTab,
+    desktopApi,
+    isResourceMonitoringAvailable,
+    isSystemSidebarCollapsed,
+    isSystemSidebarUserCollapsed,
+    isWorkspaceFocusMode,
+    shouldShowSystemSidebar
+  ])
 
   const setActiveFilePanelHeight = useCallback(
     (next: SetStateAction<number>) => {

--- a/apps/tauri/src/renderer/hooks/use-workspace-ipc-sync.ts
+++ b/apps/tauri/src/renderer/hooks/use-workspace-ipc-sync.ts
@@ -38,6 +38,8 @@ import {
   type SshConnectionDefaults
 } from './workspace-ipc-sync-utils'
 
+const SNAPSHOT_LISTENER_READY_TIMEOUT_MS = 5_000
+
 export type WorkspaceWindowCloseRequest = {
   id: number
   isQuit: boolean
@@ -94,7 +96,7 @@ export type UseWorkspaceIpcSyncOptions = {
 export type UseWorkspaceIpcSyncResult = {
   workspace: WorkspaceSnapshot
   setWorkspace: Dispatch<SetStateAction<WorkspaceSnapshot>>
-  applySnapshot(snapshot: WorkspaceSnapshot): void
+  applySnapshot(snapshot: WorkspaceSnapshot): boolean
   localPath: string
   setLocalPath: Dispatch<SetStateAction<string>>
   localItems: LocalFileItem[]
@@ -192,17 +194,46 @@ export function useWorkspaceIpcSync({
   const nextPaneFocusRequestIdRef = useRef(0)
   const notifiedTransferFailuresRef = useRef(new Map<string, string>())
 
-  const applySnapshot = useCallback((snapshot: WorkspaceSnapshot) => {
-    const incomingRevision = snapshot.workspaceRevision
-    const latestRevision = latestWorkspaceRevisionRef.current
-    if (typeof incomingRevision === 'number' && latestRevision !== null && incomingRevision < latestRevision) {
-      return
-    }
-    if (typeof incomingRevision === 'number') {
-      latestWorkspaceRevisionRef.current = incomingRevision
-    }
-    setWorkspace(snapshot)
-  }, [])
+  const logWorkspaceDiagnostic = useCallback(
+    (level: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR', message: string) => {
+      if (!desktopApi) {
+        return
+      }
+      // Diagnostics must never make a workspace event handler fail. The
+      // backend logger is best-effort and also performs secret redaction and
+      // size bounding before writing app.log.
+      void desktopApi.writeDiagnosticLog(level, 'renderer:workspace', message).catch(() => undefined)
+    },
+    [desktopApi]
+  )
+
+  const applySnapshot = useCallback(
+    (snapshot: WorkspaceSnapshot): boolean => {
+      const incomingRevision = snapshot.workspaceRevision
+      const latestRevision = latestWorkspaceRevisionRef.current
+      if (typeof incomingRevision === 'number' && latestRevision !== null && incomingRevision < latestRevision) {
+        logWorkspaceDiagnostic(
+          'DEBUG',
+          `workspace snapshot ignored reason=stale-revision incoming_revision=${incomingRevision} latest_revision=${latestRevision}`
+        )
+        return false
+      }
+      if (typeof incomingRevision === 'number') {
+        latestWorkspaceRevisionRef.current = incomingRevision
+      }
+      setWorkspace(snapshot)
+      const disabledResourceMonitoringSessions = Object.values(snapshot.sessions).filter(
+        (session) => session.capabilities?.resourceMonitoring === false
+      ).length
+      const activeSession = snapshot.activeTabId ? snapshot.sessions[snapshot.activeTabId] : undefined
+      logWorkspaceDiagnostic(
+        'INFO',
+        `workspace snapshot applied workspace_revision=${typeof incomingRevision === 'number' ? incomingRevision : 'none'} sessions=${Object.keys(snapshot.sessions).length} resource_monitoring_disabled_sessions=${disabledResourceMonitoringSessions} active_tab_id=${snapshot.activeTabId ?? 'none'} active_tab_resource_monitoring_disabled=${activeSession?.capabilities?.resourceMonitoring === false}`
+      )
+      return true
+    },
+    [logWorkspaceDiagnostic]
+  )
 
   const applySessionMetrics = useCallback(({ tabId, systemMetrics, mode }: SessionMetricsUpdate) => {
     startTransition(() => {
@@ -540,6 +571,15 @@ export function useWorkspaceIpcSync({
     const pendingMetrics: SessionMetricsUpdate[] = []
     const pendingTransfers: TransferTask[] = []
     const pendingRemoteFiles: RemoteFilesUpdate[] = []
+    let unsubscribeSnapshot: (() => void) | null = null
+    let snapshotListenerReadyTimer: ReturnType<typeof window.setTimeout> | null = null
+    const clearSnapshotListenerReadyTimer = () => {
+      if (snapshotListenerReadyTimer === null) {
+        return
+      }
+      window.clearTimeout(snapshotListenerReadyTimer)
+      snapshotListenerReadyTimer = null
+    }
 
     const processTransferUpdate = (transfer: TransferTask) => {
       const banner = uploadFailureBanner(transfer)
@@ -577,14 +617,47 @@ export function useWorkspaceIpcSync({
       flushPendingUpdates()
     }
 
-    const unsubscribeSnapshot = desktopApi.onWorkspaceSnapshot((snapshot) => {
-      if (canceled) {
-        return
-      }
-      receivedSnapshotEvent = true
-      applySnapshot(snapshot)
-      finishHydration()
-    })
+    const snapshotListenerRegistration = desktopApi
+      .onWorkspaceSnapshot((snapshot) => {
+        if (canceled) {
+          return
+        }
+        logWorkspaceDiagnostic(
+          'DEBUG',
+          `workspace snapshot event received workspace_revision=${typeof snapshot.workspaceRevision === 'number' ? snapshot.workspaceRevision : 'none'} sessions=${Object.keys(snapshot.sessions).length} active_tab_id=${snapshot.activeTabId ?? 'none'}`
+        )
+        receivedSnapshotEvent = applySnapshot(snapshot) || receivedSnapshotEvent
+        finishHydration()
+      })
+      .then((unsubscribe) => {
+        if (canceled) {
+          unsubscribe()
+          return
+        }
+        unsubscribeSnapshot = unsubscribe
+        logWorkspaceDiagnostic('DEBUG', 'workspace snapshot listener registered')
+      })
+      .catch((error: unknown) => {
+        if (!canceled) {
+          logWorkspaceDiagnostic('WARN', `workspace snapshot listener registration failed error=${String(error)}`)
+        }
+      })
+      .finally(clearSnapshotListenerReadyTimer)
+    const snapshotListenerReady = Promise.race([
+      snapshotListenerRegistration,
+      new Promise<void>((resolve) => {
+        snapshotListenerReadyTimer = window.setTimeout(() => {
+          snapshotListenerReadyTimer = null
+          if (!canceled) {
+            logWorkspaceDiagnostic(
+              'WARN',
+              `workspace snapshot listener registration timeout timeout_ms=${SNAPSHOT_LISTENER_READY_TIMEOUT_MS}`
+            )
+          }
+          resolve()
+        }, SNAPSHOT_LISTENER_READY_TIMEOUT_MS)
+      })
+    ])
     const unsubscribeSessionMetrics = isMainWorkspaceWindow
       ? desktopApi.onSessionMetrics((payload) => {
           if (canceled) {
@@ -624,12 +697,22 @@ export function useWorkspaceIpcSync({
 
     const hydrateWorkspace = async () => {
       try {
+        // Tauri event registration is asynchronous. Wait for the snapshot
+        // listener before taking the initial snapshot so a fast connection
+        // cannot emit the capability=false update into an unregistered
+        // WebView callback. getSnapshot below reconciles events emitted while
+        // the listener handshake was in flight.
+        await snapshotListenerReady
+        if (canceled) {
+          return
+        }
         // A standalone connection editor only needs persisted profiles and
         // folders. Do not couple it to the full workspace snapshot: that
         // snapshot initializes transfer/session state first and can fail or
         // race while a child window opens, leaving the editor unable to find
         // the profile selected in the manager.
         if (isConnectionManagerWindow || isConnectionFormWindow) {
+          logWorkspaceDiagnostic('DEBUG', 'workspace library hydration started')
           const snapshot = await desktopApi.getConnectionLibrary()
           if (canceled || receivedSnapshotEvent) {
             return
@@ -639,15 +722,21 @@ export function useWorkspaceIpcSync({
             profiles: snapshot.profiles,
             folders: snapshot.folders
           }))
+          logWorkspaceDiagnostic(
+            'DEBUG',
+            `workspace library hydration applied profiles=${snapshot.profiles.length} folders=${snapshot.folders.length}`
+          )
           return
         }
 
+        logWorkspaceDiagnostic('DEBUG', 'workspace snapshot hydration started')
         const snapshot = await desktopApi.getSnapshot()
         if (!canceled && !receivedSnapshotEvent) {
           applySnapshot(snapshot)
         }
       } catch (error) {
         if (!canceled && !receivedSnapshotEvent) {
+          logWorkspaceDiagnostic('WARN', `workspace hydration failed error=${String(error)}`)
           onErrorRef.current(
             isConnectionManagerWindow || isConnectionFormWindow ? '获取连接列表' : '获取工作区快照',
             error
@@ -688,7 +777,8 @@ export function useWorkspaceIpcSync({
       pendingMetrics.length = 0
       pendingTransfers.length = 0
       pendingRemoteFiles.length = 0
-      unsubscribeSnapshot()
+      clearSnapshotListenerReadyTimer()
+      unsubscribeSnapshot?.()
       unsubscribeSessionMetrics()
       unsubscribeTransferUpdate()
       unsubscribeRemoteFilesChanged()
@@ -701,7 +791,8 @@ export function useWorkspaceIpcSync({
     desktopApi,
     isConnectionFormWindow,
     isConnectionManagerWindow,
-    isMainWorkspaceWindow
+    isMainWorkspaceWindow,
+    logWorkspaceDiagnostic
   ])
 
   const clearWindowCloseRequest = useCallback(() => {

--- a/docs/release-notes/release-notes-2.2.8-beta.2.md
+++ b/docs/release-notes/release-notes-2.2.8-beta.2.md
@@ -1,0 +1,47 @@
+## FileTerm 2.2.8-beta.2
+
+FileTerm 2.2.8-beta.2 是面向 SSH 跳板机和老系统连接场景的诊断测试版，重点验证资源侧栏获取失败时是否能自动降级而不影响终端和 SFTP。
+
+### 2.2.8-beta.2 更新重点
+
+- **跳板机与旧系统兼容性**：改进 CentOS/RHEL 7 类 POSIX 主机的平台探测、非交互采集和本地化输出处理；资源采集失败不会中断目标机终端或文件连接。
+- **侧栏稳定性**：为指标通道增加 watchdog、退出状态、远端 stderr、EOF/Close 和超时诊断；采集能力关闭后会通过 workspace snapshot 同步到前端并折叠资源侧栏。
+- **跳板认证诊断**：保留跳板机与目标机独立的认证阶段、请求序号和跳数信息，便于定位密码、键盘交互或 OTP 在哪一跳失败。
+- **安全边界**：日志只记录请求 ID、跳数、状态、字节数和受限的错误尾部，不记录 OTP、密码、私钥口令或交互答案；本版本不新增 FIDO2/Web SSO 流程，也未宣称完成 CentOS 7 实机验证。
+
+### 本版本包含的主要 PR 和问题修复
+
+- [PR #230](https://github.com/St0ff3l/fileterm/pull/230)：跳板机资源侧栏诊断与降级修复，覆盖平台探测、指标 channel 关闭原因、snapshot 发送/接收/应用以及侧栏折叠状态。
+
+完整变更记录请查看 [v2.2.8-beta.1 与 v2.2.8-beta.2 的比较](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.1...v2.2.8-beta.2)。
+
+### 反馈与支持
+
+遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
+
+也可以打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81) 加入社区。
+
+---
+
+## FileTerm 2.2.8-beta.2
+
+FileTerm 2.2.8-beta.2 is a diagnostic beta for SSH jump-host and legacy-system workflows, focused on degrading resource-sidebar collection failures without affecting the terminal or SFTP.
+
+### Highlights
+
+- **Jump-host and legacy-system compatibility**: Improve platform detection, non-interactive collection, and locale-stable output handling for CentOS/RHEL 7-class POSIX hosts; a monitoring failure no longer interrupts the target terminal or file connection.
+- **Sidebar stability**: Add watchdog, exit-status, remote-stderr, EOF/Close, and timeout diagnostics for the metrics channel; after monitoring is disabled, a workspace snapshot synchronizes the capability to the renderer and collapses the resource sidebar.
+- **Jump authentication diagnostics**: Preserve independent jump-host and target authentication stages with request sequence and hop information, making password, keyboard-interactive, and OTP failures attributable to a specific hop.
+- **Security boundary**: Logs contain only request IDs, hop metadata, status, byte counts, and a bounded error tail; OTPs, passwords, private-key passphrases, and interactive answers are not recorded. This release does not add a FIDO2/Web SSO flow and has not been claimed as an in-person CentOS 7 validation.
+
+### Main PRs and issues
+
+- [PR #230](https://github.com/St0ff3l/fileterm/pull/230): Jump-host resource-sidebar diagnostics and graceful-degradation fixes covering platform probing, metrics-channel close reasons, snapshot emission/receipt/application, and sidebar collapse state.
+
+See the [comparison between v2.2.8-beta.1 and v2.2.8-beta.2](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.1...v2.2.8-beta.2) for the complete change set.
+
+### Feedback & Support
+
+For problems, open a [GitHub Issue](https://github.com/St0ff3l/fileterm/issues) with the operating system, FileTerm version, connection type, reproduction steps, and redacted logs. Do not submit passwords, private keys, or tokens.
+
+Join the community through the [README community section](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.1",
+  "version": "2.2.8-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.2.8-beta.1",
+      "version": "2.2.8-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,10 +33,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.2.8-beta.1",
+      "version": "2.2.8-beta.2",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.1",
-        "@fileterm/shared": "2.2.8-beta.1",
+        "@fileterm/core": "2.2.8-beta.2",
+        "@fileterm/shared": "2.2.8-beta.2",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -5501,17 +5501,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.2.8-beta.1"
+      "version": "2.2.8-beta.2"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.2.8-beta.1"
+      "version": "2.2.8-beta.2"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.2.8-beta.1",
+      "version": "2.2.8-beta.2",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.1"
+        "@fileterm/core": "2.2.8-beta.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.1",
+  "version": "2.2.8-beta.2",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.2.8-beta.1",
+  "version": "2.2.8-beta.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2437,6 +2437,7 @@ export interface FileTermDesktopApi {
   openFileEditorWindow(input: FileEditorWindowInput): Promise<void>
   openExternalUrl(url: string): Promise<void>
   openLogsDirectory(): Promise<void>
+  writeDiagnosticLog(level: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR', scope: string, message: string): Promise<void>
   listSerialPorts(): Promise<SerialPortInfo[]>
   onSerialPortsChanged(listener: (ports: SerialPortInfo[]) => void): () => void
   serialControl(
@@ -2650,7 +2651,8 @@ export interface FileTermDesktopApi {
   onTerminalState(listener: (payload: TerminalStatePayload) => void): () => void
   onTransferUpdate(listener: (transfer: TransferTask) => void): () => void
   onSerialTransferProgress(listener: (progress: SerialTransferProgress) => void): () => void
-  onWorkspaceSnapshot(listener: (snapshot: WorkspaceSnapshot) => void): () => void
+  /** Resolves only after the native snapshot listener is registered. */
+  onWorkspaceSnapshot(listener: (snapshot: WorkspaceSnapshot) => void): Promise<() => void>
   onSessionMetrics(listener: (payload: SessionMetricsUpdate) => void): () => void
   onRemoteFilesChanged(listener: (payload: RemoteFilesUpdate) => void): () => void
   /** Resolves only after the SSH interaction listener is registered in Tauri. */

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.2.8-beta.1",
+  "version": "2.2.8-beta.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.2.8-beta.1",
+  "version": "2.2.8-beta.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.1"
+    "@fileterm/core": "2.2.8-beta.2"
   }
 }


### PR DESCRIPTION
## Summary

- Harden SSH jump-host and legacy POSIX/CentOS/RHEL-style platform probing.
- Keep terminal and SFTP usable when the resource metrics channel closes or stalls.
- Log remote exit status, stderr tail, EOF/Close, snapshot emission, renderer receipt/application, and sidebar state.
- Prepare FileTerm 2.2.8-beta.2 as a prerelease test build.

关联背景：B-3148 跳板机连接后资源侧栏获取不到或卡死。

## Validation

- `npm run test:tauri`
- `npm run typecheck -w @fileterm/tauri`
- `npm run lint`
- `npx prettier --check apps/tauri packages/core packages/shared packages/storage`
- `cargo fmt --manifest-path apps/tauri/src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path apps/tauri/src-tauri/Cargo.toml --locked --all-targets --all-features -- -D warnings`

CentOS 7 实机仍需用 beta2 安装包验证；本 PR 不新增 FIDO2/Web SSO。