### PR TITLE
chore(release): prepare FileTerm 2.2.8-beta.10

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/tauri",
-  "version": "2.2.8-beta.9",
+  "version": "2.2.8-beta.10",
   "private": true,
   "type": "module",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",
@@ -26,8 +26,8 @@
     "release:linux": "node ./scripts/run-tauri.mjs build --target x86_64-unknown-linux-gnu --config src-tauri/tauri.release.linux.conf.json"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.9",
-    "@fileterm/shared": "2.2.8-beta.9",
+    "@fileterm/core": "2.2.8-beta.10",
+    "@fileterm/shared": "2.2.8-beta.10",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-virtual": "^3.14.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "fileterm"
-version = "2.2.8-beta.9"
+version = "2.2.8-beta.10"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileterm"
-version = "2.2.8-beta.9"
+version = "2.2.8-beta.10"
 description = "FileTerm desktop workspace"
 authors = ["FileTerm"]
 edition = "2021"

--- a/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
+++ b/apps/tauri/src-tauri/linux/com.fileterm.desktop.metainfo.xml
@@ -58,7 +58,7 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-    <release version="2.2.8-beta.9" date="2026-09-09">
+    <release version="2.2.8-beta.10" date="2026-09-10">
       <description>
         <p>Official release with multi-tab remote terminal and file management workspace.</p>
       </description>

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FileTerm",
-  "version": "2.2.8-beta.9",
+  "version": "2.2.8-beta.10",
   "identifier": "com.fileterm.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:renderer",

--- a/docs/release-notes/release-notes-2.2.8-beta.10.md
+++ b/docs/release-notes/release-notes-2.2.8-beta.10.md
@@ -1,0 +1,43 @@
+## FileTerm 2.2.8-beta.10
+
+FileTerm 2.2.8-beta.10 improves folder upload reliability across Linux, macOS, and Windows with stronger diagnostics and complete traversal.
+
+### 2.2.8-beta.10 更新重点
+
+- **文件夹上传**：修复 Windows 重解析点目录、特殊文件名、空文件和空目录处理，确保单次上传完整遍历。
+- **传输诊断**：补充请求、扫描、目录准备、远端临时文件校验和失败路径日志；单个文件失败时继续诊断其余文件。
+- **兼容性**：覆盖 Linux、macOS、Windows 的文件夹上传流程，保持现有单一上传按钮。
+
+### 本版本包含的主要 PR 和问题修复
+
+- [PR #249](https://github.com/St0ff3l/fileterm/pull/249)：加固跨平台文件夹上传、Windows 重解析点处理、远端完整性校验和传输诊断日志。
+
+完整变更记录请查看 [v2.2.8-beta.9 与 v2.2.8-beta.10 的比较](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.9...v2.2.8-beta.10)。
+
+### 反馈与支持
+
+> &bull;&nbsp;遇到问题请前往 [GitHub Issues](https://github.com/St0ff3l/fileterm/issues) 提交反馈，并附上操作系统、FileTerm 版本、连接类型、复现步骤和脱敏日志；不要提交密码、私钥或 token。
+> &bull;&nbsp;也可以加入微信群交流：请打开仓库 [README 的“社区交流”部分](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81) 扫描二维码进微信群，也可加入 QQ 群 534418986。
+
+---
+
+## FileTerm 2.2.8-beta.10
+
+FileTerm 2.2.8-beta.10 improves folder upload reliability across Linux, macOS, and Windows with stronger diagnostics and complete traversal.
+
+### Highlights
+
+- **Folder uploads**: Handle Windows reparse-point directories, special names, empty files, and empty directories while preserving complete traversal.
+- **Transfer diagnostics**: Add request, scan, directory-preparation, remote temporary-file verification, and path-specific failure logs while continuing after individual file failures.
+- **Compatibility**: Cover folder uploads on Linux, macOS, and Windows while keeping the existing single upload button.
+
+### Main PRs and issues
+
+- [PR #249](https://github.com/St0ff3l/fileterm/pull/249): Harden cross-platform folder uploads, Windows reparse-point handling, remote completeness checks, and transfer diagnostics.
+
+See the [comparison between v2.2.8-beta.9 and v2.2.8-beta.10](https://github.com/St0ff3l/fileterm/compare/v2.2.8-beta.9...v2.2.8-beta.10) for the complete change set.
+
+### Feedback & Support
+
+> &bull;&nbsp;For problems, open a [GitHub Issue](https://github.com/St0ff3l/fileterm/issues) with the operating system, FileTerm version, connection type, reproduction steps, and redacted logs. Do not submit passwords, private keys, or tokens.
+> &bull;&nbsp;Join the community through the [README community section](https://github.com/St0ff3l/fileterm#%E7%A4%BE%E5%8C%BA%E4%BA%A4%E6%B5%81).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.9",
+  "version": "2.2.8-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fileterm",
-      "version": "2.2.8-beta.9",
+      "version": "2.2.8-beta.10",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -33,10 +33,10 @@
     },
     "apps/tauri": {
       "name": "@fileterm/tauri",
-      "version": "2.2.8-beta.9",
+      "version": "2.2.8-beta.10",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.9",
-        "@fileterm/shared": "2.2.8-beta.9",
+        "@fileterm/core": "2.2.8-beta.10",
+        "@fileterm/shared": "2.2.8-beta.10",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2.5.0",
@@ -5501,17 +5501,17 @@
     },
     "packages/core": {
       "name": "@fileterm/core",
-      "version": "2.2.8-beta.9"
+      "version": "2.2.8-beta.10"
     },
     "packages/shared": {
       "name": "@fileterm/shared",
-      "version": "2.2.8-beta.9"
+      "version": "2.2.8-beta.10"
     },
     "packages/storage": {
       "name": "@fileterm/storage",
-      "version": "2.2.8-beta.9",
+      "version": "2.2.8-beta.10",
       "dependencies": {
-        "@fileterm/core": "2.2.8-beta.9"
+        "@fileterm/core": "2.2.8-beta.10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fileterm",
-  "version": "2.2.8-beta.9",
+  "version": "2.2.8-beta.10",
   "private": true,
   "license": "MIT",
   "description": "Modern remote workspace for SSH, SFTP, and FTP.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/core",
-  "version": "2.2.8-beta.9",
+  "version": "2.2.8-beta.10",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/shared",
-  "version": "2.2.8-beta.9",
+  "version": "2.2.8-beta.10",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fileterm/storage",
-  "version": "2.2.8-beta.9",
+  "version": "2.2.8-beta.10",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
@@ -13,6 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fileterm/core": "2.2.8-beta.9"
+    "@fileterm/core": "2.2.8-beta.10"
   }
 }


### PR DESCRIPTION
## Summary

- bump the root version to `2.2.8-beta.10` and synchronize workspace/Tauri versions
- add bilingual release notes for the cross-platform folder upload diagnostics fix

## Validation

- `npm run sync:version`
- `npx prettier --check docs/release-notes/release-notes-2.2.8-beta.10.md`
