### PR TITLE
fix(ssh): route JumpServer gateway sessions safely

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.2.8-beta.3",
+  "version": "2.2.8-beta.4",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -26,8 +26,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.3",
-    "@fileterm/shared": "2.2.8-beta.3",
+    "@fileterm/core": "2.2.8-beta.4",
+    "@fileterm/shared": "2.2.8-beta.4",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.2.8-beta.3"
+version = "2.2.8-beta.4"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.2.8-beta.3"
+version = "2.2.8-beta.4"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
+++ b/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
@@ -58,7 +58,7 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-    <release version="2.2.8-beta.3" date="2026-09-03">
+    <release version="2.2.8-beta.4" date="2026-09-03">
       <description>
         <p>Official release with multi-tab remote terminal and file management workspace.</p>
       </description>

--- a/apps/tauri/src-tauri/src/sessions/ssh/transport/session.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/transport/session.rs
@@ -246,6 +246,18 @@ async fn open_session(
                 }
             ),
         );
+        if jump_identification
+            .to_ascii_lowercase()
+            .starts_with("ssh-2.0-go")
+        {
+            crate::services::logging::session(
+                app,
+                "WARN",
+                "ssh",
+                tab_id,
+                "jump host identifies as SSH-2.0-Go; direct-tcpip target routing may be policy-gated by an application gateway (for KoKo use a direct asset username or an ordinary OpenSSH jump host)",
+            );
+        }
         let jump_handle = jump_session.handle;
 
         let mut target_profile = effective_profile.clone();

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/context.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/context.rs
@@ -135,6 +135,13 @@ struct SshWorkerStartupContext<'a> {
     /// platform probe records that compatibility decision so the persistent
     /// metrics channel uses the same transport instead of exiting immediately.
     metrics_request_pty: bool,
+    /// A menu-driven gateway such as JumpServer/KoKo has not routed this
+    /// channel to an asset yet. Auxiliary channels would each receive a new
+    /// asset-selection menu instead of reaching the selected target.
+    interactive_gateway: bool,
+    /// Best-effort route classification used only for diagnostics. It is
+    /// intentionally computed from profile shape and never changes routing.
+    route_hint: &'static str,
     cancellation: &'a CancellationToken,
     state: &'a crate::services::workspace::WorkspaceState,
 }

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/loop.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/loop.rs
@@ -17,11 +17,39 @@ async fn run_worker_loop(
         .and_then(|u| u.as_str())
         .unwrap_or("root")
         .to_string();
+    let jump_host_configured = profile
+        .get("jumpProfileId")
+        .and_then(Value::as_str)
+        .is_some();
+    let direct_login_hint =
+        crate::sessions::system_metrics::jumpserver_direct_login_hint(&username);
+    let route_hint = if jump_host_configured {
+        "transparent-jump-host"
+    } else if direct_login_hint.is_some() {
+        "jumpserver-direct-asset"
+    } else {
+        "direct-or-interactive"
+    };
+    crate::services::logging::session(
+        app,
+        "INFO",
+        "ssh",
+        tab_id,
+        format!(
+            "SSH route classified route_hint={route_hint} jump_profile_configured={jump_host_configured} direct_login_hint={} direct_login_user_segments={}",
+            direct_login_hint.unwrap_or("none"),
+            username
+                .split(['@', '#'])
+                .filter(|part| !part.trim().is_empty())
+                .count()
+        ),
+    );
 
-    // ── Main session (single SSH session multiplexes shell + SFTP + metrics) ─
+    // ── Main session (one authenticated handle for shell + auxiliary channels)
     // Servers with strict MaxSessions reject parallel sessions, so we reuse
-    // one authenticated handle for every channel. The handle is wrapped in
-    // `Arc` so the background metrics task can share it with the main loop.
+    // one authenticated handle for every channel when the target route is
+    // known. Menu-driven gateways are the exception: their auxiliary channels
+    // start a new unselected menu and are deferred after platform probing.
     let session = match tokio::select! {
         biased;
         _ = cancellation.cancelled() => Err("SSH connection canceled".to_string()),
@@ -48,7 +76,13 @@ async fn run_worker_loop(
             return Err(error);
         }
     };
-    crate::services::logging::session(app, "INFO", "ssh", tab_id, "SSH session established");
+    crate::services::logging::session(
+        app,
+        "INFO",
+        "ssh",
+        tab_id,
+        format!("SSH session established route_hint={route_hint}"),
+    );
     let remote_sshid = session.remote_sshid;
     let disconnect_reason = session.disconnect_reason;
     let handle: Arc<Handle<ClientHandler>> = Arc::new(session.handle);
@@ -177,7 +211,7 @@ async fn run_worker_loop(
     // channel.wait() 循环读取且无内层 timeout。服务器在 exec 模式下卡住
     // 时整个 probe 会永久 await，worker 永远起不来。超时后回落到
     // "unknown"，shell CWD 注入会被 fail-closed 门控跳过，终端仍可用。
-    let (platform, mut metrics_request_pty) = if network_device_mode {
+    let (platform, mut metrics_request_pty, interactive_gateway) = if network_device_mode {
         crate::services::logging::session(
             app,
             "INFO",
@@ -185,7 +219,7 @@ async fn run_worker_loop(
             tab_id,
             "network-device mode; skipping platform probe",
         );
-        ("unknown".to_string(), false)
+        ("unknown".to_string(), false, false)
     } else if exec_channel_enabled {
         crate::services::logging::session(
             app,
@@ -206,7 +240,7 @@ async fn run_worker_loop(
         )
         .await
         {
-            Ok(result) => (result.platform, result.request_pty),
+            Ok(result) => (result.platform, result.request_pty, result.interactive_gateway),
             Err(_) => {
                 crate::services::logging::session(
                     app,
@@ -215,7 +249,7 @@ async fn run_worker_loop(
                     tab_id,
                     "platform probe timed out, falling back to unknown",
                 );
-                ("unknown".to_string(), false)
+                ("unknown".to_string(), false, false)
             }
         }
     } else {
@@ -226,7 +260,7 @@ async fn run_worker_loop(
             tab_id,
             "exec channel disabled; skipping platform probe",
         );
-        ("unknown".to_string(), false)
+        ("unknown".to_string(), false, false)
     };
 
     // Go-based jump hosts commonly gate all command handlers on a PTY. Keep a
@@ -253,7 +287,7 @@ async fn run_worker_loop(
         "metrics",
         tab_id,
         format!(
-            "platform probe completed platform={platform} transport={} metrics_request_pty={metrics_request_pty}",
+            "platform probe completed platform={platform} transport={} metrics_request_pty={metrics_request_pty} interactive_gateway={interactive_gateway} route_hint={route_hint}",
             if metrics_request_pty {
                 "exec-pty"
             } else {
@@ -261,6 +295,25 @@ async fn run_worker_loop(
             }
         ),
     );
+    if interactive_gateway {
+        crate::services::logging::session(
+            app,
+            "WARN",
+            "ssh",
+            tab_id,
+            format!(
+                "interactive SSH gateway detected route_hint={route_hint}; terminal is still connected but target asset is not routed; deferring metrics and SFTP; use JumpServer direct username JumpServerUser@AssetUser@AssetIP or a transparent jumpProfileId route through an ordinary OpenSSH jump host"
+            ),
+        );
+    } else if remote_sshid_is_go {
+        crate::services::logging::session(
+            app,
+            "DEBUG",
+            "ssh",
+            tab_id,
+            "SSH-2.0-Go banner observed without an interactive asset menu; continuing auxiliary channels and requiring a real target identity in the first metrics sample",
+        );
+    }
 
     // ── Inject shell CWD setup (POSIX only, fail-closed) ───────────────────
     // Mirrors Electron's `supportsPosixShellSetup()` + `injectShellSetup()`
@@ -314,6 +367,8 @@ async fn run_worker_loop(
         network_device_mode,
         exec_channel_enabled,
         metrics_request_pty,
+        interactive_gateway,
+        route_hint,
         cancellation: &cancellation,
         state: &state,
     };
@@ -321,9 +376,47 @@ async fn run_worker_loop(
     let (sftp_arc, sftp_unavailable_reason) = initialize_sftp_session(&startup).await;
     let transfer_sftp_slot: TransferSftpSlot = Arc::new(Mutex::new(None));
 
-    // Push the full snapshot (with files) to the renderer
-    if let Ok(snapshot) = crate::commands::get_workspace_snapshot(app.clone()).await {
-        let _ = app.emit("workspace:snapshot", snapshot);
+    // Push the full snapshot (with files) to the renderer. Record both sides
+    // of this boundary: the backend emit result is useful when a WebView is
+    // not yet listening, while the renderer logs receipt/application of the
+    // same workspace revision.
+    match crate::commands::get_workspace_snapshot(app.clone()).await {
+        Ok(snapshot) => {
+            let workspace_revision = snapshot
+                .get("workspaceRevision")
+                .and_then(Value::as_u64)
+                .map(|revision| revision.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            match app.emit("workspace:snapshot", snapshot) {
+                Ok(()) => crate::services::logging::session(
+                    app,
+                    "INFO",
+                    "ssh",
+                    tab_id,
+                    format!(
+                        "initial workspace snapshot emitted workspace_revision={workspace_revision} interactive_gateway={interactive_gateway}"
+                    ),
+                ),
+                Err(error) => crate::services::logging::session(
+                    app,
+                    "WARN",
+                    "ssh",
+                    tab_id,
+                    format!(
+                        "initial workspace snapshot emission failed workspace_revision={workspace_revision} interactive_gateway={interactive_gateway} error={error}"
+                    ),
+                ),
+            }
+        }
+        Err(error) => crate::services::logging::session(
+            app,
+            "WARN",
+            "ssh",
+            tab_id,
+            format!(
+                "initial workspace snapshot build failed interactive_gateway={interactive_gateway} error={error}"
+            ),
+        ),
     }
     if sftp_arc.is_some() {
         let cleanup_app = app.clone();

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/metrics.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/metrics.rs
@@ -16,6 +16,19 @@ let platform = startup.platform;
 let cancellation = startup.cancellation;
 let state = startup.state;
 let metrics_request_pty = startup.metrics_request_pty;
+let route_hint = startup.route_hint;
+if startup.interactive_gateway {
+    crate::services::logging::session(
+        app,
+        "INFO",
+        "metrics",
+        tab_id,
+        format!(
+            "interactive gateway detected; skipping auxiliary metrics channel until target route is known route_hint={route_hint}"
+        ),
+    );
+    return;
+}
 // ── Spawn metrics collection task (single persistent channel) ─────────
 // Instead of opening a new exec channel every second (which adds variable
 // SSH overhead and makes the refresh cadence jittery), we open one
@@ -46,7 +59,7 @@ if effective_resource_monitoring_enabled(profile) {
             "metrics",
             &metrics_tid,
             format!(
-                "collector starting flow_role=target target={target_host}:{target_port} platform={} collector_variant={} interval_seconds={metrics_interval_seconds} request_pty={metrics_request_pty}",
+                "collector starting flow_role=target target={target_host}:{target_port} profile_endpoint={target_host}:{target_port} route_hint={route_hint} platform={} collector_variant={} interval_seconds={metrics_interval_seconds} request_pty={metrics_request_pty}",
                 metrics_plat,
                 if metrics_plat == "windows" {
                     "windows"
@@ -523,7 +536,7 @@ if effective_resource_monitoring_enabled(profile) {
                                             "metrics",
                                             &metrics_tid,
                                             format!(
-                                                "target identity rejected before first snapshot flow_role=target target={target_host}:{target_port} platform={} remote_ip={remote_ip:?} remote_hostname={remote_hostname:?} remote_os={remote_os:?} remote_kernel={remote_kernel:?} reason=missing-or-incompatible-identity",
+                                                "target identity rejected before first snapshot flow_role=target target={target_host}:{target_port} profile_endpoint={target_host}:{target_port} route_hint={route_hint} platform={} remote_ip={remote_ip:?} remote_hostname={remote_hostname:?} remote_os={remote_os:?} remote_kernel={remote_kernel:?} reason=missing-or-incompatible-identity",
                                                 metrics_plat,
                                             ),
                                         );
@@ -542,7 +555,7 @@ if effective_resource_monitoring_enabled(profile) {
                                         "metrics",
                                         &metrics_tid,
                                         format!(
-                                            "target identity validated before first snapshot flow_role=target target={target_host}:{target_port} platform={} remote_ip={remote_ip:?} remote_hostname={remote_hostname:?} remote_os={remote_os:?} remote_kernel={remote_kernel:?}",
+                                            "target identity validated before first snapshot flow_role=target target={target_host}:{target_port} profile_endpoint={target_host}:{target_port} route_hint={route_hint} platform={} remote_ip={remote_ip:?} remote_hostname={remote_hostname:?} remote_os={remote_os:?} remote_kernel={remote_kernel:?}",
                                             metrics_plat,
                                         ),
                                     );
@@ -555,7 +568,7 @@ if effective_resource_monitoring_enabled(profile) {
                                         "metrics",
                                         &metrics_tid,
                                         format!(
-                                            "first sample target={target_host}:{target_port} cpu_percent={cpu_pct:.1} memory_percent={mem_pct:.1} remote_ip={} remote_hostname={:?} remote_os={:?} remote_kernel={:?}",
+                                            "first sample flow_role=target target={target_host}:{target_port} profile_endpoint={target_host}:{target_port} route_hint={route_hint} cpu_percent={cpu_pct:.1} memory_percent={mem_pct:.1} remote_ip={} remote_hostname={:?} remote_os={:?} remote_kernel={:?}",
                                             metrics_identity_field(&val, "ip"),
                                             metrics_identity_field(&val, "hostname"),
                                             metrics_identity_field(&val, "osName"),

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/metrics_diagnostics.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/metrics_diagnostics.rs
@@ -40,7 +40,12 @@ fn metrics_stderr_preview(tail: &[u8]) -> String {
 
 fn metrics_stdout_preview(tail: &[u8], sample_count: u64) -> String {
     if sample_count == 0 {
-        metrics_stderr_preview(tail)
+        let output = String::from_utf8_lossy(tail);
+        if crate::sessions::system_metrics::detect_interactive_gateway(&output).is_some() {
+            "<interactive-gateway-menu-suppressed>".to_string()
+        } else {
+            metrics_stderr_preview(tail)
+        }
     } else {
         "<suppressed-after-first-sample>".to_string()
     }
@@ -187,7 +192,8 @@ async fn close_metrics_channel(
 #[cfg(test)]
 mod metrics_tests {
     use super::{
-        append_metrics_stderr_tail, metrics_identity_field, target_identity_is_valid,
+        append_metrics_stderr_tail, metrics_identity_field, metrics_stdout_preview,
+        target_identity_is_valid,
         METRICS_STDERR_TAIL_BYTES,
     };
 
@@ -279,5 +285,20 @@ mod metrics_tests {
         });
 
         assert!(!target_identity_is_valid(&value, "linux"));
+    }
+
+    #[test]
+    fn stdout_preview_suppresses_interactive_gateway_menu() {
+        let menu = b"JumpServer open source fortress system\n1) Search\nOpt> ";
+
+        assert_eq!(
+            metrics_stdout_preview(menu, 0),
+            "<interactive-gateway-menu-suppressed>"
+        );
+        assert_eq!(metrics_stdout_preview(b"probe failed\n", 0), "probe failed\n");
+        assert_eq!(
+            metrics_stdout_preview(menu, 1),
+            "<suppressed-after-first-sample>"
+        );
     }
 }

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/session_snapshot.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/session_snapshot.rs
@@ -10,6 +10,7 @@ let port = startup.port;
 let username = startup.username;
 let network_device_mode = startup.network_device_mode;
 let exec_channel_enabled = startup.exec_channel_enabled;
+let interactive_gateway = startup.interactive_gateway;
 // ── Initialize session snapshot ────────────────────────────────────────
 let state = startup.state;
 {
@@ -40,6 +41,26 @@ let state = startup.state;
         capabilities.resource_monitoring = false;
         capabilities.shell_integration = false;
     }
+    if interactive_gateway {
+        // A menu-driven gateway creates a fresh, unselected route for every
+        // auxiliary SSH channel. Keep the terminal capability, but do not
+        // advertise file or metrics channels that would only observe the
+        // gateway menu instead of the target asset.
+        capabilities.files = false;
+        capabilities.file_access = false;
+        capabilities.resource_monitoring = false;
+        capabilities.shell_integration = false;
+        crate::services::logging::session(
+            startup.app,
+            "INFO",
+            "ssh",
+            tab_id,
+            format!(
+                "session snapshot target route pending route_hint={}; capabilities files=false file_access=false resource_monitoring=false shell_integration=false",
+                startup.route_hint
+            ),
+        );
+    }
     sessions.insert(
         tab_id.to_string(),
         crate::services::SessionSnapshot {
@@ -57,7 +78,7 @@ let state = startup.state;
             terminal_transcript: existing_transcript,
             remote_path: existing_remote_path,
             shell_cwd: existing_shell_cwd,
-            follow_shell_cwd: exec_channel_enabled,
+            follow_shell_cwd: exec_channel_enabled && !interactive_gateway,
             remote_files_loading: false,
             remote_files: Vec::new(),
             sftp_unavailable_reason: None,

--- a/apps/tauri/src-tauri/src/sessions/ssh/worker/sftp_startup.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/worker/sftp_startup.rs
@@ -14,6 +14,8 @@ let network_device_mode = startup.network_device_mode;
 let exec_enabled = startup.exec_channel_enabled;
 let cancellation = startup.cancellation;
 let state = startup.state;
+let interactive_gateway = startup.interactive_gateway;
+let route_hint = startup.route_hint;
 // ── SFTP subsystem ─────────────────────────────────────────────────────
 // russh-sftp 2.3 needs an explicit subsystem request before converting
 // the channel into its protocol stream. A failed SFTP negotiation must
@@ -29,6 +31,25 @@ let (sftp_arc, sftp_unavailable_reason) = if network_device_mode {
         "network-device mode; skipping SFTP channel",
     );
     (None, None)
+} else if interactive_gateway {
+    let reason = "Interactive JumpServer asset selection is active; use JumpServerUser@AssetUser@AssetIP or a transparent OpenSSH jump host before opening SFTP".to_string();
+    crate::services::logging::session(
+        app,
+        "INFO",
+        "sftp",
+        tab_id,
+        format!("interactive gateway detected; skipping auxiliary SFTP channel until target route is known route_hint={route_hint}"),
+    );
+    {
+        let mut sessions = state.sessions.write().await;
+        if let Some(session) = sessions.get_mut(tab_id) {
+            session.remote_files_loading = false;
+            session.sftp_unavailable_reason = Some(reason.clone());
+            session.capabilities.files = false;
+            session.capabilities.file_access = false;
+        }
+    }
+    (None, Some(reason))
 } else if !sftp_enabled {
     let reason = "SFTP disabled for this connection profile".to_string();
     crate::services::logging::session(

--- a/apps/tauri/src-tauri/src/sessions/system_metrics/exec.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics/exec.rs
@@ -15,29 +15,6 @@ pub(crate) async fn probe_remote_platform_for_session<H: Handler>(
         .platform
 }
 
-/// Result of the short platform probe that runs before the terminal worker
-/// enters its main event loop.
-///
-/// A few SSH servers (including Go-based jump hosts) reject every `exec`
-/// request that does not carry a PTY. Returning the transport used by the
-/// successful probe lets the long-lived metrics channel make the same choice;
-/// otherwise platform detection can succeed while the collector immediately
-/// exits with a benign-looking status 0.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct PlatformProbeResult {
-    pub platform: String,
-    pub request_pty: bool,
-}
-
-impl PlatformProbeResult {
-    fn new(platform: impl Into<String>, request_pty: bool) -> Self {
-        Self {
-            platform: platform.into(),
-            request_pty,
-        }
-    }
-}
-
 /// Build a single remote command for PTY-only SSH gateways.
 ///
 /// KoKo-style gateways inspect the raw `exec` command before forwarding it to
@@ -82,6 +59,7 @@ pub(crate) async fn probe_remote_platform_for_session_with_transport<H: Handler>
     .await;
     request_pty |= used_pty;
     if let Ok(result) = &posix_result {
+        return_if_interactive_gateway!(&posix_result, tab_id, "posix", request_pty);
         // CRLF normalization — Windows remotes emit `\r\n` which would
         // pollute platform detection (e.g. `linux\r` fails `contains`).
         let output = result.output.replace("\r\n", "\n").replace('\r', "\n");
@@ -114,6 +92,7 @@ pub(crate) async fn probe_remote_platform_for_session_with_transport<H: Handler>
     .await;
     request_pty |= used_pty;
     if let Ok(result) = &fallback_result {
+        return_if_interactive_gateway!(&fallback_result, tab_id, "posix-fallback", request_pty);
         let output = result.output.replace("\r\n", "\n").replace('\r', "\n");
         if let Some(platform) = classify_posix_probe_body(&output) {
             log_probe_message(
@@ -141,6 +120,7 @@ pub(crate) async fn probe_remote_platform_for_session_with_transport<H: Handler>
     .await;
     request_pty |= used_pty;
     if let Ok(result) = &release_result {
+        return_if_interactive_gateway!(&release_result, tab_id, "release-files", request_pty);
         let output = result.output.replace("\r\n", "\n").replace('\r', "\n");
         if let Some(platform) = classify_posix_probe_body(&output) {
             log_probe_message(
@@ -166,6 +146,7 @@ pub(crate) async fn probe_remote_platform_for_session_with_transport<H: Handler>
     for cmd in &windows_cmds {
         let (result, used_pty) = run_probe_command(handle, cmd, cmd, tab_id, request_pty).await;
         request_pty |= used_pty;
+        return_if_interactive_gateway!(&result, tab_id, cmd, request_pty);
         if let Ok(result) = &result {
             let output = result.output.replace("\r\n", "\n").replace('\r', "\n");
             if let Some(platform) = classify_windows_probe_output(&output) {
@@ -323,7 +304,7 @@ fn log_probe_result(
                     .unwrap_or_else(|| "none".to_string()),
                 result.timed_out,
                 result.output_truncated,
-                result.output.chars().take(300).collect::<String>(),
+                probe_output_preview(&result.output),
             ),
         ),
         Err(error) => crate::services::logging::debug_global(

--- a/apps/tauri/src-tauri/src/sessions/system_metrics/gateway.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics/gateway.rs
@@ -1,0 +1,189 @@
+/// Result of the short platform probe that runs before the terminal worker
+/// enters its main event loop.
+///
+/// Interactive SSH gateways (for example JumpServer/KoKo) expose a menu on
+/// every ordinary client session.  Their banner is not the target asset's OS
+/// identity, so startup phases must carry this distinction instead of treating
+/// a PTY handshake as proof that an asset was reached.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PlatformProbeResult {
+    pub platform: String,
+    pub request_pty: bool,
+    pub interactive_gateway: bool,
+}
+
+impl PlatformProbeResult {
+    fn new(platform: impl Into<String>, request_pty: bool) -> Self {
+        Self {
+            platform: platform.into(),
+            request_pty,
+            interactive_gateway: false,
+        }
+    }
+
+    fn interactive_gateway(request_pty: bool) -> Self {
+        Self {
+            platform: "unknown".to_string(),
+            request_pty,
+            interactive_gateway: true,
+        }
+    }
+}
+
+/// Return the known interactive gateway kind when probe output is a menu
+/// rather than a target shell response.
+///
+/// The detector deliberately requires both a menu prompt and a JumpServer
+/// marker (or its stable Chinese menu phrases).  A normal shell may contain
+/// the word `Opt>` in application output, but it should not disable metrics or
+/// SFTP unless the surrounding output looks like an asset-selection gateway.
+pub(crate) fn detect_interactive_gateway(output: &str) -> Option<&'static str> {
+    let visible = strip_terminal_control_sequences(output).to_lowercase();
+    let has_menu_prompt = visible.contains("opt>") || visible.contains("opt >");
+    let has_jumpserver_marker =
+        visible.contains("jumpserver") || visible.contains("jump server");
+    let has_asset_menu = visible.contains("进行搜索")
+        && (visible.contains("进行退出") || visible.contains("显示帮助"));
+    // KoKo's English locale uses translated labels such as "Show assets you
+    // have access to", "Refresh the latest machine and node information",
+    // and "Show Help".  A custom terminal title can hide the JumpServer
+    // banner, so keep a structural English-menu fallback as well.  Requiring
+    // the prompt plus two menu labels avoids classifying an application's
+    // ordinary `Opt>` output as a gateway.
+    let has_english_asset_menu = visible.contains("show assets you have access")
+        && (visible.contains("refresh the latest")
+            || visible.contains("show help")
+            || visible.contains("switch language"));
+
+    if has_menu_prompt && (has_jumpserver_marker || has_asset_menu || has_english_asset_menu) {
+        Some("jumpserver")
+    } else {
+        None
+    }
+}
+
+/// Recognize the direct-login username shapes documented by JumpServer/KoKo.
+///
+/// KoKo accepts both `user@account@asset` and the equivalent `#` separator;
+/// an optional protocol segment produces `user@ssh@account@asset`.  A
+/// `JMS-...` username is the connection-token form.  This helper is only a
+/// diagnostic hint: it never changes authentication or rewrites a profile.
+/// Keeping it pure lets startup logs explain why a session is expected to be
+/// an asset route or why it is still an interactive menu route.
+pub(crate) fn jumpserver_direct_login_hint(username: &str) -> Option<&'static str> {
+    let username = username.trim();
+    // KoKo's parser uses a case-sensitive `JMS-` token prefix. Keep the
+    // diagnostic hint aligned with that parser; treating `jms-...` as a token
+    // would claim that a normal username is an asset route when KoKo will
+    // actually show the interactive menu (or reject the login).
+    if username.starts_with("JMS-") && username.len() > 4 {
+        return Some("connection-token");
+    }
+
+    for separator in ['@', '#'] {
+        let parts = username.split(separator).collect::<Vec<_>>();
+        if !parts.iter().all(|part| !part.trim().is_empty()) {
+            continue;
+        }
+        match parts.len() {
+            3 => {
+                return Some(match separator {
+                    '@' => "direct-asset-at",
+                    '#' => "direct-asset-hash",
+                    _ => unreachable!(),
+                });
+            }
+            4 => {
+                // KoKo accepts four fields syntactically, but the SSH session
+                // handler only dispatches the direct route when the protocol
+                // field is exactly `ssh`. Do not label an RDP/database shape
+                // as an SSH asset route in diagnostics.
+                if parts[1] != "ssh" {
+                    continue;
+                }
+                return Some(match separator {
+                    '@' => "direct-asset-at-with-protocol",
+                    '#' => "direct-asset-hash-with-protocol",
+                    _ => unreachable!(),
+                });
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Keep probe diagnostics useful without copying a JumpServer asset menu into
+/// `app.log`. The full menu can contain tenant-specific asset names and is not
+/// needed to identify the route; the detector already records its bounded
+/// structural classification separately.
+pub(crate) fn probe_output_preview(output: &str) -> String {
+    if detect_interactive_gateway(output).is_some() {
+        "<interactive-gateway-menu-suppressed>".to_string()
+    } else {
+        output.chars().take(300).collect()
+    }
+}
+
+/// Convert a probe's menu response into an explicit startup result and emit a
+/// bounded diagnostic.  The menu itself is intentionally not logged: it can
+/// contain asset names, hostnames, or other tenant-visible information.
+pub(crate) fn interactive_gateway_probe_result(
+    probe_result: &Result<ExecCommandResult, String>,
+    tab_id: Option<&str>,
+    label: &str,
+    request_pty: bool,
+) -> Option<PlatformProbeResult> {
+    let result = probe_result.as_ref().ok()?;
+    let kind = detect_interactive_gateway(&result.output)?;
+    let transport = probe_transport_label(request_pty);
+    log_probe_message(
+        tab_id,
+        format!(
+            "probe={label} flow_role=target interactive gateway detected kind={kind} transport={transport} exit_code={} timed_out={} output_truncated={} output_bytes={}",
+            result
+                .exit_code
+                .map(|status| status.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            result.timed_out,
+            result.output_truncated,
+            result.output.len(),
+        ),
+    );
+    Some(PlatformProbeResult::interactive_gateway(request_pty))
+}
+
+macro_rules! return_if_interactive_gateway {
+    ($probe_result:expr, $tab_id:expr, $label:expr, $request_pty:expr) => {
+        if let Some(gateway) = interactive_gateway_probe_result(
+            $probe_result,
+            $tab_id,
+            $label,
+            $request_pty,
+        ) {
+            return gateway;
+        }
+    };
+}
+
+fn strip_terminal_control_sequences(input: &str) -> String {
+    let mut visible = String::with_capacity(input.len());
+    let mut in_escape = false;
+    for character in input.chars() {
+        if in_escape {
+            if ('@'..='~').contains(&character) {
+                in_escape = false;
+            }
+            continue;
+        }
+        if character == '\u{1b}' {
+            in_escape = true;
+            continue;
+        }
+        if character.is_control() && !matches!(character, '\n' | '\r' | '\t') {
+            continue;
+        }
+        visible.push(character);
+    }
+    visible
+}

--- a/apps/tauri/src-tauri/src/sessions/system_metrics/mod.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics/mod.rs
@@ -59,6 +59,7 @@ pub(crate) struct BackgroundExecChannel {
     pub pending_pty_stdin: Option<Vec<u8>>,
 }
 
+include!("gateway.rs");
 include!("exec.rs");
 include!("parser.rs");
 include!("posix.rs");

--- a/apps/tauri/src-tauri/src/sessions/system_metrics/tests.rs
+++ b/apps/tauri/src-tauri/src/sessions/system_metrics/tests.rs
@@ -6,7 +6,8 @@ mod tests {
         build_windows_metrics_command, build_windows_streaming_metrics_command,
         build_windows_streaming_metrics_exec_command, classify_posix_probe_body,
         classify_windows_probe_output, extend_with_cap, parse_system_metrics,
-        output_indicates_pty_required, pty_password_prompt_detected,
+        detect_interactive_gateway, output_indicates_pty_required, pty_password_prompt_detected,
+        jumpserver_direct_login_hint, probe_output_preview,
         is_retryable_exec_channel_open_error,
         EXEC_CHANNEL_OPEN_RETRY_ATTEMPTS, EXEC_CHANNEL_OPEN_RETRY_DELAY, EXEC_COMMAND_OUTPUT_CAP,
     };
@@ -114,6 +115,62 @@ mod tests {
             .expect("shell syntax checker should start");
 
         assert!(status.success(), "generated PTY command is invalid");
+    }
+
+    #[test]
+    fn jumpserver_direct_login_hint_matches_documented_username_shapes() {
+        assert_eq!(
+            jumpserver_direct_login_hint("liuhong@root@192.168.0.123"),
+            Some("direct-asset-at")
+        );
+        assert_eq!(
+            jumpserver_direct_login_hint("liuhong@ssh@root@192.168.0.123"),
+            Some("direct-asset-at-with-protocol")
+        );
+        assert_eq!(
+            jumpserver_direct_login_hint("liuhong#root#192.168.0.123"),
+            Some("direct-asset-hash")
+        );
+        assert_eq!(
+            jumpserver_direct_login_hint("JMS-connection-token"),
+            Some("connection-token")
+        );
+    }
+
+    #[test]
+    fn jumpserver_direct_login_hint_rejects_ordinary_or_malformed_usernames() {
+        assert_eq!(jumpserver_direct_login_hint("liuhong"), None);
+        assert_eq!(jumpserver_direct_login_hint("liuhong@root"), None);
+        assert_eq!(jumpserver_direct_login_hint("liuhong@@192.168.0.123"), None);
+        assert_eq!(jumpserver_direct_login_hint("jms-connection-token"), None);
+        assert_eq!(jumpserver_direct_login_hint("JMS-"), None);
+        assert_eq!(
+            jumpserver_direct_login_hint("liuhong@rdp@root@192.168.0.123"),
+            None
+        );
+        assert_eq!(jumpserver_direct_login_hint("用户@root@192.168.0.123"), Some("direct-asset-at"));
+    }
+
+    #[test]
+    fn interactive_gateway_detector_accepts_english_menu_without_brand_banner() {
+        let output = "1) Partial IP, hostname, remark to search\n"
+            .to_string()
+            + "3) Show assets you have access to\n"
+            + "7) Refresh the latest machine and node information\n"
+            + "Opt> ";
+
+        assert_eq!(detect_interactive_gateway(&output), Some("jumpserver"));
+    }
+
+    #[test]
+    fn probe_preview_suppresses_interactive_gateway_menu() {
+        let menu = "JumpServer open source fortress system\n1) Search\nOpt> ";
+
+        assert_eq!(
+            probe_output_preview(menu),
+            "<interactive-gateway-menu-suppressed>"
+        );
+        assert_eq!(probe_output_preview("Linux\n"), "Linux\n");
     }
 
     #[test]
@@ -547,6 +604,22 @@ devil() {{
         assert!(output_indicates_pty_required("MUST REQUEST PTY"));
         assert!(!output_indicates_pty_required("pty allocation request accepted"));
         assert!(!output_indicates_pty_required("Linux\n"));
+    }
+
+    #[test]
+    fn platform_probe_detects_jumpserver_asset_menu_after_pty_retry() {
+        let output = "\u{1b}[H\u{1b}[2J JumpServer 开源堡垒机\r\n 1) 输入部分IP进行搜索登录\r\n 10) 输入 q 进行退出\r\nOpt> ";
+
+        assert_eq!(detect_interactive_gateway(output), Some("jumpserver"));
+    }
+
+    #[test]
+    fn platform_probe_does_not_disable_normal_shell_with_opt_text() {
+        assert_eq!(detect_interactive_gateway("Opt> echo Linux\n"), None);
+        assert_eq!(
+            detect_interactive_gateway("JumpServer docs: use the selector\n"),
+            None
+        );
     }
 
     #[test]

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.2.8-beta.3",
+  "version": "2.2.8-beta.4",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/docs/release-notes/release-notes-2.2.8-beta.4.md
+++ b/docs/release-notes/release-notes-2.2.8-beta.4.md
@@ -1,0 +1,49 @@
+## FileTerm 2.2.8-beta.4
+
+FileTerm 2.2.8-beta.4 是面向 JumpServer/KoKo SSH 网关的兼容性测试版，重点确保资源监控和文件面板只连接已经确认路由到的目标机。
+
+### 2.2.8-beta.4 更新重点
+
+- **网关路由识别**：识别 JumpServer/KoKo 的交互式资产选择菜单，区分“停留在跳板机”与“已经进入目标机”的会话，不再把跳板机菜单误当成 CentOS 资源数据。
+- **目标机监控保护**：指标首个快照必须包含目标 hostname、OS 和 kernel 身份；无法确认目标身份时，自动关闭资源采集并折叠侧栏，终端仍保持可用。
+- **文件通道稳定性**：交互式资产选择尚未完成时不再启动独立 SFTP/exec 通道，避免每个后台通道重新打开菜单、卡住或读取错误主机；已路由目标继续使用 PTY/login-shell 兼容路径。
+- **可排查性与安全**：增加 route hint、跳板/目标握手、PTY、通道退出、目标身份、snapshot 和侧栏状态日志；菜单正文、密码、OTP、私钥口令和交互答案不会写入日志。本版本不新增 FIDO2/Web SSO 流程，仍需真实 KoKo + CentOS 7 环境验证。
+- **使用边界**：JumpServer 请使用其文档中的直接资产登录格式（如 `JumpServerUser@AssetUser@AssetIP`），或配置真正提供 `direct-tcpip` 透传的普通 OpenSSH 跳板机；可参考 [JumpServer SSH 终端连接说明](https://www.jumpserver.com/blog/connecting-via-ssh-terminal)。
+
+### 本版本包含的主要 PR 和问题修复
+
+- [PR #235](https://github.com/St0ff3l/fileterm/pull/235)：识别 JumpServer/KoKo 交互式网关并对指标、SFTP 和侧栏进行目标路由保护，补充全链路诊断日志。
+
+完整变更记录请查看 [v2.2.8-beta.3 与 v2.2.8-beta.4 的比较](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.3...v2.2.8-beta.4)。
+
+### 反馈与支持
+
+遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
+
+也可以打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81) 加入社区。
+
+---
+
+## FileTerm 2.2.8-beta.4
+
+FileTerm 2.2.8-beta.4 is a compatibility beta for JumpServer/KoKo SSH gateways, ensuring that resource monitoring and file browsing are enabled only after the session is confirmed to be routed to the target host.
+
+### Highlights
+
+- **Gateway route detection**: Detect JumpServer/KoKo interactive asset-selection menus and distinguish a session still at the jump gateway from one that has reached the target host, avoiding false CentOS resource data from the gateway.
+- **Target monitoring protection**: Require the first metrics snapshot to identify the target hostname, OS, and kernel; when identity cannot be confirmed, disable collection and collapse the sidebar while keeping the terminal usable.
+- **File-channel stability**: Do not start independent SFTP/exec channels while interactive asset selection is pending, preventing each background channel from opening a fresh menu, hanging, or observing the wrong host; routed targets retain the PTY/login-shell compatibility path.
+- **Diagnostics and security**: Add route-hint, jump/target handshake, PTY, channel-exit, target-identity, snapshot, and sidebar-state diagnostics. Menu contents, passwords, OTPs, private-key passphrases, and interactive answers are not logged. This release adds no FIDO2/Web SSO flow and still requires validation with a real KoKo + CentOS 7 environment.
+- **Usage boundary**: For JumpServer, use its documented direct-asset username format such as `JumpServerUser@AssetUser@AssetIP`, or configure a regular OpenSSH jump host that provides transparent `direct-tcpip` forwarding; see the [JumpServer SSH terminal guide](https://www.jumpserver.com/blog/connecting-via-ssh-terminal).
+
+### Main PRs and issues
+
+- [PR #235](https://github.com/St0ff3l/fileterm/pull/235): Detect JumpServer/KoKo interactive gateways, protect metrics/SFTP/sidebar state until the target route is known, and add end-to-end diagnostics.
+
+See the [comparison between v2.2.8-beta.3 and v2.2.8-beta.4](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.3...v2.2.8-beta.4) for the complete change set.
+
+### Feedback & Support
+
+For problems, open a [GitHub Issue](https://github.com/St0ff3l/fileterm/issues) with the operating system, FileTerm version, connection type, reproduction steps, and redacted logs. Do not submit passwords, private keys, or tokens.
+
+Join the community through the [README community section](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.3",
+  "version": "2.2.8-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.2.8-beta.3",
+      "version": "2.2.8-beta.4",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,10 +33,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.2.8-beta.3",
+      "version": "2.2.8-beta.4",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.3",
-        "@fileterm/shared": "2.2.8-beta.3",
+        "@fileterm/core": "2.2.8-beta.4",
+        "@fileterm/shared": "2.2.8-beta.4",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -5501,17 +5501,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.2.8-beta.3"
+      "version": "2.2.8-beta.4"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.2.8-beta.3"
+      "version": "2.2.8-beta.4"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.2.8-beta.3",
+      "version": "2.2.8-beta.4",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.3"
+        "@fileterm/core": "2.2.8-beta.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.3",
+  "version": "2.2.8-beta.4",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.2.8-beta.3",
+  "version": "2.2.8-beta.4",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.2.8-beta.3",
+  "version": "2.2.8-beta.4",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.2.8-beta.3",
+  "version": "2.2.8-beta.4",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.3"
+    "@fileterm/core": "2.2.8-beta.4"
   }
 }


### PR DESCRIPTION
## Summary

- Detect JumpServer/KoKo interactive asset-selection menus and distinguish them from a routed target shell.
- Fail closed for auxiliary metrics/SFTP channels until a target asset route is established, keeping the terminal usable.
- Add bounded route, target identity, PTY, snapshot, and sidebar diagnostics without logging credentials or menu contents.
- Preserve PTY/login-shell compatibility for routed SSH-2.0-Go paths and require a real target identity before rendering resource metrics.

## Verification

- `cargo fmt --all --manifest-path apps/tauri/src-tauri/Cargo.toml -- --check`
- `cargo test --locked --manifest-path apps/tauri/src-tauri/Cargo.toml`
- `cargo clippy --locked --manifest-path apps/tauri/src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- `npm run typecheck -w @fileterm/tauri`

This is a compatibility beta follow-up and still needs validation with a real KoKo/JumpServer plus CentOS 7 target. Refs SSH jump-host monitoring reports.
