### PR TITLE
fix(ui): normalize theme font delete button sizing

### DIFF
--- a/apps/tauri/src/renderer/features/settings/settings-modal/panels/interface-settings-panel.tsx
+++ b/apps/tauri/src/renderer/features/settings/settings-modal/panels/interface-settings-panel.tsx
@@ -520,7 +520,7 @@ export function InterfaceSettingsPanel() {
                   </span>
                   <button
                     type="button"
-                    className="flat-button compact danger theme-config-font-delete-btn"
+                    className="flat-button danger theme-config-font-delete-btn"
                     title={`${t.themeDeleteFont}: ${font.family}`}
                     aria-label={`${t.themeDeleteFont}: ${font.family}`}
                     onClick={() => setFontToDelete(font)}

--- a/apps/tauri/src/renderer/styles/features/modal-components.css
+++ b/apps/tauri/src/renderer/styles/features/modal-components.css
@@ -2192,13 +2192,15 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 6px 4px 10px;
+  box-sizing: border-box;
+  height: 36px;
+  min-height: 36px;
+  padding: 0 6px 0 10px;
   border: 1px solid var(--border-light);
   border-radius: var(--radius-sm, 4px);
-  background: var(--bg-card);
+  background: var(--surface-card, var(--bg-card));
   font-size: 12px;
-  color: var(--text-main);
-  box-sizing: border-box;
+  color: var(--text-primary, var(--text-main));
 }
 
 .theme-config-imported-font-name {
@@ -2224,11 +2226,14 @@
   text-transform: uppercase;
 }
 
+.settings-panel .theme-config-imported-font-item .theme-config-font-delete-btn,
+.settings-modal .theme-config-imported-font-item .theme-config-font-delete-btn,
 .settings-modal .theme-config-font-delete-btn {
   display: inline-flex;
   flex: 0 0 24px;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
   width: 24px;
   min-width: 24px;
   max-width: 24px;
@@ -2236,6 +2241,7 @@
   min-height: 24px;
   max-height: 24px;
   padding: 0;
+  border: 1px solid var(--border-light);
   border-radius: 4px;
   color: var(--text-muted);
   transition:
@@ -2243,6 +2249,8 @@
     background 0.15s ease;
 }
 
+.settings-panel .theme-config-imported-font-item .theme-config-font-delete-btn:hover,
+.settings-modal .theme-config-imported-font-item .theme-config-font-delete-btn:hover,
 .settings-modal .theme-config-font-delete-btn:hover {
   color: var(--danger-text);
   background: var(--danger-surface);


### PR DESCRIPTION
## Summary

- Normalize imported theme-font row height and surface/text tokens.
- Keep the delete button at a consistent 24px control size with visible border and hover state.

## Validation

- `git diff --check`
- CSS contract check
- `npx prettier --check apps/tauri/src/renderer packages/core`
- `npm run typecheck -w @fileterm/tauri`
- `npm run lint`