### PR TITLE
fix(transfers): harden cross-platform folder uploads

### DIFF
--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -81,6 +81,7 @@ windows-sys = { version = "0.61", features = [
   "Win32_Security",
   "Win32_System_JobObjects",
   "Win32_System_Registry",
+  "Win32_System_SystemServices",
   "Win32_System_Threading",
 ] }
 

--- a/apps/tauri/src-tauri/src/services/transfers/creation.rs
+++ b/apps/tauri/src-tauri/src/services/transfers/creation.rs
@@ -13,12 +13,53 @@ pub async fn create_upload(
     remote_directory: String,
     target_name: Option<String>,
 ) -> Result<(), AppError> {
+    let request_id = format!("transfer-{}", uuid::Uuid::new_v4());
+    let started = std::time::Instant::now();
+    crate::services::logging::info(
+        app, &format!("transfer:{request_id}"),
+        format!("upload requested tab={tab_id} source={local_path:?} remote_directory={remote_directory:?} target_name={target_name:?}"),
+    );
+    let result = create_upload_task(
+        app,
+        tab_id,
+        local_path,
+        remote_directory,
+        target_name,
+        request_id.clone(),
+    )
+    .await;
+    match &result {
+        Ok(()) => crate::services::logging::info(
+            app,
+            &format!("transfer:{request_id}"),
+            format!("upload queued elapsed_ms={}", started.elapsed().as_millis()),
+        ),
+        Err(error) => crate::services::logging::error(
+            app,
+            &format!("transfer:{request_id}"),
+            format!(
+                "upload creation failed elapsed_ms={} error={error}",
+                started.elapsed().as_millis()
+            ),
+        ),
+    }
+    result
+}
+
+async fn create_upload_task(
+    app: &AppHandle,
+    tab_id: String,
+    local_path: String,
+    remote_directory: String,
+    target_name: Option<String>,
+    task_id: String,
+) -> Result<(), AppError> {
     ensure_loaded(app).await?;
     let state = app.state::<crate::services::workspace::WorkspaceState>();
     let _lifecycle = state.transfer_lifecycle.lock().await;
     let metadata = tokio::fs::metadata(&local_path)
         .await
-        .map_err(|error| transfer_error(format!("无法读取本地上传文件: {error}")))?;
+        .map_err(|error| transfer_error(format!("无法读取本地上传路径 {local_path}: {error}")))?;
     let tab = state
         .tabs
         .read()
@@ -37,41 +78,34 @@ pub async fn create_upload(
         .map(|session| session.file_access_mode.clone())
         .unwrap_or_else(|| "user".to_string());
     if metadata.is_dir() {
+        crate::services::logging::info(app, &format!("transfer:{task_id}"), format!("local directory scan started source={local_path:?} protocol={} access={file_access_mode}", tab.session_type));
+        let scan_started = std::time::Instant::now();
         let (directories, files) = collect_local_tree(Path::new(&local_path)).await?;
         let scanned_directory_count = directories.len();
         let scanned_file_count = files.len();
         let scanned_total_bytes = files.iter().map(|(_, identity)| identity.size).sum::<u64>();
         crate::services::logging::info(
             app,
-            "transfer",
+            &format!("transfer:{task_id}"),
             format!(
-                "local directory scan completed directories={} files={} total_bytes={}",
-                scanned_directory_count, scanned_file_count, scanned_total_bytes
+                "local directory scan completed directories={} files={} total_bytes={} elapsed_ms={}",
+                scanned_directory_count, scanned_file_count, scanned_total_bytes, scan_started.elapsed().as_millis()
             ),
         );
-        let task_id = format!("transfer-{}", uuid::Uuid::new_v4());
         let mut manifest_directories = vec![destination_path.clone()];
-        manifest_directories.extend(directories.into_iter().map(|directory| {
-            let relative = directory
-                .strip_prefix(&local_path)
-                .unwrap_or(&directory)
-                .to_string_lossy()
-                .replace('\\', "/");
-            join_remote_path(&destination_path, &relative)
-        }));
+        for directory in directories {
+            let relative = local_upload_relative_path(Path::new(&local_path), &directory)?;
+            manifest_directories.push(join_remote_path(&destination_path, &relative));
+        }
         let manifest_files = files
             .into_iter()
             .map(|(source, source_identity)| {
-                let relative_path = source
-                    .strip_prefix(&local_path)
-                    .unwrap_or(&source)
-                    .to_string_lossy()
-                    .replace('\\', "/");
+                let relative_path = local_upload_relative_path(Path::new(&local_path), &source)?;
                 let entry_destination = join_remote_path(&destination_path, &relative_path);
                 let entry_partial = partial_path(&entry_destination);
                 let entry_staging =
                     (file_access_mode == "root").then(|| root_staging_path(&relative_path));
-                TransferManifestEntry {
+                Ok(TransferManifestEntry {
                     relative_path,
                     source_path: source.to_string_lossy().into_owned(),
                     destination_path: entry_destination,
@@ -80,9 +114,9 @@ pub async fn create_upload(
                     source_identity,
                     status: "pending".to_string(),
                     transferred_bytes: 0,
-                }
+                })
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, AppError>>()?;
         let manifest = TransferManifest {
             version: 1,
             directories: manifest_directories,
@@ -130,7 +164,7 @@ pub async fn create_upload(
     let staging = (file_access_mode == "root").then(|| root_staging_path(&name));
     let now = now_ms();
     let task = TransferTask {
-        id: format!("transfer-{}", uuid::Uuid::new_v4()),
+        id: task_id,
         direction: "upload".to_string(),
         name,
         progress: 0.0,

--- a/apps/tauri/src-tauri/src/services/transfers/directory_entry.rs
+++ b/apps/tauri/src-tauri/src/services/transfers/directory_entry.rs
@@ -20,7 +20,7 @@ async fn transfer_directory_entry_once(
     transfer_id: &str,
     tab_id: &str,
     direction: &str,
-    session_type: Option<&str>,
+    _session_type: Option<&str>,
     cancel: &CancellationToken,
     resume_requested: bool,
     manifest: &mut TransferManifest,
@@ -31,12 +31,18 @@ async fn transfer_directory_entry_once(
 ) -> Result<DirectoryEntryAttempt, AppError> {
     let entry = manifest.files[index].clone();
     let current_identity = if direction == "upload" {
-        stat_local_transfer_file(&entry.source_path)
+        stat_local_transfer_file_result(&entry.source_path)
             .await
+            .map_err(|error| {
+                transfer_error(format!(
+                    "无法读取本地上传文件 {}: {error}",
+                    entry.source_path
+                ))
+            })?
             .ok_or_else(|| {
                 transfer_error(format!(
-                    "上传源文件不存在或无法读取：{}",
-                    entry.relative_path
+                    "上传源文件不存在或无法读取：{} ({})",
+                    entry.relative_path, entry.source_path
                 ))
             })?
     } else {
@@ -185,16 +191,18 @@ async fn transfer_directory_entry_once(
             })
             .await?;
         }
-        // FTP 没有类似 SSH MAC 的传输层完整性保证，上传完成后需一次
-        // 远端大小比对兜底；SSH 传输层已保证完整性，跳过该往返。
-        if session_type == Some("ftp") && upload_plan.upload_needed {
+        // Transport integrity does not detect a source truncated or extended
+        // while reading. Check the staged size for both SSH and FTP before commit.
+        if upload_plan.upload_needed {
             let uploaded =
                 stat_remote_transfer_size(app, tab_id, &upload_plan.upload_path, Some(cancel))
                     .await?
-                    .unwrap_or(0);
+                    .ok_or_else(|| transfer_error(format!(
+                        "传输校验失败：远端文件不存在：{}", upload_plan.upload_path
+                    )))?;
             if uploaded != entry.source_identity.size {
                 return Err(transfer_error(format!(
-                    "FTP 传输校验失败：{} 实际 {uploaded} 字节，期望 {}",
+                    "传输校验失败：{} 实际 {uploaded} 字节，期望 {}",
                     entry.relative_path, entry.source_identity.size
                 )));
             }

--- a/apps/tauri/src-tauri/src/services/transfers/directory_execution.rs
+++ b/apps/tauri/src-tauri/src/services/transfers/directory_execution.rs
@@ -7,15 +7,21 @@ fn same_transfer_identity(current: &TransferFileIdentity, expected: &TransferFil
 }
 
 async fn stat_local_transfer_file(path: &str) -> Option<TransferFileIdentity> {
-    let metadata = tokio::fs::metadata(path).await.ok()?;
-    metadata.is_file().then(|| TransferFileIdentity {
+    stat_local_transfer_file_result(path).await.ok().flatten()
+}
+
+async fn stat_local_transfer_file_result(
+    path: &str,
+) -> std::io::Result<Option<TransferFileIdentity>> {
+    let metadata = tokio::fs::metadata(path).await?;
+    Ok(metadata.is_file().then(|| TransferFileIdentity {
         size: metadata.len(),
         modified_at: metadata
             .modified()
             .ok()
             .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
             .map(|value| value.as_millis() as u64),
-    })
+    }))
 }
 
 struct DirectoryTransferThrottler {
@@ -222,10 +228,17 @@ async fn run_directory_transfer(
                     if cancel.is_cancelled() {
                         return Ok(());
                     }
+                    crate::services::logging::warn(
+                        app,
+                        &format!("transfer:{transfer_id}"),
+                        format!("directory preparation failed direction={} protocol={:?} path={directory:?} attempt={attempt}/{TRANSIENT_MAX_ATTEMPTS} error={error}", task.direction, task.session_type),
+                    );
                     if is_permanent_transfer_error(&error.to_string())
                         || attempt >= TRANSIENT_MAX_ATTEMPTS
                     {
-                        return Err(error);
+                        return Err(transfer_error(format!(
+                            "无法准备传输目录 {directory}: {error}"
+                        )));
                     }
                     sleep_transient_backoff(&cancel, transient_retry_backoff(attempt)).await;
                     if cancel.is_cancelled() {

--- a/apps/tauri/src-tauri/src/services/transfers/remote.rs
+++ b/apps/tauri/src-tauri/src/services/transfers/remote.rs
@@ -249,21 +249,114 @@ fn parent_remote_path(path: &str) -> String {
 }
 
 #[cfg(windows)]
-fn is_windows_reparse_point(metadata: &std::fs::Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt;
+fn windows_reparse_tag(path: &Path) -> std::io::Result<u32> {
+    use std::fs::OpenOptions;
+    use std::mem::size_of;
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandleEx, FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        FileAttributeTagInfo,
+    };
 
-    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
-    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    // Open the directory entry itself. Without OPEN_REPARSE_POINT Windows may
+    // resolve a junction/cloud provider before we can inspect its tag.
+    let handle = OpenOptions::new()
+        .access_mode(0)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    let mut info = FILE_ATTRIBUTE_TAG_INFO::default();
+    let success = unsafe {
+        GetFileInformationByHandleEx(
+            handle.as_raw_handle(),
+            FileAttributeTagInfo,
+            (&mut info as *mut FILE_ATTRIBUTE_TAG_INFO).cast(),
+            size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    };
+    if success == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(info.ReparseTag)
+}
+
+#[cfg(windows)]
+fn windows_reparse_rejection(path: &Path, metadata: &std::fs::Metadata) -> Option<String> {
+    use std::os::windows::fs::MetadataExt;
+    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+    use windows_sys::Win32::System::SystemServices::{
+        IO_REPARSE_TAG_CLOUD, IO_REPARSE_TAG_CLOUD_MASK, IO_REPARSE_TAG_FILE_PLACEHOLDER,
+        IO_REPARSE_TAG_MOUNT_POINT, IO_REPARSE_TAG_SYMLINK, IO_REPARSE_TAG_WOF,
+    };
+
+    // WOF-compressed files and cloud placeholders are data files handled by
+    // Windows transparently. They are reparse points, but not path redirects.
+
+    let attributes = metadata.file_attributes();
+    if attributes & FILE_ATTRIBUTE_REPARSE_POINT == 0 {
+        return None;
+    }
+    let tag = match windows_reparse_tag(path) {
+        Ok(tag) => tag,
+        Err(error) => {
+            return Some(format!(
+                "Windows 重解析点无法读取 tag: path={} attributes=0x{attributes:08x} error={error}",
+                path.display()
+            ));
+        }
+    };
+    let cloud_placeholder = (tag & !IO_REPARSE_TAG_CLOUD_MASK)
+        == (IO_REPARSE_TAG_CLOUD & !IO_REPARSE_TAG_CLOUD_MASK);
+    if matches!(tag, IO_REPARSE_TAG_FILE_PLACEHOLDER | IO_REPARSE_TAG_WOF)
+        || cloud_placeholder
+    {
+        return None;
+    }
+    if tag == IO_REPARSE_TAG_SYMLINK || tag == IO_REPARSE_TAG_MOUNT_POINT {
+        return Some(format!(
+            "Windows 符号链接/Junction: path={} tag=0x{tag:08x} attributes=0x{attributes:08x}",
+            path.display()
+        ));
+    }
+    Some(format!(
+        "Windows 不支持的重解析点: path={} tag=0x{tag:08x} attributes=0x{attributes:08x}",
+        path.display()
+    ))
 }
 
 #[cfg(not(windows))]
-fn is_windows_reparse_point(_metadata: &std::fs::Metadata) -> bool {
-    false
+fn windows_reparse_rejection(_path: &Path, _metadata: &std::fs::Metadata) -> Option<String> {
+    None
 }
 
 async fn collect_local_tree(
     root: &Path,
 ) -> Result<(Vec<PathBuf>, Vec<(PathBuf, TransferFileIdentity)>), AppError> {
+    let root_metadata = tokio::fs::symlink_metadata(root).await.map_err(|error| {
+        transfer_error(format!(
+            "无法读取本地目录 {}: {error}",
+            root.display()
+        ))
+    })?;
+    if let Some(reason) = windows_reparse_rejection(root, &root_metadata) {
+        return Err(transfer_error(format!(
+            "无法递归扫描本地目录：{reason}"
+        )));
+    }
+    if root_metadata.file_type().is_symlink() {
+        return Err(transfer_error(format!(
+            "无法递归扫描本地目录：不支持符号链接或 Windows Junction：{}",
+            root.display()
+        )));
+    }
+    if !root_metadata.is_dir() {
+        return Err(transfer_error(format!(
+            "无法递归扫描本地目录：源路径不是目录：{}",
+            root.display()
+        )));
+    }
     let mut directories = Vec::new();
     let mut files = Vec::new();
     let mut pending = vec![root.to_path_buf()];
@@ -271,21 +364,25 @@ async fn collect_local_tree(
         let mut entries = tokio::fs::read_dir(&directory).await.map_err(|error| {
             transfer_error(format!("无法读取本地目录 {}: {error}", directory.display()))
         })?;
-        while let Some(entry) = entries
-            .next_entry()
-            .await
-            .map_err(|error| transfer_error(format!("无法读取本地目录项: {error}")))?
-        {
+        while let Some(entry) = entries.next_entry().await.map_err(|error| {
+            transfer_error(format!(
+                "无法读取本地目录项 {}: {error}",
+                directory.display()
+            ))
+        })? {
             let path = entry.path();
-            let file_type = entry
-                .file_type()
-                .await
-                .map_err(|error| transfer_error(format!("无法读取本地文件类型: {error}")))?;
-            let metadata = entry
-                .metadata()
-                .await
-                .map_err(|error| transfer_error(format!("无法读取本地文件信息: {error}")))?;
-            if file_type.is_symlink() || is_windows_reparse_point(&metadata) {
+            let file_type = entry.file_type().await.map_err(|error| {
+                transfer_error(format!("无法读取本地文件类型 {}: {error}", path.display()))
+            })?;
+            let metadata = entry.metadata().await.map_err(|error| {
+                transfer_error(format!("无法读取本地文件信息 {}: {error}", path.display()))
+            })?;
+            if let Some(reason) = windows_reparse_rejection(&path, &metadata) {
+                return Err(transfer_error(format!(
+                    "无法递归扫描本地目录：{reason}"
+                )));
+            }
+            if file_type.is_symlink() {
                 return Err(transfer_error(format!(
                     "无法递归扫描本地目录：不支持符号链接或 Windows Junction：{}",
                     path.display()
@@ -317,6 +414,25 @@ async fn collect_local_tree(
     directories.sort();
     files.sort_by(|left, right| left.0.cmp(&right.0));
     Ok((directories, files))
+}
+
+// Convert separators using native path components, never characters inside a
+// filename (a backslash is a valid filename character on Unix).
+fn local_upload_relative_path(root: &Path, source: &Path) -> Result<String, AppError> {
+    use std::path::Component;
+    let invalid = || transfer_error(format!("无法无损映射本地上传路径：{}", source.display()));
+    let relative = source.strip_prefix(root).map_err(|_| invalid())?;
+    let mut names = Vec::new();
+    for component in relative.components() {
+        match component {
+            Component::Normal(name) => names.push(name.to_str().ok_or_else(invalid)?),
+            _ => return Err(invalid()),
+        }
+    }
+    if names.is_empty() || source.to_str().is_none() {
+        return Err(invalid());
+    }
+    Ok(names.join("/"))
 }
 
 async fn collect_remote_tree(

--- a/apps/tauri/src-tauri/src/services/transfers/run_lifecycle.rs
+++ b/apps/tauri/src-tauri/src/services/transfers/run_lifecycle.rs
@@ -194,7 +194,12 @@ async fn run(
             let source_size = if task.direction == "upload" {
                 let metadata = tokio::fs::metadata(&source_path)
                     .await
-                    .map_err(|_| transfer_error("上传源文件不存在或无法读取"))?;
+                    .map_err(|error| {
+                        transfer_error(format!(
+                            "上传源文件不存在或无法读取 {}: {error}",
+                            source_path
+                        ))
+                    })?;
                 if !metadata.is_file() {
                     return Err(transfer_error("上传源不是普通文件"));
                 }

--- a/apps/tauri/src-tauri/src/services/transfers/tests.rs
+++ b/apps/tauri/src-tauri/src/services/transfers/tests.rs
@@ -11,6 +11,63 @@ mod tests {
     use std::time::Duration;
 
     #[tokio::test]
+    async fn upload_scan_maps_every_entry_without_changing_names() {
+        let root = std::env::temp_dir().join(format!("fileterm-complete-{}", rand::random::<u64>()));
+        let names = ["files/preferences/中文 空格.json", "shared/runtime/empty.dll", ".hidden/config", "shared/runtime/data.bin"];
+        tokio::fs::create_dir_all(root.join("empty/nested")).await.unwrap();
+        for name in names {
+            let path = root.join(name);
+            tokio::fs::create_dir_all(path.parent().unwrap()).await.unwrap();
+            tokio::fs::write(path, if name.ends_with("empty.dll") { &b""[..] } else { &b"contents"[..] }).await.unwrap();
+        }
+        let (directories, files) = collect_local_tree(&root).await.unwrap();
+        let mapped: std::collections::BTreeSet<_> = files.iter().map(|(path, identity)| {
+            let relative = super::local_upload_relative_path(&root, path).unwrap();
+            assert_eq!(root.join(&relative), *path);
+            assert_eq!(identity.size, if relative.ends_with("empty.dll") { 0 } else { 8 });
+            relative
+        }).collect();
+        assert_eq!(mapped, names.into_iter().map(str::to_owned).collect());
+        assert!(directories.contains(&root.join("empty/nested")));
+        assert!(super::local_upload_relative_path(&root, &root).is_err());
+        assert!(super::local_upload_relative_path(&root, &root.join("../outside")).is_err());
+        tokio::fs::remove_dir_all(root).await.unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn upload_mapping_preserves_backslashes_and_rejects_lossy_names() {
+        use std::os::unix::ffi::OsStringExt;
+        let root = std::path::Path::new("/tmp/upload");
+        assert_eq!(super::local_upload_relative_path(root, &root.join("a\\b.txt")).unwrap(), "a\\b.txt");
+        let invalid = root.join(std::ffi::OsString::from_vec(vec![b'a', 0xff]));
+        assert!(super::local_upload_relative_path(root, &invalid).is_err());
+        assert!(super::local_upload_relative_path(root, std::path::Path::new("/tmp/other/file")).is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn upload_mapping_handles_windows_drive_and_unc_roots() {
+        use std::path::Path;
+        for root in [r"C:\upload", r"\\server\share\upload", r"\\?\C:\upload"] {
+            let root = Path::new(root);
+            assert_eq!(super::local_upload_relative_path(root, &root.join(r"shared\runtime\文件.dll")).unwrap(), "shared/runtime/文件.dll");
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn upload_scan_reports_socket_instead_of_omitting_it() {
+        let root = std::env::temp_dir().join(format!("ft-socket-{}", rand::random::<u32>()));
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let socket = std::os::unix::net::UnixListener::bind(root.join("socket")).unwrap();
+        let error = collect_local_tree(&root).await.unwrap_err();
+        assert!(error.to_string().contains("socket"));
+        drop(socket);
+        tokio::fs::remove_dir_all(root).await.unwrap();
+    }
+
+    #[tokio::test]
     async fn local_directory_scan_includes_nested_and_hidden_files() {
         let root =
             std::env::temp_dir().join(format!("fileterm-transfer-scan-{}", rand::random::<u64>()));
@@ -53,6 +110,50 @@ mod tests {
         let _ = tokio::fs::remove_dir_all(&root).await;
         let error = result.expect_err("symlinks must not be silently skipped");
         assert!(error.to_string().contains("linked"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_directory_scan_rejects_symlink_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "fileterm-transfer-symlink-root-{}",
+            rand::random::<u64>()
+        ));
+        let real = root.join("real");
+        let linked = root.join("linked");
+        tokio::fs::create_dir_all(&real).await.unwrap();
+        symlink(&real, &linked).expect("create root symlink");
+
+        let result = collect_local_tree(&linked).await;
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
+        let error = result.expect_err("the selected root symlink must be rejected");
+        assert!(error.to_string().contains("linked"));
+    }
+
+    #[tokio::test]
+    async fn local_directory_scan_preserves_empty_folders() {
+        let root = std::env::temp_dir().join(format!("fileterm-empty-{}", rand::random::<u64>()));
+        tokio::fs::create_dir_all(root.join("files")).await.unwrap();
+        tokio::fs::create_dir_all(root.join("shared"))
+            .await
+            .unwrap();
+        let (directories, files) = collect_local_tree(&root).await.unwrap();
+        assert_eq!(directories, vec![root.join("files"), root.join("shared")]);
+        assert!(files.is_empty());
+        let (directories, files) = collect_local_tree(&root.join("files")).await.unwrap();
+        assert!(directories.is_empty());
+        assert!(files.is_empty());
+        tokio::fs::remove_dir_all(root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn local_directory_scan_reports_missing_root_path() {
+        let root = std::env::temp_dir().join(format!("fileterm-missing-{}", rand::random::<u64>()));
+        let error = collect_local_tree(&root).await.unwrap_err();
+        assert!(error.to_string().contains(root.to_str().unwrap()));
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/sessions/ftp/file_operations.rs
+++ b/apps/tauri/src-tauri/src/sessions/ftp/file_operations.rs
@@ -139,7 +139,7 @@ async fn upload_file<T: TokioTlsStream + Send + 'static>(
 ) -> Result<(), String> {
     let total = tokio::fs::metadata(local_path)
         .await
-        .map_err(|error| error.to_string())?
+        .map_err(|error| format!("无法读取本地上传文件 {local_path}: {error}"))?
         .len();
     if resume_offset > total {
         return Err("FTP 上传断点大于源文件".to_string());
@@ -152,7 +152,7 @@ async fn upload_file<T: TokioTlsStream + Send + 'static>(
     .await?;
     let mut local = tokio::fs::File::open(local_path)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| format!("无法打开本地上传文件 {local_path}: {error}"))?;
     let mut buffer = vec![0_u8; crate::sessions::TRANSFER_IO_BUFFER_BYTES];
     let mut attempt_offset = resume_offset;
     let mut rebuilt_from_zero = false;

--- a/apps/tauri/src-tauri/src/sessions/ssh/root_transfer.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/root_transfer.rs
@@ -27,14 +27,14 @@ async fn upload_root_local_file(
     }
     let metadata = tokio::fs::metadata(local_path)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| format!("无法读取本地上传文件 {local_path}: {error}"))?;
     let total = metadata.len();
     if resume_offset > total {
         return Err("上传断点大于源文件".to_string());
     }
     let mut source = tokio::fs::File::open(local_path)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| format!("无法打开本地上传文件 {local_path}: {error}"))?;
     source
         .seek(std::io::SeekFrom::Start(resume_offset))
         .await
@@ -139,14 +139,14 @@ async fn upload_root_local_file_via_su_pty(
 ) -> Result<(), String> {
     let metadata = tokio::fs::metadata(local_path)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| format!("无法读取本地上传文件 {local_path}: {error}"))?;
     let total = metadata.len();
     if resume_offset > total {
         return Err("上传断点大于源文件".to_string());
     }
     let mut source = tokio::fs::File::open(local_path)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| format!("无法打开本地上传文件 {local_path}: {error}"))?;
     source
         .seek(std::io::SeekFrom::Start(resume_offset))
         .await

--- a/apps/tauri/src-tauri/src/sessions/ssh/transfer_io.rs
+++ b/apps/tauri/src-tauri/src/sessions/ssh/transfer_io.rs
@@ -85,7 +85,7 @@ async fn upload_local_file(
 ) -> Result<(), String> {
     let metadata = tokio::fs::metadata(local_path)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| format!("无法读取本地上传文件 {local_path}: {error}"))?;
     let total = metadata.len();
     if resume_offset > total {
         return Err("上传断点大于源文件".to_string());
@@ -93,7 +93,7 @@ async fn upload_local_file(
     ensure_transfer_parent_dir(sftp, remote_path).await?;
     let mut source = tokio::fs::File::open(local_path)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| format!("无法打开本地上传文件 {local_path}: {error}"))?;
     source
         .seek(std::io::SeekFrom::Start(resume_offset))
         .await

--- a/apps/tauri/src/renderer/hooks/file-operations-transfers.ts
+++ b/apps/tauri/src/renderer/hooks/file-operations-transfers.ts
@@ -1,5 +1,6 @@
 import { useEffect, type DragEvent } from 'react'
-import type { LocalFileItem, RemoteFileItem, WorkspaceSnapshot } from '@fileterm/core'
+import type { LocalFileItem, RemoteFileItem } from '@fileterm/core'
+import { createUploadBatch } from './upload-batch'
 import { APP_EVENT, onAppEvent } from '../lib/app-events'
 import { t } from '../i18n'
 import type {
@@ -74,20 +75,15 @@ export function useFileOperationsTransfers(context: FileOperationsRuntime, navig
       return
     }
 
-    const uniquePaths = Array.from(new Set(paths))
-    let latestSnapshot: WorkspaceSnapshot | null = null
-    try {
-      for (const sourcePath of uniquePaths) {
-        latestSnapshot = await desktopApi.uploadFile(activeTab.id, sourcePath, activeSession.remotePath)
-      }
-    } finally {
-      // Creating several durable tasks used to apply a full workspace snapshot
-      // once per source path. Transfer updates already stream independently;
-      // publish one final snapshot after the batch and keep the last successful
-      // snapshot visible if a later source fails.
-      if (latestSnapshot) {
-        onApplySnapshot(latestSnapshot)
-      }
+    const { latestSnapshot, failures } = await createUploadBatch(paths, (sourcePath) =>
+      desktopApi.uploadFile(activeTab.id, sourcePath, activeSession.remotePath)
+    )
+    // Transfer events stream independently; apply only the last successful snapshot.
+    if (latestSnapshot) {
+      onApplySnapshot(latestSnapshot)
+    }
+    if (failures.length) {
+      throw new Error(failures.map(({ path, error }) => formatError(path, error)).join('\n'))
     }
   }
 

--- a/apps/tauri/src/renderer/hooks/upload-batch.ts
+++ b/apps/tauri/src/renderer/hooks/upload-batch.ts
@@ -1,0 +1,13 @@
+/** Try every selected path even when an earlier task cannot be created. */
+export async function createUploadBatch<T>(paths: string[], upload: (path: string) => Promise<T>) {
+  let latestSnapshot: T | null = null
+  const failures: { path: string; error: unknown }[] = []
+  for (const path of new Set(paths)) {
+    try {
+      latestSnapshot = await upload(path)
+    } catch (error) {
+      failures.push({ path, error })
+    }
+  }
+  return { latestSnapshot, failures }
+}

--- a/apps/tauri/tests/upload-batch.test.mjs
+++ b/apps/tauri/tests/upload-batch.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createUploadBatch } from '../src/renderer/hooks/upload-batch.ts'
+
+test('failed folders do not prevent later paths from being queued, duplicates are submitted once', async () => {
+  const attempted = []
+  const result = await createUploadBatch(['files', 'app.exe', 'shared', 'last.dll', 'files'], async (path) => {
+    attempted.push(path)
+    if (path === 'files' || path === 'shared') throw new Error(`cannot scan ${path}`)
+    return { path }
+  })
+  assert.deepEqual(attempted, ['files', 'app.exe', 'shared', 'last.dll'])
+  assert.deepEqual(result.latestSnapshot, { path: 'last.dll' })
+  assert.deepEqual(
+    result.failures.map(({ path }) => path),
+    ['files', 'shared']
+  )
+  assert.equal(result.failures[0].error.message, 'cannot scan files')
+})
+
+test('a final failure preserves the last successful snapshot', async () => {
+  const result = await createUploadBatch(['good', 'bad'], async (path) => {
+    if (path === 'bad') throw new Error('denied')
+    return path
+  })
+  assert.equal(result.latestSnapshot, 'good')
+  assert.equal(result.failures.length, 1)
+})
+
+test('an entirely failed or empty batch has no snapshot to apply', async () => {
+  const result = await createUploadBatch(['files', 'shared'], async () => {
+    throw new Error('denied')
+  })
+  assert.equal(result.latestSnapshot, null)
+  assert.equal(result.failures.length, 2)
+  assert.deepEqual(await createUploadBatch([], async () => 'unused'), { latestSnapshot: null, failures: [] })
+})

--- a/docs/plans/completed/folder-upload-diagnostics.md
+++ b/docs/plans/completed/folder-upload-diagnostics.md
@@ -1,0 +1,53 @@
+# 文件夹上传诊断与批次隔离
+
+## 背景与结论
+
+现场反馈 Windows 下 `files`、`shared` 文件夹未上传。缺少原始目录、协议和日志，尚不能确认现场根因。
+
+之前的 `11048bc1` 提供 manifest 执行阶段的文件失败隔离和瞬时重试；`83286dab` 合并批量上传快照更新。但 renderer 创建任务的循环遇到任意异常就退出，后续选择路径不会尝试，之前的重试无法覆盖这个阶段。
+
+这次重点核对 Windows 后，发现一个只在 Windows 生效的高概率原因：`3955e6b3` 为避免静默漏传，曾把所有 `FILE_ATTRIBUTE_REPARSE_POINT` 都当作 Junction 拒绝。这个属性不只表示符号链接或 Junction，也会出现在 WOF 压缩文件、OneDrive/Cloud Files 占位文件等仍可由 Windows 正常读取的条目上。macOS 不执行这段 `cfg(windows)` 逻辑，所以同一目录在 macOS 上可能正常。
+
+截图中的 `files` 与 `shared` 是 Office Tool Plus 的运行时目录，目录名本身没有特殊处理。问题应落在目录内某个条目的 Windows 文件属性、访问权限或读取时机，不能仅凭截图确定具体条目。
+
+## 实现
+
+- `upload-batch.ts` 逐个提交去重后的路径，单项失败后继续提交，其余成功任务正常运行；批次结束只应用最后一个成功快照，再集中报告每个失败路径与原因。
+- Rust 在上传入口生成传输 ID，创建成功后继续作为任务 ID；创建失败也能在日志中定位。请求日志记录本地路径、远端目录和标签页；目录扫描记录协议、权限模式、数量、字节数和耗时；创建失败记录原因与耗时。
+- 扫描读取目录项、文件类型和元数据的错误均携带具体路径；远端建目录失败记录任务 ID、协议、方向、路径及重试次数，任务错误也保留目录路径。
+- Windows 扫描现在读取重解析点 tag：只拒绝符号链接、Junction 和无法识别的重解析点，允许 WOF、旧版 placeholder 及 Cloud Files tag；拒绝日志包含完整本地路径、`tag` 和文件属性值。上传文件的 metadata/open 错误也包含完整本地路径。
+- 保持符号链接/Junction、不支持类型和不可读目录显式失败，不将漏传伪装成成功；空目录仍进入目录 manifest。
+
+## 验证
+
+- `node --test apps/tauri/tests/upload-batch.test.mjs`：3 项通过，覆盖首项/中项失败后继续、路径去重、末项失败保留快照、全失败和空批次。
+- `npm run test:tauri`：610 个单元测试、10 个 CLI 集成测试和 21 个契约测试通过。
+- 新增空目录保留、扫描失败携带路径的 Rust 用例，与原有嵌套/隐藏文件、符号链接拒绝用例一同针对性回归。
+- 类型检查、ESLint、Prettier、Clippy 通过。
+
+## 现场复测
+
+最终跨平台复核补充：
+
+- 本地路径按原生组件转换为远端相对路径，保留 Unix 文件名里的反斜杠；越界路径和非 UTF-8 路径明确失败，禁止有损改名。
+- SFTP 与 FTP 目录上传均在提交文件前验证远端临时文件大小；零字节文件也要求远端条目存在。此处增加每个 SFTP 文件一次 stat 往返，以检查上传期间源文件长度变化造成的截断或多传；并非目录的原子快照或全量内容哈希验证。
+- Windows 查询重解析 tag 使用零数据访问权限的句柄，避免单纯读取属性额外要求文件内容读取权限。
+- 新增完整清单回归：中文、空格、隐藏条目、空目录和零字节文件；Unix 反斜杠、非法编码与 socket 显式失败；Windows 盘符、UNC 与扩展路径转换用例。
+- 上传按钮和选择器 UI 保持现状：按钮仍调用原有文件选择器；文件夹继续使用原有拖拽或本地文件列表上传入口，不新增文件夹选择按钮。
+- Windows 重解析误判属于已确认的代码缺陷，但截图无法证明原始目录具有这些属性；现场根因仍待日志确认。当前只在 macOS 运行测试，Windows 专属用例待 Windows CI 执行，Linux 尚未实机验证。
+
+使用包含本修复的版本，将普通文件与 `files`、`shared` 一起拖入远程文件区。确认普通文件不因其他路径失败而漏传；失败文件夹应显示具体原因。从设置打开日志目录，提供同一时间段的 `transfer:` 日志，并记录使用 SSH/SFTP 还是 FTP、目标路径及是否 root 模式。
+
+若需要在 Windows 现场先确认属性，可执行：
+
+```powershell
+Get-ChildItem -LiteralPath "C:\路径\files", "C:\路径\shared" -Force -Recurse |
+  Where-Object { $_.Attributes -band [IO.FileAttributes]::ReparsePoint } |
+  Select-Object FullName, Attributes
+```
+
+日志中的 `Windows 符号链接/Junction`、`Windows 不支持的重解析点` 或 `Windows 重解析点无法读取 tag` 会直接指出阻断扫描的条目；若没有这些信息，则继续检查同一条目后续的 `无法读取本地上传文件` / `无法打开本地上传文件`。
+
+按传输 ID 检查 `upload requested`、`local directory scan started/completed`、`upload queued`、`upload creation failed`、`directory preparation failed`。只有扫描开始没有扫描完成时，结合创建失败原因检查目录权限、链接/Junction 或文件消失；已入队则继续查看执行阶段错误。
+
+本机未实测 Windows Explorer/WebView2、用户原始目录及真实远端，现场问题仍需复测确认。Windows 目标交叉编译还受 macOS 缺少 MSVC/Windows SDK 影响，不能替代 Windows CI 或实机验证。本次没有发版或关闭 Issue。

--- a/docs/release-notes/release-notes-2.2.8-beta.9.md
+++ b/docs/release-notes/release-notes-2.2.8-beta.9.md
@@ -1,17 +1,20 @@
 ## FileTerm 2.2.8-beta.9
 
-FileTerm 2.2.8-beta.9 improves macOS Overlay window-control hover behavior and refines the bookmark dialog focus experience.
+FileTerm 2.2.8-beta.9 improves folder upload reliability across platforms, adds actionable transfer diagnostics, and refines macOS Overlay window-control hover behavior and bookmark dialog focus.
 
 ### 2.2.8-beta.9 更新重点
 
 - **macOS 窗口控制**：同步原生标题栏容器与 Overlay 标题栏高度，修复鼠标位于可见控制按钮上时不显示按钮内容的问题。
 - **收藏弹窗焦点**：优化路径收藏弹窗的键盘焦点循环，保留按钮焦点反馈并避免弹窗容器显示多余描边。
+- **文件夹上传**：修复 Windows 重解析点目录、特殊文件名、空文件和空目录处理，确保 Linux、macOS、Windows 的单次上传完整遍历并在单个文件失败时继续诊断其余文件。
+- **传输诊断**：补充请求、扫描、目录准备、远端临时文件校验和失败路径日志，便于定位网络慢或平台差异导致的上传问题。
 - **兼容性**：修复适用于 macOS 26、27 及其他使用 Overlay 标题栏的环境，继续保留 AppKit 原生窗口控制绘制。
 
 ### 本版本包含的主要 PR 和问题修复
 
 - [PR #247](https://github.com/St0ff3l/fileterm/pull/247)：修复 macOS Overlay 窗口控制按钮的 hover 区域与可见位置不一致。
 - [PR #246](https://github.com/St0ff3l/fileterm/pull/246)：优化路径收藏弹窗的焦点管理与按钮焦点样式。
+- 文件夹上传诊断与跨平台完整性修复：覆盖 Windows 重解析点、特殊文件名、空文件/空目录和分批失败隔离。
 
 完整变更记录请查看 [v2.2.8-beta.8 与 v2.2.8-beta.9 的比较](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.8...v2.2.8-beta.9)。
 
@@ -24,18 +27,21 @@ FileTerm 2.2.8-beta.9 improves macOS Overlay window-control hover behavior and r
 
 ## FileTerm 2.2.8-beta.9
 
-FileTerm 2.2.8-beta.9 improves macOS Overlay window-control hover behavior and refines bookmark dialog focus handling.
+FileTerm 2.2.8-beta.9 improves folder upload reliability across platforms, adds actionable transfer diagnostics, and refines macOS Overlay window-control hover behavior and bookmark dialog focus handling.
 
 ### Highlights
 
 - **macOS window controls**: Align the native title-bar container with the Overlay title bar so control contents appear when the pointer is over the visible buttons.
 - **Bookmark dialog focus**: Improve keyboard focus trapping and preserve visible button focus feedback without an extra outline on the dialog container.
+- **Folder uploads**: Handle Windows reparse-point directories, special names, empty files, and empty directories correctly, while preserving complete traversal and isolating individual file failures on Linux, macOS, and Windows.
+- **Transfer diagnostics**: Add request, scan, directory-preparation, remote temporary-file verification, and path-specific failure logs for slow or platform-dependent uploads.
 - **Compatibility**: Fixes the behavior on macOS 26, 27, and other Overlay title-bar environments while retaining AppKit's native window-control rendering.
 
 ### Main PRs and issues
 
 - [PR #247](https://github.com/St0ff3l/fileterm/pull/247): Align the macOS Overlay window-control hover region with the visible controls.
 - [PR #246](https://github.com/St0ff3l/fileterm/pull/246): Refine bookmark dialog focus management and button focus styling.
+- Folder upload diagnostics and cross-platform completeness fixes covering Windows reparse points, special names, empty files/directories, and per-file failure isolation.
 
 See the [comparison between v2.2.8-beta.8 and v2.2.8-beta.9](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.8...v2.2.8-beta.9) for the complete change set.
 


### PR DESCRIPTION
## Summary

- harden folder upload traversal and per-file failure isolation across Linux, macOS, and Windows
- reject unsupported Windows reparse-point roots with diagnostics while allowing supported cloud placeholders
- verify remote temporary files before commit and add request, scan, retry, and path-specific transfer logs
- preserve special names, empty files, empty directories, and native path separators

## Validation

- `npm run test:tauri`
- `node --test apps/tauri/tests/upload-batch.test.mjs`
- `npm run typecheck -w @fileterm/tauri`
- `npm run lint`
- `npx prettier --check apps/tauri packages/core packages/shared packages/storage`
- `cargo clippy --manifest-path apps/tauri/src-tauri/Cargo.toml --locked --all-targets --all-features -- -D warnings`

Windows cross-target compilation was additionally checked for the new Windows API helper; a full Tauri Windows build requires the Windows SDK/MSVC headers unavailable on this macOS host.
