### PR TITLE
fix(ssh): support PTY metrics through Go jump hosts

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.2.8-beta.2",
+  "version": "2.2.8-beta.3",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -26,8 +26,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.2",
-    "@fileterm/shared": "2.2.8-beta.2",
+    "@fileterm/core": "2.2.8-beta.3",
+    "@fileterm/shared": "2.2.8-beta.3",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.2.8-beta.2"
+version = "2.2.8-beta.3"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.2.8-beta.2"
+version = "2.2.8-beta.3"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
+++ b/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
@@ -58,7 +58,7 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-    <release version="2.2.8-beta.2" date="2026-09-02">
+    <release version="2.2.8-beta.3" date="2026-09-03">
       <description>
         <p>Official release with multi-tab remote terminal and file management workspace.</p>
       </description>

--- a/apps/tauri/src-tauri/src/sessions/ssh/constants.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/constants.rs
@@ -25,7 +25,9 @@ const SFTP_INIT_STEP_TIMEOUT: Duration = Duration::from_secs(8);
 const SHELL_INIT_STEP_TIMEOUT: Duration = Duration::from_secs(8);
 
 /// `probe_remote_platform` 总超时。该函数在 worker 主循环之前调用，
-/// 内部最多尝试 4 次 exec_command（POSIX + 3 个 Windows probe），每次
+/// 内部最多尝试 6 组探针（3 个 POSIX + 3 个 Windows probe；发现
+/// PTY-only server 时每组最多再做一次 PTY 重试，因此最多 12 个 SSH
+/// exec channel），每次
 /// 都用 `channel.wait()` 循环读取，没有内层 timeout。如果服务器在 exec
 /// 模式下卡住（不返回 EOF/Close），整个 probe 会永久 await，worker
 /// 永远起不来，所有后续命令（含 Ctrl+C）都进不了 cmd_rx。20 秒覆盖

--- a/apps/tauri/src-tauri/src/sessions/ssh/tests.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/tests.rs
@@ -2522,6 +2522,15 @@ mod tests {
                 .unwrap();
         assert_eq!(command, "tauri-openssh-exec");
 
+        let pty_command = crate::sessions::system_metrics::exec_command_with_status_pty_detailed(
+            &handle,
+            "printf 'tauri-openssh-pty-exec'",
+        )
+        .await
+        .unwrap();
+        assert_eq!(pty_command.output, "tauri-openssh-pty-exec");
+        assert_eq!(pty_command.exit_code, Some(0));
+
         let platform = crate::sessions::system_metrics::probe_remote_platform(&handle).await;
         #[cfg(target_os = "linux")]
         assert_eq!(platform, "linux");

--- a/apps/tauri/src-tauri/src/sessions/ssh/transport/session.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/transport/session.rs
@@ -231,6 +231,21 @@ async fn open_session(
             cancellation.clone(),
         ))
         .await?;
+        let jump_identification = normalize_ssh_identification(&jump_session.remote_sshid);
+        crate::services::logging::session(
+            app,
+            "INFO",
+            "ssh",
+            tab_id,
+            format!(
+                "jump host SSH session ready flow_role=jump-host identification={}",
+                if jump_identification.is_empty() {
+                    "unknown"
+                } else {
+                    jump_identification.as_str()
+                }
+            ),
+        );
         let jump_handle = jump_session.handle;
 
         let mut target_profile = effective_profile.clone();
@@ -305,6 +320,22 @@ async fn open_session(
                 interaction_timeout,
             )
             .await?;
+            let target_remote_sshid = read_shared_remote_sshid(&remote_sshid);
+            let target_identification = normalize_ssh_identification(&target_remote_sshid);
+            crate::services::logging::session(
+                app,
+                "INFO",
+                "ssh",
+                tab_id,
+                format!(
+                    "target SSH session ready flow_role=target transport=direct-tcpip identification={}",
+                    if target_identification.is_empty() {
+                        "unknown"
+                    } else {
+                        target_identification.as_str()
+                    }
+                ),
+            );
             if authenticate_session(
                 &mut target_handle,
                 &target_username,
@@ -318,7 +349,7 @@ async fn open_session(
             {
                 Ok(OpenSshSession {
                     handle: target_handle,
-                    remote_sshid: read_shared_remote_sshid(&remote_sshid),
+                    remote_sshid: target_remote_sshid,
                     disconnect_reason,
                 })
             } else {

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/context.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/context.rs
@@ -131,6 +131,10 @@ struct SshWorkerStartupContext<'a> {
     operation_timeout: Duration,
     network_device_mode: bool,
     exec_channel_enabled: bool,
+    /// Some SSH servers only allow exec commands attached to a PTY. The
+    /// platform probe records that compatibility decision so the persistent
+    /// metrics channel uses the same transport instead of exiting immediately.
+    metrics_request_pty: bool,
     cancellation: &'a CancellationToken,
     state: &'a crate::services::workspace::WorkspaceState,
 }

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/loop.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/loop.rs
@@ -172,11 +172,12 @@ async fn run_worker_loop(
     });
 
     // ── Probe platform ─────────────────────────────────────────────────────
-    // 加 timeout：probe 内部最多 6 次串行 exec_command，每次都用
+    // 加 timeout：probe 内部最多 6 组串行探针（PTY-only server 会对每组
+    // 再重试一次，最多 12 个 exec channel），每次都用
     // channel.wait() 循环读取且无内层 timeout。服务器在 exec 模式下卡住
     // 时整个 probe 会永久 await，worker 永远起不来。超时后回落到
     // "unknown"，shell CWD 注入会被 fail-closed 门控跳过，终端仍可用。
-    let platform = if network_device_mode {
+    let (platform, mut metrics_request_pty) = if network_device_mode {
         crate::services::logging::session(
             app,
             "INFO",
@@ -184,7 +185,7 @@ async fn run_worker_loop(
             tab_id,
             "network-device mode; skipping platform probe",
         );
-        "unknown".to_string()
+        ("unknown".to_string(), false)
     } else if exec_channel_enabled {
         crate::services::logging::session(
             app,
@@ -198,14 +199,14 @@ async fn run_worker_loop(
         );
         match timeout(
             PLATFORM_PROBE_TIMEOUT,
-            crate::sessions::system_metrics::probe_remote_platform_for_session(
+            crate::sessions::system_metrics::probe_remote_platform_for_session_with_transport(
                 &handle,
                 Some(tab_id),
             ),
         )
         .await
         {
-            Ok(p) => p,
+            Ok(result) => (result.platform, result.request_pty),
             Err(_) => {
                 crate::services::logging::session(
                     app,
@@ -214,7 +215,7 @@ async fn run_worker_loop(
                     tab_id,
                     "platform probe timed out, falling back to unknown",
                 );
-                "unknown".to_string()
+                ("unknown".to_string(), false)
             }
         }
     } else {
@@ -225,14 +226,40 @@ async fn run_worker_loop(
             tab_id,
             "exec channel disabled; skipping platform probe",
         );
-        "unknown".to_string()
+        ("unknown".to_string(), false)
     };
+
+    // Go-based jump hosts commonly gate all command handlers on a PTY. Keep a
+    // conservative banner heuristic for the case where the probe itself was
+    // interrupted or all PTY retries were rejected; requesting a PTY for the
+    // detached collector is harmless on these servers and prevents the exact
+    // `No PTY requested.` exit-0 failure seen in the field.
+    let remote_sshid_is_go = String::from_utf8_lossy(&remote_sshid)
+        .to_ascii_lowercase()
+        .starts_with("ssh-2.0-go");
+    if exec_channel_enabled && remote_sshid_is_go && !metrics_request_pty {
+        metrics_request_pty = true;
+        crate::services::logging::session(
+            app,
+            "INFO",
+            "metrics",
+            tab_id,
+            "metrics transport heuristic enabled request_pty=true reason=go-server-identification",
+        );
+    }
     crate::services::logging::session(
         app,
         "INFO",
         "metrics",
         tab_id,
-        format!("platform probe completed platform={platform}"),
+        format!(
+            "platform probe completed platform={platform} transport={} metrics_request_pty={metrics_request_pty}",
+            if metrics_request_pty {
+                "exec-pty"
+            } else {
+                "exec"
+            }
+        ),
     );
 
     // ── Inject shell CWD setup (POSIX only, fail-closed) ───────────────────
@@ -286,6 +313,7 @@ async fn run_worker_loop(
         operation_timeout,
         network_device_mode,
         exec_channel_enabled,
+        metrics_request_pty,
         cancellation: &cancellation,
         state: &state,
     };

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/metrics.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/metrics.rs
@@ -1,111 +1,3 @@
-const METRICS_MAX_BLOCK_BYTES: usize = 256 * 1024;
-const METRICS_MAX_BUFFER_BYTES: usize = 1_000_000;
-const METRICS_BUFFER_TARGET_BYTES: usize = 500_000;
-const METRICS_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
-const METRICS_STDERR_EXTENDED_DATA_TYPE: u32 = 1;
-/// Keep enough of the remote stderr tail to identify a missing command,
-/// shell syntax error, or permission failure without allowing a noisy remote
-/// process to turn diagnostics into an unbounded log stream. The logger also
-/// redacts common secret-labelled values before writing the line.
-const METRICS_STDERR_TAIL_BYTES: usize = 8 * 1024;
-
-fn append_metrics_stderr_tail(tail: &mut Vec<u8>, chunk: &[u8]) {
-    if chunk.len() >= METRICS_STDERR_TAIL_BYTES {
-        tail.clear();
-        tail.extend_from_slice(&chunk[chunk.len() - METRICS_STDERR_TAIL_BYTES..]);
-        return;
-    }
-
-    let required_drop = tail
-        .len()
-        .saturating_add(chunk.len())
-        .saturating_sub(METRICS_STDERR_TAIL_BYTES);
-    if required_drop > 0 {
-        tail.drain(..required_drop);
-    }
-    tail.extend_from_slice(chunk);
-}
-
-#[cfg(test)]
-mod metrics_tests {
-    use super::{append_metrics_stderr_tail, METRICS_STDERR_TAIL_BYTES};
-
-    #[test]
-    fn stderr_tail_is_bounded_and_keeps_latest_bytes() {
-        let mut tail = Vec::new();
-        append_metrics_stderr_tail(&mut tail, &[b'a'; METRICS_STDERR_TAIL_BYTES]);
-        append_metrics_stderr_tail(&mut tail, b"tail");
-
-        assert_eq!(tail.len(), METRICS_STDERR_TAIL_BYTES);
-        assert_eq!(&tail[tail.len() - 4..], b"tail");
-        assert!(tail[..tail.len() - 4].iter().all(|byte| *byte == b'a'));
-    }
-
-    #[test]
-    fn stderr_tail_discards_old_chunk_when_new_chunk_exceeds_cap() {
-        let mut tail = Vec::new();
-        let chunk = (0..METRICS_STDERR_TAIL_BYTES + 32)
-            .map(|index| (index % 251) as u8)
-            .collect::<Vec<_>>();
-        append_metrics_stderr_tail(&mut tail, &chunk);
-
-        assert_eq!(tail.len(), METRICS_STDERR_TAIL_BYTES);
-        assert_eq!(tail, chunk[chunk.len() - METRICS_STDERR_TAIL_BYTES..]);
-    }
-}
-
-fn metrics_stderr_preview(tail: &[u8]) -> String {
-    if tail.is_empty() {
-        "<empty>".to_string()
-    } else {
-        String::from_utf8_lossy(tail).into_owned()
-    }
-}
-
-fn metrics_exit_status_label(exit_status: Option<u32>) -> String {
-    exit_status
-        .map(|status| status.to_string())
-        .unwrap_or_else(|| "none".to_string())
-}
-
-fn should_log_metrics_anomaly(count: u64) -> bool {
-    count <= 3 || count.is_power_of_two()
-}
-
-async fn close_metrics_channel(
-    channel: &mut Channel<russh::client::Msg>,
-    app: &AppHandle,
-    tab_id: &str,
-    reason: &str,
-) {
-    match timeout(METRICS_CLOSE_TIMEOUT, channel.close()).await {
-        Ok(Ok(())) => crate::services::logging::session(
-            app,
-            "DEBUG",
-            "metrics",
-            tab_id,
-            format!("collector channel closed reason={reason}"),
-        ),
-        Ok(Err(error)) => crate::services::logging::session(
-            app,
-            "WARN",
-            "metrics",
-            tab_id,
-            format!("collector channel close failed reason={reason} error={error}"),
-        ),
-        Err(_) => crate::services::logging::session(
-            app,
-            "WARN",
-            "metrics",
-            tab_id,
-            format!(
-                "collector channel close timed out reason={reason} timeout_secs={}",
-                METRICS_CLOSE_TIMEOUT.as_secs()
-            ),
-        ),
-    }
-}
-
 /// Start the persistent system-metrics collector for an SSH session.
 ///
 /// Metrics are intentionally detached from the terminal event loop: a slow
@@ -118,9 +10,12 @@ let app = startup.app;
 let tab_id = startup.tab_id;
 let profile = startup.profile;
 let handle = startup.handle;
+let target_host = startup.host.to_string();
+let target_port = startup.port;
 let platform = startup.platform;
 let cancellation = startup.cancellation;
 let state = startup.state;
+let metrics_request_pty = startup.metrics_request_pty;
 // ── Spawn metrics collection task (single persistent channel) ─────────
 // Instead of opening a new exec channel every second (which adds variable
 // SSH overhead and makes the refresh cadence jittery), we open one
@@ -151,7 +46,7 @@ if effective_resource_monitoring_enabled(profile) {
             "metrics",
             &metrics_tid,
             format!(
-                "collector starting platform={} collector_variant={} interval_seconds={metrics_interval_seconds}",
+                "collector starting flow_role=target target={target_host}:{target_port} platform={} collector_variant={} interval_seconds={metrics_interval_seconds} request_pty={metrics_request_pty}",
                 metrics_plat,
                 if metrics_plat == "windows" {
                     "windows"
@@ -198,9 +93,14 @@ if effective_resource_monitoring_enabled(profile) {
                 };
                 crate::sessions::system_metrics::build_posix_metrics_command(raw)
             };
+            let collector_preamble = if metrics_request_pty {
+                "stty -echo 2>/dev/null || true\ncd / >/dev/null 2>&1 || true"
+            } else {
+                "cd / >/dev/null 2>&1 || true"
+            };
             let script = format!(
                 "{}\nwhile true; do\n{}\necho '{}'\nsleep {}\ndone\n",
-                "cd / >/dev/null 2>&1 || true", metrics, marker, metrics_interval_seconds
+                collector_preamble, metrics, marker, metrics_interval_seconds
             );
             (None, Some(script))
         };
@@ -237,20 +137,170 @@ if effective_resource_monitoring_enabled(profile) {
             }
         };
 
+        // Carry the compatibility decision from platform probing into the
+        // persistent collector. A Go-based jump host can accept the visible
+        // terminal PTY while returning `No PTY requested.` for every plain
+        // exec channel; requesting the PTY here keeps metrics on the same
+        // transport instead of disabling the sidebar after exit status 0.
+        let collector_request_pty = if metrics_request_pty {
+            crate::services::logging::session(
+                &metrics_app,
+                "DEBUG",
+                "metrics",
+                &metrics_tid,
+                "collector requesting PTY transport=exec-pty reason=platform-probe-or-server-banner",
+            );
+            match timeout(
+                SHELL_INIT_STEP_TIMEOUT,
+                channel.request_pty(
+                    true,
+                    "xterm-256color",
+                    80,
+                    24,
+                    0,
+                    0,
+                    &[
+                        (russh::Pty::ECHO, 0),
+                        (russh::Pty::ECHOE, 0),
+                        (russh::Pty::ECHOK, 0),
+                        (russh::Pty::ECHONL, 0),
+                        (russh::Pty::TTY_OP_ISPEED, 115200),
+                        (russh::Pty::TTY_OP_OSPEED, 115200),
+                    ],
+                ),
+            )
+            .await
+            {
+                Ok(Ok(())) => {
+                    crate::services::logging::session(
+                        &metrics_app,
+                        "INFO",
+                        "metrics",
+                        &metrics_tid,
+                        "collector PTY request accepted transport=exec-pty",
+                    );
+                    true
+                }
+                Ok(Err(error)) => {
+                    crate::services::logging::session(
+                        &metrics_app,
+                        "WARN",
+                        "metrics",
+                        &metrics_tid,
+                        format!("collector PTY request rejected error={error}"),
+                    );
+                    false
+                }
+                Err(_) => {
+                    crate::services::logging::session(
+                        &metrics_app,
+                        "WARN",
+                        "metrics",
+                        &metrics_tid,
+                        format!(
+                            "collector PTY request timed out timeout_secs={}",
+                            SHELL_INIT_STEP_TIMEOUT.as_secs()
+                        ),
+                    );
+                    false
+                }
+            }
+        } else {
+            false
+        };
+
+        // A PTY-required gateway cannot use the regular non-PTY collector
+        // path: KoKo-style proxies inspect the raw exec request before
+        // forwarding it to the asset. If the requested PTY was rejected, fail
+        // closed instead of falling back to a script write that would leave
+        // the channel hanging with no target sample.
+        if metrics_request_pty && !collector_request_pty {
+            crate::services::logging::session(
+                &metrics_app,
+                "WARN",
+                "metrics",
+                &metrics_tid,
+                "collector PTY required but unavailable; disabling POSIX collector reason=pty-request-rejected",
+            );
+            close_metrics_channel(
+                &mut channel,
+                &metrics_app,
+                &metrics_tid,
+                "pty-request-rejected",
+            )
+            .await;
+            disable_resource_monitoring_capability(
+                &metrics_app,
+                &metrics_tid,
+                "collector PTY request rejected for PTY-only gateway",
+            )
+            .await;
+            return;
+        }
+
+        // PTY mode sends no script bytes through stdin. Encoding the complete
+        // collector in the command keeps the gateway's login-shell matcher
+        // satisfied and avoids TTY line-buffer limits and input echo.
+        let inline_login_shell_command = if collector_request_pty && windows_command.is_none() {
+            script_body.as_deref().map(
+                crate::sessions::system_metrics::build_pty_login_shell_command,
+            )
+        } else {
+            None
+        };
+        let collector_command_mode = if windows_command.is_some() {
+            if collector_request_pty {
+                "exec-pty"
+            } else {
+                "exec"
+            }
+        } else if inline_login_shell_command.is_some() {
+            "exec-pty-login-shell-inline-b64"
+        } else {
+            "exec-sh-stdin"
+        };
+        crate::services::logging::session(
+            &metrics_app,
+            "DEBUG",
+            "metrics",
+            &metrics_tid,
+            format!(
+                "collector command prepared flow_role=target command_mode={collector_command_mode} script_bytes={} command_bytes={} stdin_bytes={}",
+                script_body.as_deref().map(str::len).unwrap_or(0),
+                inline_login_shell_command
+                    .as_deref()
+                    .or(windows_command.as_deref())
+                    .map(str::len)
+                    .unwrap_or_else(|| "sh -s".len()),
+                if inline_login_shell_command.is_some() {
+                    0
+                } else {
+                    script_body.as_deref().map(str::len).unwrap_or(0)
+                },
+            ),
+        );
+
         // Windows OpenSSH on this host stalls when a large script is sent
         // through stdin. Match Electron's transport: gzip + base64 keeps
         // the loader below cmd.exe's safe command-line budget, while the
         // decoded script runs as one persistent PowerShell process.
+        crate::services::logging::session(
+            &metrics_app,
+            "DEBUG",
+            "metrics",
+            &metrics_tid,
+            format!(
+                "collector exec request sending flow_role=target command_mode={collector_command_mode} request_pty={collector_request_pty}"
+            ),
+        );
         let collector_start = if let Some(command) = windows_command.as_deref() {
             timeout(SHELL_INIT_STEP_TIMEOUT, channel.exec(true, command)).await
+        } else if let Some(command) = inline_login_shell_command.as_deref() {
+            timeout(SHELL_INIT_STEP_TIMEOUT, channel.exec(true, command)).await
         } else {
-            // Run the POSIX collector through an explicit non-interactive
-            // `sh -s` command instead of the user's login shell. CentOS/RHEL
-            // hosts commonly retain bash startup policy (or a restricted
-            // vendor shell) that can exit a no-PTY request-shell channel as
-            // soon as it receives a script. `sh -s` is available on the
-            // documented POSIX server families and keeps startup files,
-            // prompts, and aliases out of the metrics stream.
+            // Normal OpenSSH servers keep the existing non-interactive
+            // `sh -s` + stdin path. It avoids a very long command line when a
+            // PTY-only gateway is not involved.
             timeout(SHELL_INIT_STEP_TIMEOUT, channel.exec(true, "sh -s")).await
         };
         let collector_start = match collector_start {
@@ -289,42 +339,46 @@ if effective_resource_monitoring_enabled(profile) {
             return;
         }
 
-        if let Some(script) = script_body.as_deref() {
-            // 写脚本也加 timeout：Windows OpenSSH 在大脚本场景偶发 stall，
-            // 不加超时会让 metrics task 永久卡在 data() 调用上。
-            match timeout(SHELL_INIT_STEP_TIMEOUT, channel.data(script.as_bytes())).await {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => {
-                    close_metrics_channel(
-                        &mut channel,
-                        &metrics_app,
-                        &metrics_tid,
-                        "collector-script-write-error",
-                    )
-                    .await;
-                    disable_resource_monitoring_capability(
-                        &metrics_app,
-                        &metrics_tid,
-                        format!("write collector script failed: {e}"),
-                    )
-                    .await;
-                    return;
-                }
-                Err(_) => {
-                    close_metrics_channel(
-                        &mut channel,
-                        &metrics_app,
-                        &metrics_tid,
-                        "collector-script-write-timeout",
-                    )
-                    .await;
-                    disable_resource_monitoring_capability(
-                        &metrics_app,
-                        &metrics_tid,
-                        "write collector script timed out",
-                    )
-                    .await;
-                    return;
+        if inline_login_shell_command.is_none() {
+            if let Some(script) = script_body.as_deref() {
+                // Keep a timeout on the non-PTY stdin path as well: a
+                // constrained OpenSSH server can stop accepting channel data
+                // without closing the channel, which otherwise leaves the
+                // metrics task awaiting forever.
+                match timeout(SHELL_INIT_STEP_TIMEOUT, channel.data(script.as_bytes())).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        close_metrics_channel(
+                            &mut channel,
+                            &metrics_app,
+                            &metrics_tid,
+                            "collector-script-write-error",
+                        )
+                        .await;
+                        disable_resource_monitoring_capability(
+                            &metrics_app,
+                            &metrics_tid,
+                            format!("write collector script failed: {e}"),
+                        )
+                        .await;
+                        return;
+                    }
+                    Err(_) => {
+                        close_metrics_channel(
+                            &mut channel,
+                            &metrics_app,
+                            &metrics_tid,
+                            "collector-script-write-timeout",
+                        )
+                        .await;
+                        disable_resource_monitoring_capability(
+                            &metrics_app,
+                            &metrics_tid,
+                            "write collector script timed out",
+                        )
+                        .await;
+                        return;
+                    }
                 }
             }
         }
@@ -335,13 +389,14 @@ if effective_resource_monitoring_enabled(profile) {
             "metrics",
             &metrics_tid,
             format!(
-                "collector started; waiting for first sample transport={} script_bytes={} idle_timeout_secs={}",
-                if windows_command.is_some() {
-                    "exec"
-                } else {
-                    "exec-sh-stdin"
-                },
+                "collector started; waiting for first sample flow_role=target command_mode={collector_command_mode} request_pty={} script_bytes={} command_bytes={} idle_timeout_secs={}",
+                collector_request_pty,
                 script_body.as_deref().map(str::len).unwrap_or(0),
+                inline_login_shell_command
+                    .as_deref()
+                    .or(windows_command.as_deref())
+                    .map(str::len)
+                    .unwrap_or_else(|| "sh -s".len()),
                 metrics_idle_timeout.as_secs()
             ),
         );
@@ -356,10 +411,11 @@ if effective_resource_monitoring_enabled(profile) {
         let mut dropped_buffer_bytes = 0_u64;
         let mut stdout_bytes = 0_u64;
         let mut stderr_bytes = 0_u64;
+        let mut stdout_tail = Vec::with_capacity(METRICS_STDOUT_TAIL_BYTES);
         let mut stderr_tail = Vec::with_capacity(METRICS_STDERR_TAIL_BYTES);
         let mut collector_exit_code = None;
         let mut remote_terminal_event = "none";
-        let close_reason = loop {
+        let close_reason = 'collector: loop {
             tokio::select! {
                 biased;
                 _ = metrics_shutdown_clone.notified() => {
@@ -396,6 +452,7 @@ if effective_resource_monitoring_enabled(profile) {
                         }
                         Ok(Some(ChannelMsg::Data { data })) => {
                             stdout_bytes = stdout_bytes.saturating_add(data.len() as u64);
+                            append_metrics_stderr_tail(&mut stdout_tail, data.as_ref());
                             buffer.extend_from_slice(data.as_ref());
                             // Drain all complete blocks from the buffer.
                             while let Some(idx) = find_subsequence(&buffer, marker_bytes) {
@@ -453,6 +510,43 @@ if effective_resource_monitoring_enabled(profile) {
                                     }
                                     continue;
                                 }
+
+                                if sample_count == 0 {
+                                    let remote_ip = metrics_identity_field(&val, "ip");
+                                    let remote_hostname = metrics_identity_field(&val, "hostname");
+                                    let remote_os = metrics_identity_field(&val, "osName");
+                                    let remote_kernel = metrics_identity_field(&val, "kernelName");
+                                    if !target_identity_is_valid(&val, &metrics_plat) {
+                                        crate::services::logging::session(
+                                            &metrics_app,
+                                            "WARN",
+                                            "metrics",
+                                            &metrics_tid,
+                                            format!(
+                                                "target identity rejected before first snapshot flow_role=target target={target_host}:{target_port} platform={} remote_ip={remote_ip:?} remote_hostname={remote_hostname:?} remote_os={remote_os:?} remote_kernel={remote_kernel:?} reason=missing-or-incompatible-identity",
+                                                metrics_plat,
+                                            ),
+                                        );
+                                        disable_resource_monitoring_capability(
+                                            &metrics_app,
+                                            &metrics_tid,
+                                            "first metrics snapshot did not identify a compatible target",
+                                        )
+                                        .await;
+                                        remote_terminal_event = "target-identity-invalid";
+                                        break 'collector "target-identity-invalid";
+                                    }
+                                    crate::services::logging::session(
+                                        &metrics_app,
+                                        "INFO",
+                                        "metrics",
+                                        &metrics_tid,
+                                        format!(
+                                            "target identity validated before first snapshot flow_role=target target={target_host}:{target_port} platform={} remote_ip={remote_ip:?} remote_hostname={remote_hostname:?} remote_os={remote_os:?} remote_kernel={remote_kernel:?}",
+                                            metrics_plat,
+                                        ),
+                                    );
+                                }
                                 sample_count += 1;
                                 if sample_count == 1 {
                                     crate::services::logging::session(
@@ -460,7 +554,13 @@ if effective_resource_monitoring_enabled(profile) {
                                         "INFO",
                                         "metrics",
                                         &metrics_tid,
-                                        format!("first sample cpu_percent={cpu_pct:.1} memory_percent={mem_pct:.1}"),
+                                        format!(
+                                            "first sample target={target_host}:{target_port} cpu_percent={cpu_pct:.1} memory_percent={mem_pct:.1} remote_ip={} remote_hostname={:?} remote_os={:?} remote_kernel={:?}",
+                                            metrics_identity_field(&val, "ip"),
+                                            metrics_identity_field(&val, "hostname"),
+                                            metrics_identity_field(&val, "osName"),
+                                            metrics_identity_field(&val, "kernelName"),
+                                        ),
                                     );
                                 } else if sample_count.is_multiple_of(60) {
                                     crate::services::logging::session(
@@ -475,7 +575,7 @@ if effective_resource_monitoring_enabled(profile) {
                                         ),
                                     );
                                 }
-                                {
+                                let state_updated = {
                                     let state = metrics_app
                                         .state::<crate::services::workspace::WorkspaceState>();
                                     let mut sessions = state.sessions.write().await;
@@ -485,24 +585,54 @@ if effective_resource_monitoring_enabled(profile) {
                                             val.clone(),
                                             600,
                                         ));
+                                        true
+                                    } else {
+                                        false
                                     }
+                                };
+                                if !state_updated {
+                                    crate::services::logging::session(
+                                        &metrics_app,
+                                        "WARN",
+                                        "metrics",
+                                        &metrics_tid,
+                                            format!(
+                                                "metrics state update skipped sample={} reason=session-not-found",
+                                                sample_count,
+                                            ),
+                                    );
                                 }
                                 let payload = serde_json::json!({
                                     "tabId": metrics_tid,
                                     "systemMetrics": val,
                                     "mode": "append",
                                 });
-                                if let Err(error) = metrics_app.emit("workspace:sessionMetrics", payload) {
-                                    crate::services::logging::session(
-                                        &metrics_app,
-                                        "WARN",
-                                        "metrics",
-                                        &metrics_tid,
-                                        format!(
-                                            "metrics event emission failed samples={} error={error}",
-                                            sample_count,
-                                        ),
-                                    );
+                                match metrics_app.emit("workspace:sessionMetrics", payload) {
+                                    Ok(()) if sample_count == 1 => {
+                                        crate::services::logging::session(
+                                            &metrics_app,
+                                            "INFO",
+                                            "metrics",
+                                            &metrics_tid,
+                                            format!(
+                                                "first metrics snapshot event emitted to renderer flow_role=target mode=append resource_monitoring=true state_update={}",
+                                                if state_updated { "applied" } else { "skipped" },
+                                            ),
+                                        );
+                                    }
+                                    Ok(()) => {}
+                                    Err(error) => {
+                                        crate::services::logging::session(
+                                            &metrics_app,
+                                            "WARN",
+                                            "metrics",
+                                            &metrics_tid,
+                                            format!(
+                                                "metrics event emission failed samples={} error={error}",
+                                                sample_count,
+                                            ),
+                                        );
+                                    }
                                 }
                             }
                             // Cap buffer to prevent unbounded growth
@@ -552,11 +682,14 @@ if effective_resource_monitoring_enabled(profile) {
                                 "metrics",
                                     &metrics_tid,
                                     format!(
-                                        "collector exit status exit_code={} stderr_bytes={} stderr_tail={} elapsed_ms={}",
+                                        "collector exit status exit_code={} stdout_bytes={} stdout_tail={} stderr_bytes={} stderr_tail={} transport={} elapsed_ms={}",
                                         exit_status,
-                                    stderr_bytes,
-                                    metrics_stderr_preview(&stderr_tail),
-                                    collector_started_at.elapsed().as_millis(),
+                                        stdout_bytes,
+                                        metrics_stdout_preview(&stdout_tail, sample_count),
+                                        stderr_bytes,
+                                        metrics_stderr_preview(&stderr_tail),
+                                        collector_command_mode,
+                                        collector_started_at.elapsed().as_millis(),
                                 ),
                             );
                             if !metrics_cancellation.is_cancelled() {
@@ -582,9 +715,12 @@ if effective_resource_monitoring_enabled(profile) {
                                 "metrics",
                                 &metrics_tid,
                                 format!(
-                                    "collector exit signal signal={signal_name:?} core_dumped={core_dumped} error_message={error_message:?} lang_tag={lang_tag:?} stderr_bytes={} stderr_tail={}",
+                                    "collector exit signal signal={signal_name:?} core_dumped={core_dumped} error_message={error_message:?} lang_tag={lang_tag:?} stdout_bytes={} stdout_tail={} stderr_bytes={} stderr_tail={} transport={}",
+                                    stdout_bytes,
+                                    metrics_stdout_preview(&stdout_tail, sample_count),
                                     stderr_bytes,
                                     metrics_stderr_preview(&stderr_tail),
+                                    collector_command_mode,
                                 ),
                             );
                             if !metrics_cancellation.is_cancelled() {
@@ -605,10 +741,12 @@ if effective_resource_monitoring_enabled(profile) {
                                 "metrics",
                                 &metrics_tid,
                                 format!(
-                                    "remote collector sent EOF before exit status stdout_bytes={} stderr_bytes={} stderr_tail={}",
+                                    "remote collector sent EOF before exit status stdout_bytes={} stdout_tail={} stderr_bytes={} stderr_tail={} transport={}",
                                     stdout_bytes,
+                                    metrics_stdout_preview(&stdout_tail, sample_count),
                                     stderr_bytes,
                                     metrics_stderr_preview(&stderr_tail),
+                                    collector_command_mode,
                                 ),
                             );
                             if !metrics_cancellation.is_cancelled() {
@@ -629,10 +767,12 @@ if effective_resource_monitoring_enabled(profile) {
                                 "metrics",
                                 &metrics_tid,
                                 format!(
-                                    "remote collector sent channel close stdout_bytes={} stderr_bytes={} stderr_tail={}",
+                                    "remote collector sent channel close stdout_bytes={} stdout_tail={} stderr_bytes={} stderr_tail={} transport={}",
                                     stdout_bytes,
+                                    metrics_stdout_preview(&stdout_tail, sample_count),
                                     stderr_bytes,
                                     metrics_stderr_preview(&stderr_tail),
+                                    collector_command_mode,
                                 ),
                             );
                             if !metrics_cancellation.is_cancelled() {
@@ -653,10 +793,12 @@ if effective_resource_monitoring_enabled(profile) {
                                 "metrics",
                                 &metrics_tid,
                                 format!(
-                                    "remote collector channel request failed stdout_bytes={} stderr_bytes={} stderr_tail={}",
+                                    "remote collector channel request failed stdout_bytes={} stdout_tail={} stderr_bytes={} stderr_tail={} transport={}",
                                     stdout_bytes,
+                                    metrics_stdout_preview(&stdout_tail, sample_count),
                                     stderr_bytes,
                                     metrics_stderr_preview(&stderr_tail),
+                                    collector_command_mode,
                                 ),
                             );
                             if !metrics_cancellation.is_cancelled() {
@@ -676,7 +818,10 @@ if effective_resource_monitoring_enabled(profile) {
                                 "WARN",
                                 "metrics",
                                 &metrics_tid,
-                                format!("remote collector channel open failure reason={reason:?}"),
+                                    format!(
+                                        "remote collector channel open failure reason={reason:?} transport={}",
+                                        collector_command_mode,
+                                    ),
                             );
                             if !metrics_cancellation.is_cancelled() {
                                 disable_resource_monitoring_capability(
@@ -696,10 +841,12 @@ if effective_resource_monitoring_enabled(profile) {
                                 "metrics",
                                 &metrics_tid,
                                 format!(
-                                    "collector channel stream ended without terminal event reason=remote-stream-ended-or-transport-drop stdout_bytes={} stderr_bytes={} stderr_tail={} elapsed_ms={}",
+                                    "collector channel stream ended without terminal event reason=remote-stream-ended-or-transport-drop stdout_bytes={} stdout_tail={} stderr_bytes={} stderr_tail={} transport={} elapsed_ms={}",
                                     stdout_bytes,
+                                    metrics_stdout_preview(&stdout_tail, sample_count),
                                     stderr_bytes,
                                     metrics_stderr_preview(&stderr_tail),
+                                    collector_command_mode,
                                     collector_started_at.elapsed().as_millis(),
                                 ),
                             );
@@ -726,15 +873,17 @@ if effective_resource_monitoring_enabled(profile) {
             "metrics",
             &metrics_tid,
             format!(
-                "collector stopped reason={close_reason} remote_terminal_event={remote_terminal_event} exit_code={} samples={} malformed_samples={} oversized_samples={} dropped_buffer_bytes={} stdout_bytes={} stderr_bytes={} stderr_tail={}",
+                "collector stopped flow_role=target reason={close_reason} remote_terminal_event={remote_terminal_event} exit_code={} samples={} malformed_samples={} oversized_samples={} dropped_buffer_bytes={} stdout_bytes={} stdout_tail={} stderr_bytes={} stderr_tail={} transport={}",
                 metrics_exit_status_label(collector_exit_code),
                 sample_count,
                 malformed_block_count,
                 oversized_block_count,
                 dropped_buffer_bytes,
                 stdout_bytes,
+                metrics_stdout_preview(&stdout_tail, sample_count),
                 stderr_bytes,
                 metrics_stderr_preview(&stderr_tail),
+                collector_command_mode,
             ),
         );
     });

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/metrics_diagnostics.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/metrics_diagnostics.rs
@@ -1,0 +1,283 @@
+const METRICS_MAX_BLOCK_BYTES: usize = 256 * 1024;
+const METRICS_MAX_BUFFER_BYTES: usize = 1_000_000;
+const METRICS_BUFFER_TARGET_BYTES: usize = 500_000;
+const METRICS_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
+const METRICS_STDERR_EXTENDED_DATA_TYPE: u32 = 1;
+/// Keep enough of the remote stderr tail to identify a missing command,
+/// shell syntax error, or permission failure without allowing a noisy remote
+/// process to turn diagnostics into an unbounded log stream. The logger also
+/// redacts common secret-labelled values before writing the line.
+const METRICS_STDERR_TAIL_BYTES: usize = 8 * 1024;
+/// PTY-required servers write their refusal to the regular data stream rather
+/// than SSH extended stderr. Keep a bounded stdout tail so a zero-sample exit
+/// exposes the remote reason in `app.log` without allowing unbounded output.
+const METRICS_STDOUT_TAIL_BYTES: usize = 8 * 1024;
+
+fn append_metrics_stderr_tail(tail: &mut Vec<u8>, chunk: &[u8]) {
+    if chunk.len() >= METRICS_STDERR_TAIL_BYTES {
+        tail.clear();
+        tail.extend_from_slice(&chunk[chunk.len() - METRICS_STDERR_TAIL_BYTES..]);
+        return;
+    }
+
+    let required_drop = tail
+        .len()
+        .saturating_add(chunk.len())
+        .saturating_sub(METRICS_STDERR_TAIL_BYTES);
+    if required_drop > 0 {
+        tail.drain(..required_drop);
+    }
+    tail.extend_from_slice(chunk);
+}
+
+fn metrics_stderr_preview(tail: &[u8]) -> String {
+    if tail.is_empty() {
+        "<empty>".to_string()
+    } else {
+        String::from_utf8_lossy(tail).into_owned()
+    }
+}
+
+fn metrics_stdout_preview(tail: &[u8], sample_count: u64) -> String {
+    if sample_count == 0 {
+        metrics_stderr_preview(tail)
+    } else {
+        "<suppressed-after-first-sample>".to_string()
+    }
+}
+
+fn metrics_identity_field(value: &serde_json::Value, key: &str) -> String {
+    // The parser keeps host identity under the `identity` object. Keep a
+    // top-level fallback for older/alternate payloads so diagnostics remain
+    // useful if a collector returns a flattened value.
+    let raw = value
+        .get("identity")
+        .and_then(|identity| identity.get(key))
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| value.get(key).and_then(serde_json::Value::as_str));
+    let Some(raw) = raw else {
+        return "<unknown>".to_string();
+    };
+    let compact = raw
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(128)
+        .collect::<String>();
+    if compact.is_empty() {
+        "<unknown>".to_string()
+    } else {
+        compact
+    }
+}
+
+fn metrics_identity_is_unknown(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    normalized.is_empty()
+        || matches!(
+            normalized.as_str(),
+            "-" | "<unknown>" | "unknown" | "n/a" | "na" | "null"
+        )
+}
+
+/// A parsed metrics block is only trusted after it identifies the machine
+/// that owns the long-lived channel. This prevents a PTY gateway banner (or a
+/// synthetic zero-valued response) from opening the sidebar with data that
+/// actually belongs to the jump host.
+fn target_identity_is_valid(value: &serde_json::Value, platform: &str) -> bool {
+    let hostname = metrics_identity_field(value, "hostname");
+    let os_name = metrics_identity_field(value, "osName");
+    let kernel_name = metrics_identity_field(value, "kernelName");
+    if metrics_identity_is_unknown(&hostname)
+        || metrics_identity_is_unknown(&os_name)
+        || metrics_identity_is_unknown(&kernel_name)
+    {
+        return false;
+    }
+
+    let os_lower = os_name.to_ascii_lowercase();
+    let kernel_lower = kernel_name.to_ascii_lowercase();
+    let linux_family_os = [
+        "linux",
+        "centos",
+        "red hat",
+        "rhel",
+        "fedora",
+        "debian",
+        "ubuntu",
+        "rocky",
+        "alma linux",
+        "amazon linux",
+        "suse",
+        "opensuse",
+        "alpine",
+        "arch linux",
+        "gentoo",
+        "kali",
+        "openwrt",
+        "buildroot",
+        "busybox",
+    ]
+    .iter()
+    .any(|marker| os_lower.contains(marker));
+    match platform {
+        "windows" => {
+            os_lower.contains("windows")
+                || os_lower.contains("microsoft")
+                || kernel_lower.contains("windows")
+        }
+        "freebsd" => os_lower.contains("freebsd") || kernel_lower.contains("freebsd"),
+        "darwin" => {
+            os_lower.contains("macos")
+                || os_lower.contains("mac os")
+                || kernel_lower.contains("darwin")
+        }
+        "busybox" => linux_family_os,
+        // CentOS 7 normally reports `CentOS Linux ...`. A kernel name alone is
+        // deliberately not enough: a gateway can also run on Linux. The OS
+        // identity itself must name a Linux-family system so a
+        // `JumpServer`/`Go` banner cannot open the sidebar as a target.
+        _ => linux_family_os,
+    }
+}
+
+fn metrics_exit_status_label(exit_status: Option<u32>) -> String {
+    exit_status
+        .map(|status| status.to_string())
+        .unwrap_or_else(|| "none".to_string())
+}
+
+fn should_log_metrics_anomaly(count: u64) -> bool {
+    count <= 3 || count.is_power_of_two()
+}
+
+async fn close_metrics_channel(
+    channel: &mut Channel<russh::client::Msg>,
+    app: &AppHandle,
+    tab_id: &str,
+    reason: &str,
+) {
+    match timeout(METRICS_CLOSE_TIMEOUT, channel.close()).await {
+        Ok(Ok(())) => crate::services::logging::session(
+            app,
+            "DEBUG",
+            "metrics",
+            tab_id,
+            format!("collector channel closed reason={reason}"),
+        ),
+        Ok(Err(error)) => crate::services::logging::session(
+            app,
+            "WARN",
+            "metrics",
+            tab_id,
+            format!("collector channel close failed reason={reason} error={error}"),
+        ),
+        Err(_) => crate::services::logging::session(
+            app,
+            "WARN",
+            "metrics",
+            tab_id,
+            format!(
+                "collector channel close timed out reason={reason} timeout_secs={}",
+                METRICS_CLOSE_TIMEOUT.as_secs()
+            ),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod metrics_tests {
+    use super::{
+        append_metrics_stderr_tail, metrics_identity_field, target_identity_is_valid,
+        METRICS_STDERR_TAIL_BYTES,
+    };
+
+    #[test]
+    fn stderr_tail_is_bounded_and_keeps_latest_bytes() {
+        let mut tail = Vec::new();
+        append_metrics_stderr_tail(&mut tail, &[b'a'; METRICS_STDERR_TAIL_BYTES]);
+        append_metrics_stderr_tail(&mut tail, b"tail");
+
+        assert_eq!(tail.len(), METRICS_STDERR_TAIL_BYTES);
+        assert_eq!(&tail[tail.len() - 4..], b"tail");
+        assert!(tail[..tail.len() - 4].iter().all(|byte| *byte == b'a'));
+    }
+
+    #[test]
+    fn stderr_tail_discards_old_chunk_when_new_chunk_exceeds_cap() {
+        let mut tail = Vec::new();
+        let chunk = (0..METRICS_STDERR_TAIL_BYTES + 32)
+            .map(|index| (index % 251) as u8)
+            .collect::<Vec<_>>();
+        append_metrics_stderr_tail(&mut tail, &chunk);
+
+        assert_eq!(tail.len(), METRICS_STDERR_TAIL_BYTES);
+        assert_eq!(tail, chunk[chunk.len() - METRICS_STDERR_TAIL_BYTES..]);
+    }
+
+    #[test]
+    fn identity_fields_are_read_from_nested_identity_payload() {
+        let value = serde_json::json!({
+            "identity": {
+                "hostname": "centos-target",
+                "osName": "CentOS Linux 7 (Core)",
+                "kernelName": "Linux"
+            }
+        });
+
+        assert_eq!(metrics_identity_field(&value, "hostname"), "centos-target");
+        assert_eq!(
+            metrics_identity_field(&value, "osName"),
+            "CentOS Linux 7 (Core)"
+        );
+        assert_eq!(metrics_identity_field(&value, "kernelName"), "Linux");
+    }
+
+    #[test]
+    fn identity_field_keeps_flattened_payload_compatibility() {
+        let value = serde_json::json!({"hostname": "legacy-target"});
+
+        assert_eq!(metrics_identity_field(&value, "hostname"), "legacy-target");
+    }
+
+    #[test]
+    fn target_identity_requires_a_real_linux_identity_for_posix_metrics() {
+        let target = serde_json::json!({
+            "identity": {
+                "hostname": "centos-target",
+                "osName": "CentOS Linux 7 (Core)",
+                "kernelName": "Linux"
+            }
+        });
+        let gateway = serde_json::json!({
+            "identity": {
+                "hostname": "koko",
+                "osName": "JumpServer",
+                "kernelName": "Linux"
+            }
+        });
+        let ubuntu = serde_json::json!({
+            "identity": {
+                "hostname": "ubuntu-target",
+                "osName": "Ubuntu 24.04.2 LTS",
+                "kernelName": "Linux"
+            }
+        });
+
+        assert!(target_identity_is_valid(&target, "linux"));
+        assert!(target_identity_is_valid(&ubuntu, "linux"));
+        assert!(!target_identity_is_valid(&gateway, "linux"));
+    }
+
+    #[test]
+    fn target_identity_rejects_missing_identity_fields() {
+        let value = serde_json::json!({
+            "identity": {
+                "hostname": "centos-target",
+                "osName": "-",
+                "kernelName": "Linux"
+            }
+        });
+
+        assert!(!target_identity_is_valid(&value, "linux"));
+    }
+}

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/mod.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/mod.rs
@@ -9,6 +9,7 @@ include!("event_loop.rs");
 include!("terminal_output.rs");
 include!("tunnel_startup.rs");
 include!("command_event.rs");
+include!("metrics_diagnostics.rs");
 include!("metrics.rs");
 include!("session_snapshot.rs");
 include!("sftp_startup.rs");

--- a/apps/tauri/src-tauri/src/sessions/system_metrics/exec.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics/exec.rs
@@ -10,11 +10,77 @@ pub(crate) async fn probe_remote_platform_for_session<H: Handler>(
     handle: &Handle<H>,
     tab_id: Option<&str>,
 ) -> String {
-    // 1. Try POSIX probe
-    let posix_cmd = "sh -lc 'printf \"__FILETERM_PROBE_START__\\n\"; uname -s 2>/dev/null; shell_exe=$(readlink /proc/$$/exe 2>/dev/null || readlink /bin/sh 2>/dev/null || true); case \"$shell_exe\" in *busybox*) printf \"busybox\\n\" ;; esac; if [ -f /etc/openwrt_release ]; then printf \"openwrt\\n\"; fi; if [ -r /etc/centos-release ] || [ -r /etc/redhat-release ] || [ -r /etc/fedora-release ]; then printf \"linux\\n\"; fi; printf \"__FILETERM_PROBE_END__\\n\"'";
+    probe_remote_platform_for_session_with_transport(handle, tab_id)
+        .await
+        .platform
+}
 
-    let posix_result = exec_command_with_status_detailed(handle, posix_cmd).await;
-    log_probe_result("posix", &posix_result, tab_id);
+/// Result of the short platform probe that runs before the terminal worker
+/// enters its main event loop.
+///
+/// A few SSH servers (including Go-based jump hosts) reject every `exec`
+/// request that does not carry a PTY. Returning the transport used by the
+/// successful probe lets the long-lived metrics channel make the same choice;
+/// otherwise platform detection can succeed while the collector immediately
+/// exits with a benign-looking status 0.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PlatformProbeResult {
+    pub platform: String,
+    pub request_pty: bool,
+}
+
+impl PlatformProbeResult {
+    fn new(platform: impl Into<String>, request_pty: bool) -> Self {
+        Self {
+            platform: platform.into(),
+            request_pty,
+        }
+    }
+}
+
+/// Build a single remote command for PTY-only SSH gateways.
+///
+/// KoKo-style gateways inspect the raw `exec` command before forwarding it to
+/// the asset.  A command beginning with `bash --login` is the compatible
+/// path, while writing a multi-kilobyte script to a PTY's stdin can be
+/// truncated by the terminal line discipline or echoed into the metrics
+/// stream.  Encode the script locally and let a login shell decode it on the
+/// remote side.  Base64's standard alphabet does not contain a single quote,
+/// so the payload is safe inside the outer `-c` shell string.
+pub(crate) fn build_pty_login_shell_command(script: &str) -> String {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(script.as_bytes());
+    format!(
+        "bash --login -c 'printf \"%s\" \"{encoded}\" | (base64 -d 2>/dev/null || base64 -D 2>/dev/null) | bash'"
+    )
+}
+
+fn probe_command_supports_login_shell_wrapper(command: &str) -> bool {
+    let normalized = command.trim_start().to_ascii_lowercase();
+    !normalized.starts_with("powershell ")
+        && !normalized.starts_with("pwsh ")
+        && !normalized.starts_with("cmd /c")
+}
+
+/// Probe the remote platform and report whether the remote requires a PTY for
+/// exec commands. The first attempt remains a regular non-PTY exec so normal
+/// servers keep their separate stderr channel; a response such as
+/// `No PTY requested.` triggers one bounded PTY retry and all following probes
+/// reuse that transport.
+pub(crate) async fn probe_remote_platform_for_session_with_transport<H: Handler>(
+    handle: &Handle<H>,
+    tab_id: Option<&str>,
+) -> PlatformProbeResult {
+    let mut request_pty = false;
+
+    let (posix_result, used_pty) = run_probe_command(
+        handle,
+        "posix",
+        "sh -lc 'printf \"__FILETERM_PROBE_START__\\n\"; uname -s 2>/dev/null; shell_exe=$(readlink /proc/$$/exe 2>/dev/null || readlink /bin/sh 2>/dev/null || true); case \"$shell_exe\" in *busybox*) printf \"busybox\\n\" ;; esac; if [ -f /etc/openwrt_release ]; then printf \"openwrt\\n\"; fi; if [ -r /etc/centos-release ] || [ -r /etc/redhat-release ] || [ -r /etc/fedora-release ]; then printf \"linux\\n\"; fi; printf \"__FILETERM_PROBE_END__\\n\"'",
+        tab_id,
+        request_pty,
+    )
+    .await;
+    request_pty |= used_pty;
     if let Ok(result) = &posix_result {
         // CRLF normalization — Windows remotes emit `\r\n` which would
         // pollute platform detection (e.g. `linux\r` fails `contains`).
@@ -23,9 +89,12 @@ pub(crate) async fn probe_remote_platform_for_session<H: Handler>(
             if let Some(platform) = classify_posix_probe_body(&body) {
                 log_probe_message(
                     tab_id,
-                    format!("probe=posix classified platform={platform}"),
+                    format!(
+                        "probe=posix classified platform={platform} transport={}",
+                        probe_transport_label(request_pty)
+                    ),
                 );
-                return platform.to_string();
+                return PlatformProbeResult::new(platform, request_pty);
             }
         }
     }
@@ -35,16 +104,26 @@ pub(crate) async fn probe_remote_platform_for_session<H: Handler>(
     // bare POSIX fallback so platform detection does not depend on shell
     // startup files. This is especially useful for hosted Debian 12 images.
     let fallback_probe = "uname -s 2>/dev/null; if [ -r /etc/centos-release ] || [ -r /etc/redhat-release ] || [ -r /etc/fedora-release ]; then cat /etc/centos-release /etc/redhat-release /etc/fedora-release 2>/dev/null; fi";
-    let fallback_result = exec_command_with_status_detailed(handle, fallback_probe).await;
-    log_probe_result("posix-fallback", &fallback_result, tab_id);
+    let (fallback_result, used_pty) = run_probe_command(
+        handle,
+        "posix-fallback",
+        fallback_probe,
+        tab_id,
+        request_pty,
+    )
+    .await;
+    request_pty |= used_pty;
     if let Ok(result) = &fallback_result {
         let output = result.output.replace("\r\n", "\n").replace('\r', "\n");
         if let Some(platform) = classify_posix_probe_body(&output) {
             log_probe_message(
                 tab_id,
-                format!("probe=posix-fallback classified platform={platform}"),
+                format!(
+                    "probe=posix-fallback classified platform={platform} transport={}",
+                    probe_transport_label(request_pty)
+                ),
             );
-            return platform.to_string();
+            return PlatformProbeResult::new(platform, request_pty);
         }
     }
 
@@ -52,44 +131,167 @@ pub(crate) async fn probe_remote_platform_for_session<H: Handler>(
     // source. Keep a direct `cat` probe after the generic POSIX probes so a
     // restricted login shell (or an image without a usable `sh -lc`) can
     // still be recognized without depending on `/etc/os-release`.
-    let release_result = exec_command_with_status_detailed(
+    let (release_result, used_pty) = run_probe_command(
         handle,
+        "release-files",
         "cat /etc/redhat-release /etc/centos-release /etc/fedora-release /etc/os-release 2>/dev/null",
+        tab_id,
+        request_pty,
     )
     .await;
-    log_probe_result("release-files", &release_result, tab_id);
+    request_pty |= used_pty;
     if let Ok(result) = &release_result {
         let output = result.output.replace("\r\n", "\n").replace('\r', "\n");
         if let Some(platform) = classify_posix_probe_body(&output) {
             log_probe_message(
                 tab_id,
-                format!("probe=release-files classified platform={platform}"),
+                format!(
+                    "probe=release-files classified platform={platform} transport={}",
+                    probe_transport_label(request_pty)
+                ),
             );
-            return platform.to_string();
+            return PlatformProbeResult::new(platform, request_pty);
         }
     }
 
-    // 2. Try Windows probes
+    // Try Windows probes only after the POSIX family. Once a PTY-required
+    // response has been observed, use PTY for these too; issuing more rejected
+    // non-PTY requests only adds latency and can exhaust a jump host's
+    // MaxSessions allowance.
     let windows_cmds = [
         "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"[Environment]::OSVersion.Platform\"",
         "pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"[Environment]::OSVersion.Platform\"",
         "cmd /c ver",
     ];
     for cmd in &windows_cmds {
-        let result = exec_command_with_status_detailed(handle, cmd).await;
-        log_probe_result(cmd, &result, tab_id);
+        let (result, used_pty) = run_probe_command(handle, cmd, cmd, tab_id, request_pty).await;
+        request_pty |= used_pty;
         if let Ok(result) = &result {
-            let output = &result.output;
-            let output = output.replace("\r\n", "\n").replace('\r', "\n");
+            let output = result.output.replace("\r\n", "\n").replace('\r', "\n");
             if let Some(platform) = classify_windows_probe_output(&output) {
-                log_probe_message(tab_id, format!("probe={cmd} classified platform={platform}"));
-                return platform.to_string();
+                log_probe_message(
+                    tab_id,
+                    format!(
+                        "probe={cmd} classified platform={platform} transport={}",
+                        probe_transport_label(request_pty)
+                    ),
+                );
+                return PlatformProbeResult::new(platform, request_pty);
             }
         }
     }
 
-    log_probe_message(tab_id, "all probes failed; returning platform=unknown");
-    "unknown".to_string()
+    log_probe_message(
+        tab_id,
+        format!(
+            "all probes failed; returning platform=unknown transport={}",
+            probe_transport_label(request_pty)
+        ),
+    );
+    PlatformProbeResult::new("unknown", request_pty)
+}
+
+/// Execute one platform probe with a transport fallback. The returned bool
+/// records whether the result was obtained through a PTY (or whether a PTY
+/// was required but the retry still failed), so the caller can carry that
+/// compatibility decision into the persistent metrics channel.
+async fn run_probe_command<H: Handler>(
+    handle: &Handle<H>,
+    label: &str,
+    command: &str,
+    tab_id: Option<&str>,
+    prefer_pty: bool,
+) -> (Result<ExecCommandResult, String>, bool) {
+    if prefer_pty {
+        let wrapped_command = probe_command_supports_login_shell_wrapper(command)
+            .then(|| build_pty_login_shell_command(command));
+        if let Some(wrapped_command) = wrapped_command.as_deref() {
+            log_probe_message(
+                tab_id,
+                format!(
+                    "probe={label} flow_role=target command prepared command_mode=login-shell-inline-b64 script_bytes={} command_bytes={}",
+                    command.len(),
+                    wrapped_command.len(),
+                ),
+            );
+        }
+        let result = exec_command_with_status_pty_detailed(
+            handle,
+            wrapped_command.as_deref().unwrap_or(command),
+        )
+        .await;
+        log_probe_result(label, &result, tab_id, "exec-pty");
+        return (result, true);
+    }
+
+    let result = exec_command_with_status_detailed(handle, command).await;
+    log_probe_result(label, &result, tab_id, "exec");
+    let requires_pty = match &result {
+        Ok(result) => output_indicates_pty_required(&result.output),
+        Err(error) => output_indicates_pty_required(error),
+    };
+    if !requires_pty {
+        return (result, false);
+    }
+
+    log_probe_message(
+        tab_id,
+        format!(
+            "probe={label} flow_role=target retrying transport=exec-pty reason=pty-required-response command_mode={}",
+            if probe_command_supports_login_shell_wrapper(command) {
+                "login-shell-inline-b64"
+            } else {
+                "direct"
+            }
+        ),
+    );
+    let wrapped_command = probe_command_supports_login_shell_wrapper(command)
+        .then(|| build_pty_login_shell_command(command));
+    if let Some(wrapped_command) = wrapped_command.as_deref() {
+        log_probe_message(
+            tab_id,
+            format!(
+                "probe={label} flow_role=target command prepared command_mode=login-shell-inline-b64 script_bytes={} command_bytes={}",
+                command.len(),
+                wrapped_command.len(),
+            ),
+        );
+    }
+    let pty_result = exec_command_with_status_pty_detailed(
+        handle,
+        wrapped_command.as_deref().unwrap_or(command),
+    )
+    .await;
+    log_probe_result(label, &pty_result, tab_id, "exec-pty");
+    (pty_result, true)
+}
+
+fn probe_transport_label(request_pty: bool) -> &'static str {
+    if request_pty {
+        "exec-pty"
+    } else {
+        "exec"
+    }
+}
+
+/// Detect the benign response emitted by SSH servers that only execute
+/// commands attached to a terminal. Keep this deliberately narrow: a generic
+/// command error mentioning `pty` must not make every subsequent probe request
+/// a PTY and change stderr semantics on otherwise compatible servers.
+fn output_indicates_pty_required(output: &str) -> bool {
+    let normalized = output.to_ascii_lowercase();
+    [
+        "no pty requested",
+        "no pty was requested",
+        "pty required",
+        "requires a pty",
+        "requires pty",
+        "must request a pty",
+        "must request pty",
+        "request a pty",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker))
 }
 
 fn log_probe_scope(tab_id: Option<&str>) -> String {
@@ -107,13 +309,14 @@ fn log_probe_result(
     label: &str,
     result: &Result<ExecCommandResult, String>,
     tab_id: Option<&str>,
+    transport: &str,
 ) {
     let scope = log_probe_scope(tab_id);
     match result {
         Ok(result) => crate::services::logging::debug_global(
             &scope,
             format!(
-                "probe={label} result=ok exit_code={} timed_out={} output_truncated={} output={:?}",
+                "probe={label} flow_role=target transport={transport} result=ok exit_code={} timed_out={} output_truncated={} output={:?}",
                 result
                     .exit_code
                     .map(|status| status.to_string())
@@ -125,7 +328,9 @@ fn log_probe_result(
         ),
         Err(error) => crate::services::logging::debug_global(
             &scope,
-            format!("probe={label} result=error error={error}"),
+                format!(
+                    "probe={label} flow_role=target transport={transport} result=error error={error}"
+                ),
         ),
     }
 }
@@ -241,9 +446,19 @@ pub async fn exec_command_with_status_pty<H: Handler>(
     handle: &Handle<H>,
     cmd: &str,
 ) -> Result<(String, Option<u32>), String> {
-    exec_command_internal(handle, cmd, None, true, None, None)
+    exec_command_with_status_pty_detailed(handle, cmd)
         .await
         .map(|result| (result.output, result.exit_code))
+}
+
+/// PTY variant of [`exec_command_with_status_detailed`] used by platform
+/// detection. Keeping the truncation/timeout metadata lets the probe logger
+/// describe the retry with the same fidelity as the regular transport.
+pub(crate) async fn exec_command_with_status_pty_detailed<H: Handler>(
+    handle: &Handle<H>,
+    cmd: &str,
+) -> Result<ExecCommandResult, String> {
+    exec_command_internal(handle, cmd, None, true, None, None).await
 }
 
 /// Run an exec command with a requested PTY, write `stdin`, and retain the

--- a/apps/tauri/src-tauri/src/sessions/system_metrics/tests.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics/tests.rs
@@ -2,12 +2,15 @@
 mod tests {
     use super::{
         append_pty_prompt_window, build_freebsd_metrics_command, build_posix_metrics_command,
+        build_pty_login_shell_command,
         build_windows_metrics_command, build_windows_streaming_metrics_command,
         build_windows_streaming_metrics_exec_command, classify_posix_probe_body,
         classify_windows_probe_output, extend_with_cap, parse_system_metrics,
-        pty_password_prompt_detected, is_retryable_exec_channel_open_error,
+        output_indicates_pty_required, pty_password_prompt_detected,
+        is_retryable_exec_channel_open_error,
         EXEC_CHANNEL_OPEN_RETRY_ATTEMPTS, EXEC_CHANNEL_OPEN_RETRY_DELAY, EXEC_COMMAND_OUTPUT_CAP,
     };
+    use base64::Engine;
     use std::time::Duration;
 
     #[test]
@@ -86,6 +89,31 @@ mod tests {
             status.success(),
             "generated POSIX metrics script is invalid"
         );
+    }
+
+    #[test]
+    fn pty_login_shell_command_keeps_script_out_of_stdin_and_uses_login_shell() {
+        let script = "printf '__FILETERM_PROBE_START__\\n'; uname -s";
+        let command = build_pty_login_shell_command(script);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(script.as_bytes());
+
+        assert!(command.starts_with("bash --login -c '"));
+        assert!(command.contains("base64 -d"));
+        assert!(command.contains("base64 -D"));
+        assert!(command.contains(&encoded));
+        assert!(!command.contains(script));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pty_login_shell_command_is_valid_shell_syntax() {
+        let command = build_pty_login_shell_command("printf 'ok\\n'");
+        let status = std::process::Command::new("sh")
+            .args(["-n", "-c", &command])
+            .status()
+            .expect("shell syntax checker should start");
+
+        assert!(status.success(), "generated PTY command is invalid");
     }
 
     #[test]
@@ -510,6 +538,15 @@ devil() {{
     fn posix_probe_returns_none_for_unrecognized_bodies() {
         assert_eq!(classify_posix_probe_body(""), None);
         assert_eq!(classify_posix_probe_body("sunos\n"), None);
+    }
+
+    #[test]
+    fn platform_probe_detects_pty_required_server_responses_without_false_positives() {
+        assert!(output_indicates_pty_required("No PTY requested.\n"));
+        assert!(output_indicates_pty_required("command requires a pty"));
+        assert!(output_indicates_pty_required("MUST REQUEST PTY"));
+        assert!(!output_indicates_pty_required("pty allocation request accepted"));
+        assert!(!output_indicates_pty_required("Linux\n"));
     }
 
     #[test]

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.2.8-beta.2",
+  "version": "2.2.8-beta.3",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/apps/tauri/src/renderer/hooks/use-workspace-ipc-sync.ts
+++ b/apps/tauri/src/renderer/hooks/use-workspace-ipc-sync.ts
@@ -569,6 +569,7 @@ export function useWorkspaceIpcSync({
     let hydrated = false
     let receivedSnapshotEvent = false
     const pendingMetrics: SessionMetricsUpdate[] = []
+    let receivedMetricsEventCount = 0
     const pendingTransfers: TransferTask[] = []
     const pendingRemoteFiles: RemoteFilesUpdate[] = []
     let unsubscribeSnapshot: (() => void) | null = null
@@ -663,11 +664,29 @@ export function useWorkspaceIpcSync({
           if (canceled) {
             return
           }
+          receivedMetricsEventCount += 1
+          const shouldLogMetricsEvent = receivedMetricsEventCount === 1 || receivedMetricsEventCount % 60 === 0
+          if (shouldLogMetricsEvent) {
+            logWorkspaceDiagnostic(
+              'DEBUG',
+              `session metrics event received count=${receivedMetricsEventCount} tab_id=${payload.tabId} mode=${payload.mode ?? 'replace'} has_system_metrics=${payload.systemMetrics !== undefined} hydrated=${hydrated}`
+            )
+          }
           if (!hydrated) {
             pendingMetrics.push(payload)
+            logWorkspaceDiagnostic(
+              'DEBUG',
+              `session metrics event queued tab_id=${payload.tabId} reason=workspace-not-hydrated pending_count=${pendingMetrics.length}`
+            )
             return
           }
           applySessionMetrics(payload)
+          if (shouldLogMetricsEvent) {
+            logWorkspaceDiagnostic(
+              'DEBUG',
+              `session metrics update scheduled count=${receivedMetricsEventCount} tab_id=${payload.tabId} mode=${payload.mode ?? 'replace'}`
+            )
+          }
         })
       : () => undefined
     const unsubscribeTransferUpdate = isMainWorkspaceWindow

--- a/docs/release-notes/release-notes-2.2.8-beta.3.md
+++ b/docs/release-notes/release-notes-2.2.8-beta.3.md
@@ -11,7 +11,7 @@ FileTerm 2.2.8-beta.3 是面向 SSH 跳板机资源监控的兼容性测试版�
 
 ### 本版本包含的主要 PR 和问题修复
 
-- SSH 跳板机资源监控兼容性修复：覆盖 SSH-2.0-Go 网关的 PTY 回退、目标机身份校验、监控通道生命周期和前后端状态同步。
+- [PR #233](https://github.com/St0ff3l/fileterm/pull/233)：SSH 跳板机资源监控兼容性修复，覆盖 SSH-2.0-Go 网关的 PTY 回退、目标机身份校验、监控通道生命周期和前后端状态同步。
 
 完整变更记录请查看 [v2.2.8-beta.2 与 v2.2.8-beta.3 的比较](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.2...v2.2.8-beta.3)。
 
@@ -36,7 +36,7 @@ FileTerm 2.2.8-beta.3 is a compatibility beta for SSH jump-host resource monitor
 
 ### Main PRs and issues
 
-- SSH jump-host resource-monitoring compatibility: PTY fallback for SSH-2.0-Go gateways, target identity validation, metrics-channel lifecycle, and renderer state synchronization.
+- [PR #233](https://github.com/St0ff3l/fileterm/pull/233): SSH jump-host resource-monitoring compatibility with PTY fallback for SSH-2.0-Go gateways, target identity validation, metrics-channel lifecycle, and renderer state synchronization.
 
 See the [comparison between v2.2.8-beta.2 and v2.2.8-beta.3](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.2...v2.2.8-beta.3) for the complete change set.
 

--- a/docs/release-notes/release-notes-2.2.8-beta.3.md
+++ b/docs/release-notes/release-notes-2.2.8-beta.3.md
@@ -1,0 +1,47 @@
+## FileTerm 2.2.8-beta.3
+
+FileTerm 2.2.8-beta.3 是面向 SSH 跳板机资源监控的兼容性测试版，重点处理 SSH-2.0-Go 网关与目标机 OpenSSH 之间的 PTY、探针和监控通道衔接。
+
+### 2.2.8-beta.3 更新重点
+
+- **跳板机监控兼容**：平台探针发现目标入口要求 PTY 或返回 `No PTY requested` 时自动重试 PTY，并将兼容性决策传递给长期指标通道。
+- **目标机采集执行**：PTY 模式使用 `bash --login` 和 Base64 单行命令执行 POSIX 采集脚本，避免向 PTY stdin 灌入长脚本导致卡死或回显污染；透明 `direct-tcpip` 场景继续与目标机 OpenSSH 端到端握手。
+- **目标身份保护**：首个完整快照必须包含目标 hostname、OS 和 kernel 信息，确认拿到目标 CentOS/Linux 身份后才更新资源侧栏；无法确认时自动关闭监控，终端和 SFTP 仍可使用。
+- **诊断与安全**：补充跳板机/目标机独立握手标识、PTY 重试、命令模式、退出码、远端 stdout/stderr 尾部、snapshot 发送/接收/应用和侧栏折叠原因日志；日志不记录密码、OTP、私钥口令或交互答案。本版本没有新增 FIDO2/Web SSO 流程，仍需真实 KoKo + CentOS 7 环境验证。
+
+### 本版本包含的主要 PR 和问题修复
+
+- SSH 跳板机资源监控兼容性修复：覆盖 SSH-2.0-Go 网关的 PTY 回退、目标机身份校验、监控通道生命周期和前后端状态同步。
+
+完整变更记录请查看 [v2.2.8-beta.2 与 v2.2.8-beta.3 的比较](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.2...v2.2.8-beta.3)。
+
+### 反馈与支持
+
+遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
+
+也可以打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81) 加入社区。
+
+---
+
+## FileTerm 2.2.8-beta.3
+
+FileTerm 2.2.8-beta.3 is a compatibility beta for SSH jump-host resource monitoring, focused on PTY, probing, and metrics-channel handoff between SSH-2.0-Go gateways and OpenSSH target hosts.
+
+### Highlights
+
+- **Jump-host monitoring compatibility**: Retry platform probes with a PTY when the target entry point requires one or returns `No PTY requested`, then carry that compatibility decision into the persistent metrics channel.
+- **Target collection execution**: PTY mode runs POSIX collection through a single `bash --login` Base64 command, avoiding long scripts sent to PTY stdin and their echo or line-buffer failures; transparent `direct-tcpip` connections continue their end-to-end handshake with the OpenSSH target.
+- **Target identity protection**: The first complete snapshot must identify the target hostname, OS, and kernel before the resource sidebar is updated; uncertain identity disables monitoring while leaving the terminal and SFTP available.
+- **Diagnostics and security**: Add independent jump/target handshake identity, PTY retry, command-mode, exit-status, bounded remote stdout/stderr, snapshot emission/receipt/application, and sidebar-collapse diagnostics. Logs do not record passwords, OTPs, private-key passphrases, or interactive answers. This release adds no FIDO2/Web SSO flow and still requires validation on a real KoKo + CentOS 7 environment.
+
+### Main PRs and issues
+
+- SSH jump-host resource-monitoring compatibility: PTY fallback for SSH-2.0-Go gateways, target identity validation, metrics-channel lifecycle, and renderer state synchronization.
+
+See the [comparison between v2.2.8-beta.2 and v2.2.8-beta.3](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.2...v2.2.8-beta.3) for the complete change set.
+
+### Feedback & Support
+
+For problems, open a [GitHub Issue](https://github.com/St0ff3l/fileterm/issues) with the operating system, FileTerm version, connection type, reproduction steps, and redacted logs. Do not submit passwords, private keys, or tokens.
+
+Join the community through the [README community section](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.2",
+  "version": "2.2.8-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.2.8-beta.2",
+      "version": "2.2.8-beta.3",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,10 +33,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.2.8-beta.2",
+      "version": "2.2.8-beta.3",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.2",
-        "@fileterm/shared": "2.2.8-beta.2",
+        "@fileterm/core": "2.2.8-beta.3",
+        "@fileterm/shared": "2.2.8-beta.3",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -5501,17 +5501,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.2.8-beta.2"
+      "version": "2.2.8-beta.3"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.2.8-beta.2"
+      "version": "2.2.8-beta.3"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.2.8-beta.2",
+      "version": "2.2.8-beta.3",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.2"
+        "@fileterm/core": "2.2.8-beta.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.2",
+  "version": "2.2.8-beta.3",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.2.8-beta.2",
+  "version": "2.2.8-beta.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.2.8-beta.2",
+  "version": "2.2.8-beta.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.2.8-beta.2",
+  "version": "2.2.8-beta.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.2"
+    "@fileterm/core": "2.2.8-beta.3"
   }
 }


### PR DESCRIPTION
## Summary
- retry platform probes with PTY when SSH-2.0-Go gateways reject plain exec
- run POSIX metrics through a bash --login Base64 command in PTY mode
- validate target hostname/OS/kernel before enabling the resource sidebar
- add bounded remote channel diagnostics and renderer snapshot/application logs
- prepare FileTerm 2.2.8-beta.3 release metadata and notes

## Validation
- cargo test --locked --manifest-path apps/tauri/src-tauri/Cargo.toml
- cargo clippy --locked --manifest-path apps/tauri/src-tauri/Cargo.toml --all-targets --all-features -- -D warnings
- npm run typecheck -w @fileterm/tauri
- npm run lint
- Prettier checks

This is a compatibility beta and still requires real KoKo + CentOS 7 validation.