### PR TITLE
chore(release): prepare FileTerm 2.2.8-beta.9

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.2.8-beta.8",
+  "version": "2.2.8-beta.9",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -26,8 +26,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.8",
-    "@fileterm/shared": "2.2.8-beta.8",
+    "@fileterm/core": "2.2.8-beta.9",
+    "@fileterm/shared": "2.2.8-beta.9",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.2.8-beta.8"
+version = "2.2.8-beta.9"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.2.8-beta.8"
+version = "2.2.8-beta.9"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
+++ b/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
@@ -58,7 +58,7 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-    <release version="2.2.8-beta.8" date="2026-09-09">
+    <release version="2.2.8-beta.9" date="2026-09-09">
       <description>
         <p>Official release with multi-tab remote terminal and file management workspace.</p>
       </description>

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.2.8-beta.8",
+  "version": "2.2.8-beta.9",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/docs/release-notes/release-notes-2.2.8-beta.9.md
+++ b/docs/release-notes/release-notes-2.2.8-beta.9.md
@@ -1,0 +1,45 @@
+## FileTerm 2.2.8-beta.9
+
+FileTerm 2.2.8-beta.9 improves macOS Overlay window-control hover behavior and refines the bookmark dialog focus experience.
+
+### 2.2.8-beta.9 更新重点
+
+- **macOS 窗口控制**：同步原生标题栏容器与 Overlay 标题栏高度，修复鼠标位于可见控制按钮上时不显示按钮内容的问题。
+- **收藏弹窗焦点**：优化路径收藏弹窗的键盘焦点循环，保留按钮焦点反馈并避免弹窗容器显示多余描边。
+- **兼容性**：修复适用于 macOS 26、27 及其他使用 Overlay 标题栏的环境，继续保留 AppKit 原生窗口控制绘制。
+
+### 本版本包含的主要 PR 和问题修复
+
+- [PR #247](https://github.com/St0ff3l/fileterm/pull/247)：修复 macOS Overlay 窗口控制按钮的 hover 区域与可见位置不一致。
+- [PR #246](https://github.com/St0ff3l/fileterm/pull/246)：优化路径收藏弹窗的焦点管理与按钮焦点样式。
+
+完整变更记录请查看 [v2.2.8-beta.8 与 v2.2.8-beta.9 的比较](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.8...v2.2.8-beta.9)。
+
+### 反馈与支持
+
+> &bull;&nbsp;遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
+> &bull;&nbsp;也可以加入微信群交流：请打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81) 扫描二维码进微信群，也可加入 QQ 群 534418986。
+
+---
+
+## FileTerm 2.2.8-beta.9
+
+FileTerm 2.2.8-beta.9 improves macOS Overlay window-control hover behavior and refines bookmark dialog focus handling.
+
+### Highlights
+
+- **macOS window controls**: Align the native title-bar container with the Overlay title bar so control contents appear when the pointer is over the visible buttons.
+- **Bookmark dialog focus**: Improve keyboard focus trapping and preserve visible button focus feedback without an extra outline on the dialog container.
+- **Compatibility**: Fixes the behavior on macOS 26, 27, and other Overlay title-bar environments while retaining AppKit's native window-control rendering.
+
+### Main PRs and issues
+
+- [PR #247](https://github.com/St0ff3l/fileterm/pull/247): Align the macOS Overlay window-control hover region with the visible controls.
+- [PR #246](https://github.com/St0ff3l/fileterm/pull/246): Refine bookmark dialog focus management and button focus styling.
+
+See the [comparison between v2.2.8-beta.8 and v2.2.8-beta.9](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.8...v2.2.8-beta.9) for the complete change set.
+
+### Feedback & Support
+
+> &bull;&nbsp;For problems, open a [GitHub Issue](https://github.com/St0ff3l/fileterm/issues) with the operating system, FileTerm version, connection type, reproduction steps, and redacted logs. Do not submit passwords, private keys, or tokens.
+> &bull;&nbsp;Join the community through the [README community section](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.8",
+  "version": "2.2.8-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.2.8-beta.8",
+      "version": "2.2.8-beta.9",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,10 +33,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.2.8-beta.8",
+      "version": "2.2.8-beta.9",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.8",
-        "@fileterm/shared": "2.2.8-beta.8",
+        "@fileterm/core": "2.2.8-beta.9",
+        "@fileterm/shared": "2.2.8-beta.9",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -5501,17 +5501,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.2.8-beta.8"
+      "version": "2.2.8-beta.9"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.2.8-beta.8"
+      "version": "2.2.8-beta.9"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.2.8-beta.8",
+      "version": "2.2.8-beta.9",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.8"
+        "@fileterm/core": "2.2.8-beta.9"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.8",
+  "version": "2.2.8-beta.9",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.2.8-beta.8",
+  "version": "2.2.8-beta.9",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.2.8-beta.8",
+  "version": "2.2.8-beta.9",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.2.8-beta.8",
+  "version": "2.2.8-beta.9",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.8"
+    "@fileterm/core": "2.2.8-beta.9"
   }
 }


### PR DESCRIPTION
## Summary

- bump the root version to `2.2.8-beta.9` and synchronize all workspace and Tauri metadata
- add the Beta9 release notes with the fixed Chinese and English feedback blocks
- document the macOS Overlay hover-region and bookmark-dialog focus fixes from PRs #246 and #247

## Validation

- `npm run sync:version`
- commit hooks: Prettier and workspace typecheck
