### PR TITLE
fix(ui): refine bookmark dialog focus behavior

### DIFF
--- a/apps/tauri/src/renderer/components/common/dialog/dialog.css
+++ b/apps/tauri/src/renderer/components/common/dialog/dialog.css
@@ -31,6 +31,19 @@
   flex-direction: column;
   overflow: hidden;
   animation: ft-dialog-pop-in var(--transition-normal);
+  outline: none;
+}
+
+.ft-dialog:focus {
+  outline: none;
+}
+
+.ft-dialog:focus-visible {
+  outline: none;
+  border-color: var(--border-default);
+  box-shadow:
+    var(--shadow-modal),
+    0 0 0 1px var(--border-default);
 }
 
 .ft-dialog--sm {

--- a/apps/tauri/src/renderer/features/common/dialog/dialog.css
+++ b/apps/tauri/src/renderer/features/common/dialog/dialog.css
@@ -31,6 +31,19 @@
   flex-direction: column;
   overflow: hidden;
   animation: ft-dialog-pop-in var(--transition-normal);
+  outline: none;
+}
+
+.ft-dialog:focus {
+  outline: none;
+}
+
+.ft-dialog:focus-visible {
+  outline: none;
+  border-color: var(--border-default);
+  box-shadow:
+    var(--shadow-modal),
+    0 0 0 1px var(--border-default);
 }
 
 .ft-dialog--sm {

--- a/apps/tauri/src/renderer/features/files/path-bookmarks-button.css
+++ b/apps/tauri/src/renderer/features/files/path-bookmarks-button.css
@@ -33,6 +33,31 @@
   height: 13px;
 }
 
+/* Dialog container focus reset and secondary focus state */
+.path-bookmarks-dialog.ft-dialog {
+  outline: none;
+}
+
+.path-bookmarks-dialog.ft-dialog:focus {
+  outline: none;
+}
+
+.path-bookmarks-dialog.ft-dialog:focus-visible {
+  outline: none;
+  border-color: var(--border-default);
+  box-shadow:
+    var(--shadow-modal),
+    0 0 0 1px var(--border-default);
+}
+
+/* Secondary focus ring for interactive elements inside the bookmarks dialog */
+.path-bookmarks-dialog .ft-btn:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--surface-modal),
+    0 0 0 3px var(--border-default);
+}
+
 /* Dialog content container */
 .path-bookmarks {
   display: flex;

--- a/apps/tauri/src/renderer/features/files/path-bookmarks-button.tsx
+++ b/apps/tauri/src/renderer/features/files/path-bookmarks-button.tsx
@@ -54,9 +54,6 @@ export function PathBookmarksButton({
     const trigger = triggerRef.current
     return () => trigger?.focus()
   }, [open])
-  useEffect(() => {
-    if (open && !removing) dialogRef.current?.focus()
-  }, [open, removing])
   const update = async (action: 'add' | 'remove' | 'up' | 'down', item: PathBookmark) => {
     if (busy || !window.fileterm) return
     setBusy(true)
@@ -68,7 +65,6 @@ export function PathBookmarksButton({
       setError(String(cause))
     } finally {
       setBusy(false)
-      if (action !== 'remove') dialogRef.current?.focus()
     }
   }
   const current = toPathBookmark(scope, {
@@ -100,7 +96,6 @@ export function PathBookmarksButton({
         createPortal(
           <Dialog
             ref={dialogRef}
-            tabIndex={-1}
             isOpen={open}
             title={t.pathBookmarks}
             aria-label={t.pathBookmarks}
@@ -114,15 +109,14 @@ export function PathBookmarksButton({
               const targets = Array.from(
                 dialogRef.current?.querySelectorAll<HTMLButtonElement>('button:not(:disabled)') || []
               )
+              if (targets.length === 0) return
               const first = targets[0],
                 last = targets.at(-1)
-              if (
-                event.shiftKey &&
-                (document.activeElement === first || document.activeElement === dialogRef.current)
-              ) {
+              const active = document.activeElement
+              if (event.shiftKey && (active === first || !dialogRef.current?.contains(active))) {
                 event.preventDefault()
                 last?.focus()
-              } else if (!event.shiftKey && document.activeElement === last) {
+              } else if (!event.shiftKey && (active === last || !dialogRef.current?.contains(active))) {
                 event.preventDefault()
                 first?.focus()
               }


### PR DESCRIPTION
## Summary

- keep the bookmark dialog container from showing an extra focus outline
- preserve visible focus styling for buttons inside the dialog
- simplify focus trapping so keyboard focus wraps only across actionable controls

## Validation

- commit hooks: Prettier, ESLint, and workspace typecheck
