### PR TITLE
fix: prepare FileTerm 2.2.8-beta.6

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.2.8-beta.5",
+  "version": "2.2.8-beta.6",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -26,8 +26,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.5",
-    "@fileterm/shared": "2.2.8-beta.5",
+    "@fileterm/core": "2.2.8-beta.6",
+    "@fileterm/shared": "2.2.8-beta.6",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.2.8-beta.5"
+version = "2.2.8-beta.6"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.2.8-beta.5"
+version = "2.2.8-beta.6"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
+++ b/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
@@ -58,7 +58,7 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-    <release version="2.2.8-beta.5" date="2026-09-04">
+    <release version="2.2.8-beta.6" date="2026-09-04">
       <description>
         <p>Official release with multi-tab remote terminal and file management workspace.</p>
       </description>

--- a/apps/tauri/src-tauri/src/sessions/ssh/authentication/primary.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/authentication/primary.rs
@@ -234,6 +234,25 @@ async fn try_system_authenticate(
 
 // Configured password, private-key, and agent authentication.
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConfiguredAuthenticationMethod {
+    Password,
+    PrivateKey,
+    KeyboardInteractive,
+    System,
+}
+
+fn configured_authentication_method(auth_type: &str) -> ConfiguredAuthenticationMethod {
+    match auth_type {
+        // KoKo records the first password factor in its SSH session context
+        // before it permits the MFA keyboard-interactive continuation.
+        "password" | "jumpserver-koko-mfa" => ConfiguredAuthenticationMethod::Password,
+        "privateKey" => ConfiguredAuthenticationMethod::PrivateKey,
+        "keyboard-interactive" => ConfiguredAuthenticationMethod::KeyboardInteractive,
+        _ => ConfiguredAuthenticationMethod::System,
+    }
+}
+
 async fn try_authenticate(
     handle: &mut Handle<ClientHandler>,
     username: &str,
@@ -243,11 +262,22 @@ async fn try_authenticate(
     interaction: &SshInteractionContext,
     interaction_timeout: Duration,
 ) -> Result<AuthenticationResult, String> {
-    match auth_type {
-        "password" => {
+    match configured_authentication_method(auth_type) {
+        ConfiguredAuthenticationMethod::Password => {
             let Some(password) = password_for_authentication(profile) else {
                 return Err("SSH password is missing".to_string());
             };
+            if auth_type == "jumpserver-koko-mfa" {
+                interaction.log_interaction(
+                    app,
+                    "INFO",
+                    "-",
+                    "authentication",
+                    "jumpserver-koko",
+                    0,
+                    "password-first authentication selected; keyboard-interactive starts only after the server advertises a follow-up challenge",
+                );
+            }
             // Some embedded SSH servers do not reply to a direct password
             // request until the client has first sent the RFC-standard
             // `none` probe. Electron's ssh2 client always performs this
@@ -309,9 +339,35 @@ async fn try_authenticate(
                     res.success()
                 ),
             );
-            Ok(authentication_result_from_auth_result(&res))
+            let authentication_result = authentication_result_from_auth_result(&res);
+            if auth_type == "jumpserver-koko-mfa" {
+                let outcome = match authentication_result {
+                    AuthenticationResult::Authenticated => "password factor accepted; no follow-up challenge",
+                    AuthenticationResult::KeyboardInteractiveAvailable {
+                        mode: KeyboardInteractiveMode::AdditionalFactor,
+                    } => "password factor accepted with partial success; continuing with keyboard-interactive MFA",
+                    AuthenticationResult::KeyboardInteractiveAvailable {
+                        mode: KeyboardInteractiveMode::PasswordFallback,
+                    } => "password method did not complete authentication; server advertised keyboard-interactive fallback",
+                    AuthenticationResult::Rejected => "password method rejected; no keyboard-interactive continuation advertised",
+                };
+                interaction.log_interaction(
+                    app,
+                    if matches!(authentication_result, AuthenticationResult::Rejected) {
+                        "WARN"
+                    } else {
+                        "INFO"
+                    },
+                    "-",
+                    "authentication",
+                    "jumpserver-koko",
+                    0,
+                    outcome,
+                );
+            }
+            Ok(authentication_result)
         }
-        "privateKey" => {
+        ConfiguredAuthenticationMethod::PrivateKey => {
             let (key_content, passphrase) = if let Some(key_id) =
                 profile.get("privateKeyId").and_then(|value| value.as_str())
             {
@@ -348,12 +404,12 @@ async fn try_authenticate(
             .await?;
             Ok(authentication_result_from_auth_result(&result))
         }
-        "keyboard-interactive" | "jumpserver-koko-mfa" => {
+        ConfiguredAuthenticationMethod::KeyboardInteractive => {
             Ok(AuthenticationResult::KeyboardInteractiveAvailable {
                 mode: KeyboardInteractiveMode::PasswordFallback,
             })
         }
-        _ => {
+        ConfiguredAuthenticationMethod::System => {
             try_system_authenticate(handle, username, profile, app, interaction).await
         }
     }

--- a/apps/tauri/src-tauri/src/sessions/ssh/tests.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/tests.rs
@@ -2,7 +2,8 @@
 mod tests {
     use super::{
         authentication_result_from_auth_result, build_http_connect_request, build_legacy_preferred,
-        capture_root_access_password_input, coalesce_terminal_input, contains_interrupt_byte,
+        capture_root_access_password_input, coalesce_terminal_input, configured_authentication_method,
+        contains_interrupt_byte,
         decode_bytes, default_ssh_key_paths, detect_network_device_family,
         detect_remote_exec_input_kind, effective_exec_channel_enabled, effective_remote_file_type,
         effective_remote_forward_port, effective_resource_monitoring_enabled,
@@ -28,6 +29,7 @@ mod tests {
         try_keyboard_interactive_with_responder, tunnel_bind_address,
         validate_root_download_completion, validate_tunnel_rule,
         wait_for_ssh_handshake_with_timeouts, wait_for_ssh_stage, AuthenticationResult,
+        ConfiguredAuthenticationMethod,
         KeyboardInteractiveMode, KeyboardInteractiveRequest, ResolvedSshDeviceMode, RootFileAccessMethod,
         ShellSetupEchoSuppression, SshDeviceModeResolution, SshTunnelRule, TunnelCommand,
         SshInteractionContext, SshInteractionFlow, SshAuthenticationTarget,
@@ -2227,6 +2229,18 @@ mod tests {
             AuthenticationResult::KeyboardInteractiveAvailable {
                 mode: KeyboardInteractiveMode::PasswordFallback,
             }
+        );
+    }
+
+    #[test]
+    fn jumpserver_koko_mfa_starts_with_the_password_method() {
+        assert_eq!(
+            configured_authentication_method("jumpserver-koko-mfa"),
+            ConfiguredAuthenticationMethod::Password
+        );
+        assert_eq!(
+            configured_authentication_method("keyboard-interactive"),
+            ConfiguredAuthenticationMethod::KeyboardInteractive
         );
     }
 

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.2.8-beta.5",
+  "version": "2.2.8-beta.6",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/apps/tauri/src/renderer/app/theme-config.ts
+++ b/apps/tauri/src/renderer/app/theme-config.ts
@@ -138,7 +138,8 @@ function resolveCompactUiVariables(
   const totalSurface = alpha(total, isLight ? 10 : 14)
   const infoSurface = alpha(info, isLight ? 10 : 14)
   const successSurface = alpha(success, isLight ? 10 : 14)
-  const warningSurface = alpha(warning, isLight ? 10 : 14)
+  const warningSurface = alpha(warning, isLight ? 10 : 8)
+  const warningText = !isLight && warning.toLowerCase() === '#ffcc00' ? '#e7c65b' : warning
   const dangerSurface = alpha(danger, isLight ? 10 : 14)
 
   const sidebarGlassActive = !theme.opaqueWindows && sidebarGlassSupported()
@@ -203,7 +204,6 @@ function resolveCompactUiVariables(
     '--theme-surface-elevated': surfaceElevated,
     '--theme-text-primary': ink,
     '--theme-text-secondary': secondaryText,
-    '--theme-info': info,
     '--theme-semantic-total': total,
     '--theme-semantic-telnet': telnet,
     '--theme-semantic-sftp': telnet,
@@ -211,9 +211,33 @@ function resolveCompactUiVariables(
     '--theme-semantic-network-rx': networkRx,
     '--theme-semantic-network-tx': networkTx,
     '--theme-warning': warning,
+    '--theme-warning-surface': warningSurface,
+    '--theme-warning-text': warningText,
     '--theme-error': danger,
+    '--theme-error-surface': dangerSurface,
     '--theme-error-hover': dangerHover,
     '--theme-success': success,
+    '--theme-success-surface': successSurface,
+    '--theme-info': info,
+    '--theme-info-surface': infoSurface,
+    '--ref-status-warning': warning,
+    '--ref-status-warning-bg': warningSurface,
+    '--ref-status-warning-text': warningText,
+    '--ref-status-danger': danger,
+    '--ref-status-danger-bg': dangerSurface,
+    '--ref-status-success': success,
+    '--ref-status-success-bg': successSurface,
+    '--ref-status-info': info,
+    '--ref-status-info-bg': infoSurface,
+    '--status-warning': warning,
+    '--status-warning-bg': warningSurface,
+    '--status-warning-text': warningText,
+    '--status-danger': danger,
+    '--status-danger-bg': dangerSurface,
+    '--status-success': success,
+    '--status-success-bg': successSurface,
+    '--status-info': info,
+    '--status-info-bg': infoSurface,
     '--focus-outline': focus,
     '--border-focus': focus,
     '--accent-highlight': secondaryAccent,
@@ -233,6 +257,7 @@ function resolveCompactUiVariables(
     '--success-surface': successSurface,
     '--success-border': alpha(success, isLight ? 20 : 30),
     '--warning': warning,
+    '--warning-text': warningText,
     '--info': info,
     '--info-text': secondaryHover,
     '--info-surface': infoSurface,
@@ -524,6 +549,8 @@ function buildThemeVariables(
   const normalized = normalizeThemeConfig({ ...config, variant }, variant)
   const theme = normalized.theme
   const isDefaultTheme = isDefaultFileTermTheme(normalized, variant)
+  const isLight = variant === 'light'
+  const isCodex = normalized.baseThemeId === 'codex'
   const sidebarGlassActive = !theme.opaqueWindows && sidebarGlassSupported()
   const variables: Record<string, string> = {
     '--theme-accent': theme.accent,
@@ -540,9 +567,38 @@ function buildThemeVariables(
     '--theme-text-primary': theme.ink,
     '--theme-text-secondary': theme.semanticColors.textSecondary,
     '--theme-info': theme.semanticColors.info,
+    '--theme-info-surface': alpha(theme.semanticColors.info, isLight ? 10 : 12),
     '--theme-warning': theme.semanticColors.warning,
+    '--theme-warning-surface': alpha(theme.semanticColors.warning, isLight ? 10 : 8),
+    '--theme-warning-text':
+      !isLight && theme.semanticColors.warning.toLowerCase() === '#ffcc00' ? '#e7c65b' : theme.semanticColors.warning,
     '--theme-error': theme.semanticColors.error,
+    '--theme-error-surface': alpha(theme.semanticColors.error, isLight ? 10 : 12),
     '--theme-success': theme.semanticColors.success,
+    '--theme-success-surface': alpha(theme.semanticColors.success, isLight ? 10 : 12),
+    '--ref-status-warning': theme.semanticColors.warning,
+    '--ref-status-warning-bg': alpha(theme.semanticColors.warning, isLight ? 10 : 8),
+    '--ref-status-warning-text':
+      !isLight && theme.semanticColors.warning.toLowerCase() === '#ffcc00' ? '#e7c65b' : theme.semanticColors.warning,
+    '--ref-status-danger': theme.semanticColors.error,
+    '--ref-status-danger-bg': alpha(theme.semanticColors.error, isLight ? 10 : 12),
+    '--ref-status-success': theme.semanticColors.success,
+    '--ref-status-success-bg': alpha(theme.semanticColors.success, isLight ? 10 : 12),
+    '--ref-status-info': theme.semanticColors.info,
+    '--ref-status-info-bg': alpha(theme.semanticColors.info, isLight ? 10 : 12),
+    '--status-warning': theme.semanticColors.warning,
+    '--status-warning-bg': alpha(theme.semanticColors.warning, isLight ? 10 : 8),
+    '--status-warning-text':
+      !isLight && theme.semanticColors.warning.toLowerCase() === '#ffcc00' ? '#e7c65b' : theme.semanticColors.warning,
+    '--status-danger': theme.semanticColors.error,
+    '--status-danger-bg': alpha(theme.semanticColors.error, isLight ? 10 : 12),
+    '--status-success': theme.semanticColors.success,
+    '--status-success-bg': alpha(theme.semanticColors.success, isLight ? 10 : 12),
+    '--status-info': theme.semanticColors.info,
+    '--status-info-bg': alpha(theme.semanticColors.info, isLight ? 10 : 12),
+    '--warning': theme.semanticColors.warning,
+    '--warning-text':
+      !isLight && theme.semanticColors.warning.toLowerCase() === '#ffcc00' ? '#e7c65b' : theme.semanticColors.warning,
     '--theme-action-primary': theme.semanticColors.primaryAction ?? theme.accent,
     '--theme-action-danger': theme.semanticColors.dangerAction ?? (variant === 'light' ? '#d32f2f' : '#c93b3b'),
     '--theme-sidebar-backdrop-filter': sidebarGlassActive ? 'blur(18px)' : 'none',
@@ -575,7 +631,28 @@ function buildThemeVariables(
     '--terminal-text': theme.terminal.foreground,
     '--terminal-selection-bg': theme.terminal.selectionBackground,
     '--terminal-search-match-bg': theme.terminal.search.matchBackground,
-    '--terminal-search-active-bg': theme.terminal.search.activeMatchBackground
+    '--terminal-search-active-bg': theme.terminal.search.activeMatchBackground,
+    // Monaco editor concrete tokens for all themes
+    '--ref-monaco-editor-bg': isLight ? '#ffffff' : isCodex ? '#111111' : theme.terminal.background,
+    '--ref-monaco-editor-foreground': isLight ? '#1a1c1f' : isCodex ? '#fcfcfc' : theme.terminal.foreground,
+    '--ref-monaco-line-number': isLight ? '#8e9197' : isCodex ? '#7a7a7a' : '#5f6875',
+    '--ref-monaco-line-number-active': isLight ? '#64676c' : isCodex ? '#a6a6a6' : '#9faab8',
+    '--ref-monaco-cursor': isLight ? '#339cff' : isCodex ? '#0169cc' : '#7cc7ff',
+    '--ref-monaco-selection': isLight ? '#e6f3ff' : isCodex ? '#172a3a' : '#21466b',
+    '--ref-monaco-inactive-selection': isLight ? '#f0f7ff' : isCodex ? '#13202c' : '#1a354d',
+    '--ref-monaco-line-highlight': isLight ? '#f5f5f5' : isCodex ? '#171717' : '#161b22',
+    '--ref-monaco-indent-guide': isLight ? '#e0e0e0' : isCodex ? '#242424' : '#1f2630',
+    '--ref-monaco-indent-guide-active': isLight ? '#c0c0c0' : isCodex ? '#383838' : '#344150',
+    '--monaco-editor-bg': isLight ? '#ffffff' : isCodex ? '#111111' : theme.terminal.background,
+    '--monaco-editor-foreground': isLight ? '#1a1c1f' : isCodex ? '#fcfcfc' : theme.terminal.foreground,
+    '--monaco-line-number': isLight ? '#8e9197' : isCodex ? '#7a7a7a' : '#5f6875',
+    '--monaco-line-number-active': isLight ? '#64676c' : isCodex ? '#a6a6a6' : '#9faab8',
+    '--monaco-cursor': isLight ? '#339cff' : isCodex ? '#0169cc' : '#7cc7ff',
+    '--monaco-selection': isLight ? '#e6f3ff' : isCodex ? '#172a3a' : '#21466b',
+    '--monaco-inactive-selection': isLight ? '#f0f7ff' : isCodex ? '#13202c' : '#1a354d',
+    '--monaco-line-highlight': isLight ? '#f5f5f5' : isCodex ? '#171717' : '#161b22',
+    '--monaco-indent-guide': isLight ? '#e0e0e0' : isCodex ? '#242424' : '#1f2630',
+    '--monaco-indent-guide-active': isLight ? '#c0c0c0' : isCodex ? '#383838' : '#344150'
   }
 
   // Built-in Codex has the same compact token contract as custom themes, but

--- a/apps/tauri/src/renderer/features/files/file-editor-modal.tsx
+++ b/apps/tauri/src/renderer/features/files/file-editor-modal.tsx
@@ -27,13 +27,61 @@ type EditorInstance = Parameters<OnMount>[0]
 type EditorMenu = 'file' | 'edit' | 'search' | 'preferences' | 'encoding' | 'language'
 const MONACO_DARK_THEME = 'fileterm-default-dark'
 
-function readCssVariable(name: string, fallbackName?: string) {
-  const styles = window.getComputedStyle(document.documentElement)
-  const value = styles.getPropertyValue(name).trim()
-  if (value) {
-    return value
+function resolveCssColorToHex(cssValue: string): string | null {
+  const trimmed = cssValue.trim()
+  if (!trimmed) return null
+  if (/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(trimmed)) {
+    return trimmed
   }
-  return fallbackName ? styles.getPropertyValue(fallbackName).trim() : ''
+  const varMatch = trimmed.match(/^var\(\s*(--[a-zA-Z0-9_-]+)/)
+  if (varMatch) {
+    const resolved = window.getComputedStyle(document.documentElement).getPropertyValue(varMatch[1]).trim()
+    if (resolved) {
+      const hex = resolveCssColorToHex(resolved)
+      if (hex) return hex
+    }
+  }
+  if (typeof document !== 'undefined') {
+    const probe = document.createElement('div')
+    probe.style.color = trimmed
+    probe.style.display = 'none'
+    document.documentElement.appendChild(probe)
+    const computedColor = window.getComputedStyle(probe).color
+    probe.remove()
+    const rgbMatch = computedColor.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*([\d.]+))?\s*\)$/)
+    if (rgbMatch) {
+      const r = Math.min(255, Math.max(0, parseInt(rgbMatch[1], 10)))
+        .toString(16)
+        .padStart(2, '0')
+      const g = Math.min(255, Math.max(0, parseInt(rgbMatch[2], 10)))
+        .toString(16)
+        .padStart(2, '0')
+      const b = Math.min(255, Math.max(0, parseInt(rgbMatch[3], 10)))
+        .toString(16)
+        .padStart(2, '0')
+      if (rgbMatch[4] !== undefined) {
+        const a = Math.min(255, Math.max(0, Math.round(parseFloat(rgbMatch[4]) * 255)))
+          .toString(16)
+          .padStart(2, '0')
+        return `#${r}${g}${b}${a}`
+      }
+      return `#${r}${g}${b}`
+    }
+  }
+  return null
+}
+
+function readMonacoColor(varName: string, fallbackVarName: string, defaultHex: string): string {
+  const styles = window.getComputedStyle(document.documentElement)
+  const val = styles.getPropertyValue(varName)
+  const resolved = resolveCssColorToHex(val)
+  if (resolved) return resolved
+
+  const fallbackVal = styles.getPropertyValue(fallbackVarName)
+  const fallbackResolved = resolveCssColorToHex(fallbackVal)
+  if (fallbackResolved) return fallbackResolved
+
+  return defaultHex
 }
 
 function defineFileTermMonacoTheme(monaco: Monaco) {
@@ -42,16 +90,16 @@ function defineFileTermMonacoTheme(monaco: Monaco) {
     inherit: true,
     rules: [],
     colors: {
-      'editor.background': readCssVariable('--monaco-editor-bg', '--terminal-bg'),
-      'editor.foreground': readCssVariable('--monaco-editor-foreground', '--terminal-text'),
-      'editorLineNumber.foreground': readCssVariable('--monaco-line-number', '--text-soft'),
-      'editorLineNumber.activeForeground': readCssVariable('--monaco-line-number-active', '--text-muted'),
-      'editorCursor.foreground': readCssVariable('--monaco-cursor', '--accent-highlight'),
-      'editor.selectionBackground': readCssVariable('--monaco-selection', '--selection-bg'),
-      'editor.inactiveSelectionBackground': readCssVariable('--monaco-inactive-selection', '--selection-bg'),
-      'editor.lineHighlightBackground': readCssVariable('--monaco-line-highlight', '--surface-inset'),
-      'editorIndentGuide.background1': readCssVariable('--monaco-indent-guide', '--border-light'),
-      'editorIndentGuide.activeBackground1': readCssVariable('--monaco-indent-guide-active', '--border-dark')
+      'editor.background': readMonacoColor('--monaco-editor-bg', '--terminal-bg', '#111316'),
+      'editor.foreground': readMonacoColor('--monaco-editor-foreground', '--terminal-text', '#d6dde7'),
+      'editorLineNumber.foreground': readMonacoColor('--monaco-line-number', '--text-soft', '#5f6875'),
+      'editorLineNumber.activeForeground': readMonacoColor('--monaco-line-number-active', '--text-muted', '#9faab8'),
+      'editorCursor.foreground': readMonacoColor('--monaco-cursor', '--accent-highlight', '#7cc7ff'),
+      'editor.selectionBackground': readMonacoColor('--monaco-selection', '--selection-bg', '#21466b'),
+      'editor.inactiveSelectionBackground': readMonacoColor('--monaco-inactive-selection', '--selection-bg', '#1a354d'),
+      'editor.lineHighlightBackground': readMonacoColor('--monaco-line-highlight', '--surface-inset', '#161b22'),
+      'editorIndentGuide.background1': readMonacoColor('--monaco-indent-guide', '--border-light', '#1f2630'),
+      'editorIndentGuide.activeBackground1': readMonacoColor('--monaco-indent-guide-active', '--border-dark', '#344150')
     }
   })
 }

--- a/apps/tauri/src/renderer/features/layout/app-main-workspace.tsx
+++ b/apps/tauri/src/renderer/features/layout/app-main-workspace.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, MouseEvent } from 'react'
+import { useEffect, useState, type CSSProperties, type MouseEvent } from 'react'
 import { AiCopilotPanel } from '../ai/ai-copilot-panel'
 import { CloseButton } from '../common/close-button'
 import { SystemSidebarShell } from '../system/system-sidebar-shell'
@@ -7,9 +7,13 @@ import { KeepAliveWorkspaceStage } from '../workspace/workspace-stage'
 import { TabBar, type TabBarProps, type TabContextTarget } from './tab-bar'
 import type { AppViewModel } from './app-view-model'
 import { WindowMenubar } from './window-menubar'
+import { STATUS_MESSAGE_TIMEOUT_MS } from '../../app/app-shell-utils'
 import { t, setLocale } from '../../i18n'
 
 export function AppMainWorkspace({ model }: { model: AppViewModel }) {
+  const [dismissedInteractiveGatewayNoticeTabId, setDismissedInteractiveGatewayNoticeTabId] = useState<string | null>(
+    null
+  )
   const { shell, workspace: workspaceState, data, resize, usesCustomWindowChrome } = model
   const {
     workspace,
@@ -154,7 +158,30 @@ export function AppMainWorkspace({ model }: { model: AppViewModel }) {
 
   const isInteractiveGatewayRoutePending =
     activeSession?.resourceMonitoringUnavailableReason === 'interactive-gateway-target-route-required'
-  const hasStatusMessage = Boolean(error || isInteractiveGatewayRoutePending)
+  const interactiveGatewayNoticeTabId = isInteractiveGatewayRoutePending ? (activeTab?.id ?? null) : null
+  const isInteractiveGatewayNoticeVisible =
+    interactiveGatewayNoticeTabId !== null && dismissedInteractiveGatewayNoticeTabId !== interactiveGatewayNoticeTabId
+
+  useEffect(() => {
+    if (!interactiveGatewayNoticeTabId || !isInteractiveGatewayNoticeVisible) {
+      return
+    }
+    const timeoutId = window.setTimeout(() => {
+      setDismissedInteractiveGatewayNoticeTabId((current) =>
+        current === interactiveGatewayNoticeTabId ? current : interactiveGatewayNoticeTabId
+      )
+    }, STATUS_MESSAGE_TIMEOUT_MS)
+    return () => window.clearTimeout(timeoutId)
+  }, [interactiveGatewayNoticeTabId, isInteractiveGatewayNoticeVisible])
+
+  useEffect(() => {
+    if (interactiveGatewayNoticeTabId || !activeTab?.id) {
+      return
+    }
+    setDismissedInteractiveGatewayNoticeTabId((current) => (current === activeTab.id ? null : current))
+  }, [activeTab?.id, interactiveGatewayNoticeTabId])
+
+  const hasStatusMessage = Boolean(error || isInteractiveGatewayNoticeVisible)
   const resolvedSidebarWidth = isSystemSidebarCollapsed ? 44 : sidebarWidth
   const activeJumpHost =
     activeProfile?.type === 'ssh' && activeProfile.jumpProfileId
@@ -248,14 +275,29 @@ export function AppMainWorkspace({ model }: { model: AppViewModel }) {
           {error ? (
             <div className="status-message" role="alert">
               <span className="status-message-text">{error}</span>
-              <CloseButton aria-label={t.closeTab} onClick={() => setError(null)} size="compact" />
+              <CloseButton
+                className="status-message-close"
+                aria-label={t.closeTab}
+                onClick={() => setError(null)}
+                size="compact"
+              />
             </div>
-          ) : isInteractiveGatewayRoutePending ? (
+          ) : isInteractiveGatewayNoticeVisible ? (
             <div className="status-message" role="status" aria-live="polite">
               <span className="status-message-text">
                 <strong>{t.interactiveGatewayResourceMonitoringTitle}</strong>{' '}
                 {t.interactiveGatewayResourceMonitoringDescription}
               </span>
+              <CloseButton
+                className="status-message-close"
+                aria-label={t.closeTab}
+                size="compact"
+                onClick={() => {
+                  if (interactiveGatewayNoticeTabId) {
+                    setDismissedInteractiveGatewayNoticeTabId(interactiveGatewayNoticeTabId)
+                  }
+                }}
+              />
             </div>
           ) : null}
           <div className={`workspace-stage ${shouldShowAiCopilot ? 'has-ai-copilot' : ''}`}>

--- a/apps/tauri/src/renderer/styles/features/component-skins/shell-skin.css
+++ b/apps/tauri/src/renderer/styles/features/component-skins/shell-skin.css
@@ -513,8 +513,8 @@
 :root:not([data-theme]) .status-message,
 :root:not([data-theme*='light']) .status-message,
 :root[data-theme='default'] .status-message {
-  color: var(--warning);
-  background: color-mix(in srgb, var(--status-warning) 10%, transparent);
+  color: var(--status-warning-text, var(--warning));
+  background: var(--status-warning-bg, color-mix(in srgb, var(--status-warning) 8%, transparent));
 }
 
 :root:not([data-theme]) .status-message-close:hover,

--- a/apps/tauri/src/renderer/styles/features/component-skins/workstation-dark-skin.css
+++ b/apps/tauri/src/renderer/styles/features/component-skins/workstation-dark-skin.css
@@ -156,9 +156,9 @@
 :root:not([data-theme]) .status-message,
 :root:not([data-theme*='light']) .status-message,
 :root[data-theme='default'] .status-message {
-  border-bottom-color: color-mix(in srgb, var(--status-warning) 28%, var(--surface-canvas));
-  background: color-mix(in srgb, var(--status-warning) 8%, transparent);
-  color: var(--status-warning);
+  border-bottom-color: color-mix(in srgb, var(--status-warning) 14%, var(--surface-canvas));
+  background: var(--status-warning-bg, color-mix(in srgb, var(--status-warning) 8%, transparent));
+  color: var(--status-warning-text, var(--status-warning));
 }
 
 :root:not([data-theme]) .workspace-stage,

--- a/apps/tauri/src/renderer/styles/tokens/codex-dark.css
+++ b/apps/tauri/src/renderer/styles/tokens/codex-dark.css
@@ -55,6 +55,7 @@
   --ref-status-success: #00a240;
   --ref-status-success-bg: rgba(0, 162, 64, 0.12);
   --ref-status-warning: #f59e0b;
+  --ref-status-warning-text: #f59e0b;
   --ref-status-warning-bg: rgba(245, 158, 11, 0.12);
   --ref-status-danger: #ff5f57;
   --ref-status-danger-hover: #e04b44;
@@ -94,6 +95,18 @@
   --ref-window-control-danger-bg: #c42b1c;
   --ref-window-control-danger-text: #ffffff;
   --ref-file-editor-primary-shadow: 0 2px 10px rgba(1, 105, 204, 0.26);
+
+  /* Monaco Editor */
+  --ref-monaco-editor-bg: #111111;
+  --ref-monaco-editor-foreground: #fcfcfc;
+  --ref-monaco-line-number: #7a7a7a;
+  --ref-monaco-line-number-active: #a6a6a6;
+  --ref-monaco-cursor: #0169cc;
+  --ref-monaco-selection: #172a3a;
+  --ref-monaco-inactive-selection: #13202c;
+  --ref-monaco-line-highlight: #171717;
+  --ref-monaco-indent-guide: #242424;
+  --ref-monaco-indent-guide-active: #383838;
   --ref-terminal-frame-gradient: none;
   --ref-terminal-frame-shadow: none;
 

--- a/apps/tauri/src/renderer/styles/tokens/codex-light.css
+++ b/apps/tauri/src/renderer/styles/tokens/codex-light.css
@@ -54,6 +54,7 @@
   --ref-status-success: #00a240;
   --ref-status-success-bg: rgba(0, 162, 64, 0.1);
   --ref-status-warning: #d97706;
+  --ref-status-warning-text: #d97706;
   --ref-status-warning-bg: rgba(217, 119, 6, 0.1);
   --ref-status-danger: #d94e4e;
   --ref-status-danger-hover: #be3f3f;
@@ -93,6 +94,18 @@
   --ref-window-control-danger-bg: #c42b1c;
   --ref-window-control-danger-text: #ffffff;
   --ref-file-editor-primary-shadow: 0 2px 10px rgba(51, 156, 255, 0.26);
+
+  /* Monaco Editor */
+  --ref-monaco-editor-bg: #ffffff;
+  --ref-monaco-editor-foreground: #1a1c1f;
+  --ref-monaco-line-number: #8e9197;
+  --ref-monaco-line-number-active: #64676c;
+  --ref-monaco-cursor: #339cff;
+  --ref-monaco-selection: #e6f3ff;
+  --ref-monaco-inactive-selection: #f0f7ff;
+  --ref-monaco-line-highlight: #f5f5f5;
+  --ref-monaco-indent-guide: #e0e0e0;
+  --ref-monaco-indent-guide-active: #c0c0c0;
   --ref-terminal-frame-gradient: none;
   --ref-terminal-frame-shadow: none;
 

--- a/apps/tauri/src/renderer/styles/tokens/fileterm-dark.css
+++ b/apps/tauri/src/renderer/styles/tokens/fileterm-dark.css
@@ -56,8 +56,9 @@
   /* Status Colors */
   --ref-status-success: #34d399;
   --ref-status-success-bg: rgba(52, 211, 153, 0.12);
-  --ref-status-warning: #f59e0b;
-  --ref-status-warning-bg: rgba(245, 158, 11, 0.12);
+  --ref-status-warning: #ffcc00;
+  --ref-status-warning-text: #e7c65b;
+  --ref-status-warning-bg: rgba(255, 204, 0, 0.08);
   --ref-status-danger: #ff5f57;
   --ref-status-danger-hover: #e04b44;
   --ref-status-danger-bg: rgba(255, 95, 87, 0.12);
@@ -96,6 +97,18 @@
   --ref-window-control-danger-bg: #c42b1c;
   --ref-window-control-danger-text: #ffffff;
   --ref-file-editor-primary-shadow: 0 2px 10px rgba(22, 135, 232, 0.26);
+
+  /* Monaco Editor */
+  --ref-monaco-editor-bg: #111316;
+  --ref-monaco-editor-foreground: #d6dde7;
+  --ref-monaco-line-number: #5f6875;
+  --ref-monaco-line-number-active: #9faab8;
+  --ref-monaco-cursor: #7cc7ff;
+  --ref-monaco-selection: #21466b;
+  --ref-monaco-inactive-selection: #1a354d;
+  --ref-monaco-line-highlight: #161b22;
+  --ref-monaco-indent-guide: #1f2630;
+  --ref-monaco-indent-guide-active: #344150;
   --ref-terminal-frame-gradient:
     linear-gradient(to bottom, rgba(18, 18, 18, 1) 0px, rgba(18, 18, 18, 0) 10px),
     linear-gradient(to top, rgba(18, 18, 18, 1) 0px, rgba(18, 18, 18, 0) 10px),

--- a/apps/tauri/src/renderer/styles/tokens/fileterm-light.css
+++ b/apps/tauri/src/renderer/styles/tokens/fileterm-light.css
@@ -55,6 +55,7 @@
   --ref-status-success: #168a53;
   --ref-status-success-bg: rgba(22, 138, 83, 0.1);
   --ref-status-warning: #d97706;
+  --ref-status-warning-text: #d97706;
   --ref-status-warning-bg: rgba(217, 119, 6, 0.1);
   --ref-status-danger: #d94e4e;
   --ref-status-danger-hover: #be3f3f;
@@ -94,6 +95,18 @@
   --ref-window-control-danger-bg: #c42b1c;
   --ref-window-control-danger-text: #ffffff;
   --ref-file-editor-primary-shadow: 0 2px 10px rgba(59, 130, 246, 0.26);
+
+  /* Monaco Editor */
+  --ref-monaco-editor-bg: #ffffff;
+  --ref-monaco-editor-foreground: #1a1c1f;
+  --ref-monaco-line-number: #8e9197;
+  --ref-monaco-line-number-active: #64676c;
+  --ref-monaco-cursor: #339cff;
+  --ref-monaco-selection: #e6f3ff;
+  --ref-monaco-inactive-selection: #f0f7ff;
+  --ref-monaco-line-highlight: #f5f5f5;
+  --ref-monaco-indent-guide: #e0e0e0;
+  --ref-monaco-indent-guide-active: #c0c0c0;
   --ref-terminal-frame-gradient: none;
   --ref-terminal-frame-shadow: none;
 

--- a/apps/tauri/src/renderer/styles/tokens/semantic.css
+++ b/apps/tauri/src/renderer/styles/tokens/semantic.css
@@ -81,17 +81,18 @@
   --action-danger-text: var(--ref-action-danger-text, var(--ref-text-inverse));
 
   /* Status Semantics */
-  --status-success: var(--ref-status-success);
-  --status-success-bg: var(--ref-status-success-bg);
-  --status-warning: var(--ref-status-warning);
-  --status-warning-bg: var(--ref-status-warning-bg);
-  --status-danger: var(--ref-status-danger);
-  --status-danger-bg: var(--ref-status-danger-bg);
-  --status-info: var(--ref-status-info);
-  --status-info-bg: var(--ref-status-info-bg);
+  --status-success: var(--theme-success, var(--ref-status-success));
+  --status-success-bg: var(--theme-success-surface, var(--ref-status-success-bg));
+  --status-warning: var(--theme-warning, var(--ref-status-warning));
+  --status-warning-bg: var(--theme-warning-surface, var(--ref-status-warning-bg));
+  --status-warning-text: var(--theme-warning-text, var(--ref-status-warning-text, var(--status-warning)));
+  --status-danger: var(--theme-error, var(--ref-status-danger));
+  --status-danger-bg: var(--theme-error-surface, var(--ref-status-danger-bg));
+  --status-info: var(--theme-info, var(--ref-status-info));
+  --status-info-bg: var(--theme-info-surface, var(--ref-status-info-bg));
   --status-error: var(--status-danger);
   --danger-color: var(--status-danger);
-  --warning-text: var(--status-warning);
+  --warning-text: var(--status-warning-text, var(--status-warning));
 
   /* Focus and Glow Rings */
   --accent-focus-ring: var(--ref-accent-focus);
@@ -151,19 +152,19 @@
   --copy-link-hover: var(--ref-accent-secondary);
 
   /* Status Colors */
-  --success: var(--ref-status-success);
-  --success-text: var(--ref-status-success);
-  --success-surface: var(--ref-status-success-bg);
-  --success-border: var(--ref-status-success);
-  --danger: var(--ref-status-danger);
-  --danger-text: var(--ref-status-danger);
-  --danger-surface: var(--ref-status-danger-bg);
-  --danger-border: var(--ref-status-danger);
-  --warning: var(--ref-status-warning);
-  --info: var(--ref-status-info);
-  --info-text: var(--ref-status-info);
-  --info-surface: var(--ref-status-info-bg);
-  --info-border: var(--ref-status-info);
+  --success: var(--status-success);
+  --success-text: var(--status-success);
+  --success-surface: var(--status-success-bg);
+  --success-border: var(--status-success);
+  --danger: var(--status-danger);
+  --danger-text: var(--status-danger);
+  --danger-surface: var(--status-danger-bg);
+  --danger-border: var(--status-danger);
+  --warning: var(--status-warning);
+  --info: var(--status-info);
+  --info-text: var(--status-info);
+  --info-surface: var(--status-info-bg);
+  --info-border: var(--status-info);
 
   /* Dialogs */
   --dialog-border: var(--border-subtle);
@@ -252,6 +253,18 @@
   --brand-title-shadow: none;
   --file-editor-button-bg: var(--surface-hover);
   --file-editor-primary-shadow: var(--ref-file-editor-primary-shadow);
+
+  /* Monaco Editor */
+  --monaco-editor-bg: var(--ref-monaco-editor-bg);
+  --monaco-editor-foreground: var(--ref-monaco-editor-foreground);
+  --monaco-line-number: var(--ref-monaco-line-number);
+  --monaco-line-number-active: var(--ref-monaco-line-number-active);
+  --monaco-cursor: var(--ref-monaco-cursor);
+  --monaco-selection: var(--ref-monaco-selection);
+  --monaco-inactive-selection: var(--ref-monaco-inactive-selection);
+  --monaco-line-highlight: var(--ref-monaco-line-highlight);
+  --monaco-indent-guide: var(--ref-monaco-indent-guide);
+  --monaco-indent-guide-active: var(--ref-monaco-indent-guide-active);
 
   /* Floating Drawer & Tabs */
   --floating-drawer-expanded-bg: var(--surface-modal);

--- a/docs/release-notes/release-notes-2.2.8-beta.6.md
+++ b/docs/release-notes/release-notes-2.2.8-beta.6.md
@@ -1,0 +1,45 @@
+## FileTerm 2.2.8-beta.6
+
+FileTerm 2.2.8-beta.6 修复 JumpServer/KoKo MFA 认证顺序，并优化交互式资产菜单的提示体验。
+
+### 2.2.8-beta.6 更新重点
+
+- **KoKo MFA 认证**：先提交堡垒机密码，服务端返回部分认证成功后，再在同一 SSH 连接上继续 keyboard-interactive MFA，避免直接启动 MFA 导致认证失败。
+- **诊断日志**：补充密码认证、部分成功和 MFA 继续阶段的日志，不记录密码、OTP 或交互答案。
+- **菜单提示**：交互式资产菜单提示与其他状态提示保持 15 秒自动消失，并支持公共关闭按钮；菜单模式仍不会虚构后台监控和 SFTP 的目标资产。
+
+### 本版本包含的主要 PR 和问题修复
+
+- KoKo MFA 认证顺序修复、交互式资产菜单提示自动关闭和公共关闭按钮优化。
+
+完整变更记录请查看 [v2.2.8-beta.5 与 v2.2.8-beta.6 的比较](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.5...v2.2.8-beta.6)。
+
+### 反馈与支持
+
+遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
+
+也可以打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81) 加入社区。
+
+---
+
+## FileTerm 2.2.8-beta.6
+
+FileTerm 2.2.8-beta.6 fixes the JumpServer/KoKo MFA authentication order and improves interactive asset-menu feedback.
+
+### Highlights
+
+- **KoKo MFA authentication**: Submit the bastion password first, then continue keyboard-interactive MFA on the same SSH connection after the server reports partial success, avoiding authentication failures caused by starting MFA directly.
+- **Diagnostics**: Add password-authentication, partial-success, and MFA-continuation logs without recording passwords, OTPs, or interactive answers.
+- **Menu feedback**: Interactive asset-menu notices now share the 15-second auto-dismiss behavior of other status notices and use the shared close button. Menu mode still does not invent a target for background monitoring or SFTP.
+
+### Main PRs and issues
+
+- KoKo MFA authentication order fix, interactive asset-menu notice auto-dismiss, and shared close-button improvements.
+
+See the [comparison between v2.2.8-beta.5 and v2.2.8-beta.6](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.5...v2.2.8-beta.6) for the complete change set.
+
+### Feedback & Support
+
+For problems, open a [GitHub Issue](https://github.com/St0ff3l/fileterm/issues) with the operating system, FileTerm version, connection type, reproduction steps, and redacted logs. Do not submit passwords, private keys, or tokens.
+
+Join the community through the [README community section](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81).

--- a/docs/release-notes/release-notes-2.2.8-beta.6.md
+++ b/docs/release-notes/release-notes-2.2.8-beta.6.md
@@ -10,7 +10,7 @@ FileTerm 2.2.8-beta.6 修复 JumpServer/KoKo MFA 认证顺序，并优化交互�
 
 ### 本版本包含的主要 PR 和问题修复
 
-- KoKo MFA 认证顺序修复、交互式资产菜单提示自动关闭和公共关闭按钮优化。
+- [PR #238](https://github.com/St0ff3l/fileterm/pull/238)：KoKo MFA 认证顺序修复、交互式资产菜单提示自动关闭和公共关闭按钮优化。
 
 完整变更记录请查看 [v2.2.8-beta.5 与 v2.2.8-beta.6 的比较](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.5...v2.2.8-beta.6)。
 
@@ -34,7 +34,7 @@ FileTerm 2.2.8-beta.6 fixes the JumpServer/KoKo MFA authentication order and imp
 
 ### Main PRs and issues
 
-- KoKo MFA authentication order fix, interactive asset-menu notice auto-dismiss, and shared close-button improvements.
+- [PR #238](https://github.com/St0ff3l/fileterm/pull/238): KoKo MFA authentication order fix, interactive asset-menu notice auto-dismiss, and shared close-button improvements.
 
 See the [comparison between v2.2.8-beta.5 and v2.2.8-beta.6](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.5...v2.2.8-beta.6) for the complete change set.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.5",
+  "version": "2.2.8-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.2.8-beta.5",
+      "version": "2.2.8-beta.6",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,10 +33,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.2.8-beta.5",
+      "version": "2.2.8-beta.6",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.5",
-        "@fileterm/shared": "2.2.8-beta.5",
+        "@fileterm/core": "2.2.8-beta.6",
+        "@fileterm/shared": "2.2.8-beta.6",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -5501,17 +5501,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.2.8-beta.5"
+      "version": "2.2.8-beta.6"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.2.8-beta.5"
+      "version": "2.2.8-beta.6"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.2.8-beta.5",
+      "version": "2.2.8-beta.6",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.5"
+        "@fileterm/core": "2.2.8-beta.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.5",
+  "version": "2.2.8-beta.6",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.2.8-beta.5",
+  "version": "2.2.8-beta.6",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1720,7 +1720,7 @@ export function createDefaultThemeConfig(variant: ThemeVariant = 'dark'): ThemeC
         secondary: isLight ? '#3b82f6' : '#8bbfff',
         textSecondary: isLight ? '#5e5e61' : '#9b9b9b',
         info: isLight ? '#3b82f6' : '#38bdf8',
-        warning: isLight ? '#d97706' : '#f59e0b',
+        warning: isLight ? '#d97706' : '#ffcc00',
         error: isLight ? '#d94e4e' : '#ff5f57',
         success: isLight ? '#168a53' : '#34d399',
         primaryAction: isLight ? '#3b82f6' : '#1687e8',

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.2.8-beta.5",
+  "version": "2.2.8-beta.6",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.2.8-beta.5",
+  "version": "2.2.8-beta.6",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.5"
+    "@fileterm/core": "2.2.8-beta.6"
   }
 }


### PR DESCRIPTION
## Summary

- 修复 JumpServer/KoKo MFA 的密码优先认证顺序，并在同一 SSH 连接继续 keyboard-interactive。
- 优化交互式资产菜单提示：15 秒自动关闭，复用公共 SVG 关闭按钮。
- 合入当前工作区的主题、编辑器和 core 改动，并准备 2.2.8-beta.6 版本号与发布说明。

## Validation

- npm run lint
- npm run typecheck -w @fileterm/tauri
- Prettier check
- CSS contract check
- cargo test --locked -- --test-threads=1
- cargo clippy --locked --all-targets --all-features -- -D warnings

发布 beta6 前请先合并此 PR。